### PR TITLE
feat(file-upload): control-value-accessor (#DS-2199)

### DIFF
--- a/packages/components-dev/file-upload/template.html
+++ b/packages/components-dev/file-upload/template.html
@@ -1,57 +1,134 @@
-<div class="dev-container">
-    <div class="kbq-subheading">Single file upload</div><br>
-    <kbq-file-upload [disabled]="disabled"
-                     [accept]="accept"
-                     [errors]="errorMessagesForSingle"
-                     (fileQueueChange)="addFile($event)">
-        <i kbq-icon="mc-info_16"></i>
-        <span hint>test</span>
-    </kbq-file-upload>
-</div>
-
-<div class="dev-container">
-    <div class="kbq-subheading">Multiple file upload</div><br>
-    <kbq-multiple-file-upload [disabled]="disabled"
-                              [errors]="errorMessagesForMultiple"
-                              [files]="files"
-                              (fileQueueChanged)="addFileMultiple($event)">
-        <ng-template #kbqFileIcon>
-            <i kbq-icon="mc-file-empty_16"></i>
-        </ng-template>
-        <span hint>Ctest</span>
-    </kbq-multiple-file-upload>
-</div>
-
-<div class="dev-container" custom-text>
-    <div class="kbq-subheading">Multiple file with custom text</div><br>
-    <kbq-file-upload
-        [accept]="accept"
-        [disabled]="disabled"
-        [errors]="errorMessagesForMultiple"
-        [files]="files"
-        (fileQueueChanged)="addFileMultiple($event)"
-        [progressMode]="'indeterminate'"
-        multiple>
-        <ng-template #kbqFileIcon>
-            <i kbq-icon="mc-file-empty_16"></i>
-        </ng-template>
-        <span hint>Ctest</span>
-    </kbq-file-upload>
-</div>
-
-<div class="dev-container">
-    <div class="kbq-subheading">Multiple file upload compact</div><br>
-    <file-upload-compact
-        [disabled]="disabled"
-        [errorMessagesForMultiple]="errorMessagesForMultiple"
-        [files]="files"
-        (addedFile)="addFileMultiple($event)">
-    </file-upload-compact>
-</div>
-
-<button kbq-button (click)="disabled = !disabled">Toggle Disabled</button>
+<button kbq-button (click)="toggleDisabled()">Toggle Disabled</button>
 
 <button kbq-button (click)="startLoading()">Loading imitation for single and multiple</button>
 <button kbq-button (click)="startIndeterminateLoading()">Indeterminate Loading imitation for single and multiple</button>
 
 <button kbq-button (click)="checkValidation()">Call validation from outside</button>
+
+<div class="layout-row layout-align-space-between">
+    <div>
+        <div class="dev-container">
+            <div class="kbq-subheading">Single file upload with ControlValueAccessor </div><br>
+            <kbq-checkbox class="layout-margin-bottom-s" [checked]="control.disabled" (change)="control.disabled ? control.enable() : control.disable()">disabled</kbq-checkbox>
+            <div class="kbq-caption_mono">file name: {{ control.value?.file?.name }}</div>
+            <kbq-file-upload class="layout-margin-bottom-s"
+                             [formControl]="control">
+                <i kbq-icon="mc-info_16"></i>
+                <span hint>test</span>
+            </kbq-file-upload>
+
+            <kbq-file-upload [formControl]="secondControl">
+                <i kbq-icon="mc-file-empty_16"></i>
+            </kbq-file-upload>
+        </div>
+
+        <div class="dev-container">
+            <div class="kbq-subheading">Single file upload with ControlValueAccessor & Form</div><br>
+            <span class="kbq-body_mono_strong">Validation after submit</span>
+            <form [formGroup]="form" (ngSubmit)="onSubmit()">
+                <kbq-file-upload class="layout-margin-bottom-s"
+                                 [disabled]="disabled"
+                                 formControlName="file-upload">
+                    <i kbq-icon="mc-info_16"></i>
+                </kbq-file-upload>
+                <button kbq-button type="submit" (click)="onSubmit()">Submit</button>
+            </form>
+        </div>
+
+        <div class="dev-container">
+            <div class="kbq-subheading">Single file upload</div><br>
+            <div class="kbq-body_strong">with customValidation</div><br>
+            <kbq-file-upload [disabled]="disabled"
+                             [accept]="accept"
+                             [customValidation]="validation">
+                <i kbq-icon="mc-info_16"></i>
+                <span hint>test</span>
+            </kbq-file-upload>
+        </div>
+
+        <div class="dev-container">
+            <div class="kbq-subheading">Single file upload</div><br>
+            <div class="kbq-body_strong">with validation outside</div><br>
+            <kbq-file-upload [disabled]="disabled"
+                             [accept]="accept"
+                             [errors]="errorMessagesForSingle">
+                <i kbq-icon="mc-info_16"></i>
+                <span hint>test</span>
+            </kbq-file-upload>
+        </div>
+    </div>
+
+    <div>
+        <div class="dev-container">
+            <div class="kbq-subheading">Multiple file upload</div><br>
+            <kbq-multiple-file-upload [disabled]="disabled"
+                                      [errors]="errorMessagesForMultiple"
+                                      [files]="files"
+                                      [progressMode]="'indeterminate'"
+                                      (fileQueueChanged)="addFileMultiple($event)">
+                <ng-template #kbqFileIcon>
+                    <i kbq-icon="mc-file-empty_16"></i>
+                </ng-template>
+                <span hint>Ctest</span>
+            </kbq-multiple-file-upload>
+        </div>
+
+        <div class="dev-container" custom-text>
+            <div class="kbq-subheading">Multiple file with custom text</div><br>
+            <kbq-file-upload
+                [accept]="accept"
+                [disabled]="disabled"
+                [errors]="errorMessagesForMultiple"
+                [files]="files"
+                (fileQueueChanged)="addFileMultiple($event)"
+                [progressMode]="'indeterminate'"
+                multiple>
+                <ng-template #kbqFileIcon>
+                    <i kbq-icon="mc-file-empty_16"></i>
+                </ng-template>
+                <span hint>Ctest</span>
+            </kbq-file-upload>
+        </div>
+
+        <div class="dev-container" custom-text>
+            <div class="kbq-subheading">Multiple file with ControlValueAccessor</div><br>
+            <kbq-file-upload
+                [formControl]="multipleFileUploadControl"
+                [progressMode]="'indeterminate'"
+                multiple>
+                <ng-template #kbqFileIcon>
+                    <i kbq-icon="mc-file-empty_16"></i>
+                </ng-template>
+                <span hint>Ctest</span>
+            </kbq-file-upload>
+        </div>
+
+        <div class="dev-container">
+            <div class="kbq-subheading">Multiple file upload with ControlValueAccessor & Form</div><br>
+            <span class="kbq-body_mono_strong">Validation after submit</span>
+            <form [formGroup]="formMultiple" (ngSubmit)="onSubmit()">
+                <kbq-file-upload class="layout-margin-bottom-s"
+                                 formControlName="file-upload"
+                                 [progressMode]="'indeterminate'"
+                                 multiple
+                >
+                    <ng-template #kbqFileIcon>
+                        <i kbq-icon="mc-file-empty_16"></i>
+                    </ng-template>
+                </kbq-file-upload>
+                <button kbq-button type="submit" (click)="onSubmit()">Submit</button>
+            </form>
+        </div>
+
+        <div class="dev-container">
+            <div class="kbq-subheading">Multiple file upload compact</div><br>
+            <file-upload-compact
+                [disabled]="disabled"
+                [errorMessagesForMultiple]="errorMessagesForMultiple"
+                [files]="files"
+                (addedFile)="addFileMultiple($event)">
+            </file-upload-compact>
+        </div>
+
+    </div>
+</div>

--- a/packages/components/file-upload/examples.file-upload.md
+++ b/packages/components/file-upload/examples.file-upload.md
@@ -5,3 +5,7 @@
 Пример загрузки файлов с неопределенным по завершенности прогрессом:
 
 <!-- example(file-upload-indeterminate-loading-overview) -->
+
+Пример использования с Control Value Accessor:
+
+<!-- example(file-upload-cva-overview) -->

--- a/packages/components/file-upload/file-upload.module.ts
+++ b/packages/components/file-upload/file-upload.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqDataSizeModule } from '@koobiq/components/core';
 import { KbqEllipsisCenterModule } from '@koobiq/components/ellipsis-center';
@@ -8,16 +9,18 @@ import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqListModule } from '@koobiq/components/list';
 import { KbqProgressSpinnerModule } from '@koobiq/components/progress-spinner';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
+import { KbqLinkModule } from '@koobiq/components/link';
 
 import { KbqFileDropDirective } from './file-drop';
 import { KbqMultipleFileUploadComponent } from './multiple-file-upload.component';
 import { KbqSingleFileUploadComponent } from './single-file-upload.component';
-import { KbqLinkModule } from '@koobiq/components/link';
 
 
 @NgModule({
     imports: [
         CommonModule,
+        FormsModule,
+        ReactiveFormsModule,
         KbqToolTipModule,
         KbqProgressSpinnerModule,
         KbqIconModule,

--- a/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.css
+++ b/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.css
@@ -1,0 +1,8 @@
+.example-button-group {
+    display: inline-flex;
+    flex-direction: column;
+}
+
+.example-button {
+    margin-bottom: 10px;
+}

--- a/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.html
+++ b/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.html
@@ -1,0 +1,31 @@
+<kbq-checkbox class="layout-margin-bottom-s"
+              [checked]="control.disabled"
+              (change)="control.disabled ? control.enable() : control.disable()">
+    disable first control
+</kbq-checkbox>
+
+<div class="kbq-form-horizontal">
+    <div class="kbq-form__row layout-margin-bottom-m">
+        <label class="kbq-form__label flex-20">Single file-upload with formControl</label>
+        <kbq-file-upload class="kbq-form__control flex-80" [formControl]="control">
+            <i kbq-icon="mc-file-empty_16"></i>
+        </kbq-file-upload>
+    </div>
+    <div class="kbq-form__row layout-margin-bottom-m">
+        <label class="kbq-form__label flex-20">control that depends on first control value</label>
+        <kbq-file-upload class="kbq-form__control flex-80" [formControl]="secondControl">
+            <i kbq-icon="mc-file-empty_16"></i>
+        </kbq-file-upload>
+    </div>
+    <div class="kbq-form__row layout-margin-bottom-m">
+        <label class="kbq-form__label flex-20">Multiple file-upload with formControl</label>
+        <kbq-file-upload class="kbq-form__control flex-80" [formControl]="multipleFileUploadControl" multiple>
+            <ng-template #kbqFileIcon>
+                <i kbq-icon="mc-file-empty_16"></i>
+            </ng-template>
+        </kbq-file-upload>
+    </div>
+</div>
+
+
+

--- a/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.ts
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+import { AbstractControl, FormControl, ValidationErrors } from '@angular/forms';
+import { KbqFileItem } from '@koobiq/components/file-upload';
+
+
+const maxFileExceededFn = (control: AbstractControl): ValidationErrors | null => {
+    const kilo = 1024;
+    const mega = kilo * kilo;
+    const maxMbytes = 5;
+    const maxSize = maxMbytes * mega;
+
+    return maxSize !== undefined && ((control.value as KbqFileItem)?.file?.size ?? 0) > maxSize
+        ? { maxFileExceeded: `Размер файла превышает максимально допустимый (${ maxSize / mega } МБ)` }
+        : null;
+};
+
+const maxFileExceededMultipleFn = (control: AbstractControl): ValidationErrors | null => {
+    const kilo = 1024;
+    const mega = kilo * kilo;
+    const maxMbytes = 5;
+    const maxSize = maxMbytes * mega;
+
+    const value: KbqFileItem[] = control.value;
+
+    const errors = value.reduce<ValidationErrors>((res, current) => {
+        // validation check & hasError set to represent error state
+        if (maxSize !== undefined && (current?.file?.size ?? 0) > maxSize) {
+            current.hasError = true;
+            res[current.file.name] = `${current.file.name} — Размер файла превышает максимально допустимый (${ maxSize / mega } МБ)`;
+        }
+        return res;
+    }, {})
+
+    return maxSize !== undefined && !!Object.values(errors).length
+        ? errors
+        : null;
+};
+
+/**
+ * @title File upload with Control Value Accessor
+ */
+@Component({
+    selector: 'file-upload-cva-overview-example',
+    templateUrl: 'file-upload-cva-overview-example.html',
+    styleUrls: ['file-upload-cva-overview-example.css']
+})
+export class FileUploadCvaOverviewExample {
+    control = new FormControl<KbqFileItem | null>(null, maxFileExceededFn);
+    secondControl = new FormControl<File | KbqFileItem | null>(null);
+    multipleFileUploadControl = new FormControl<FileList | KbqFileItem[]>([], maxFileExceededMultipleFn);
+
+    constructor() {
+        this.control.valueChanges.subscribe((value: KbqFileItem | null) => {
+            // can be used mapped file item
+            // this.secondControl.setValue(value);
+
+            // or even JS file object
+            this.secondControl.setValue(value?.file || null);
+        });
+    }
+}

--- a/packages/docs-examples/components/file-upload/index.ts
+++ b/packages/docs-examples/components/file-upload/index.ts
@@ -2,6 +2,9 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { KbqFileUploadModule } from '@koobiq/components/file-upload';
 import { KbqIconModule } from '@koobiq/components/icon';
+import { KbqButtonModule } from '@koobiq/components/button';
+import { ReactiveFormsModule } from '@angular/forms';
+import { KbqCheckboxModule } from '@koobiq/components/checkbox';
 
 import { FileUploadMultipleCompactOverviewExample } from './file-upload-multiple-compact-overview/file-upload-multiple-compact-overview-example';
 import { FileUploadMultipleDefaultOverviewExample } from './file-upload-multiple-default-overview/file-upload-multiple-default-overview-example';
@@ -10,6 +13,7 @@ import { FileUploadSingleErrorOverviewExample } from './file-upload-single-error
 import { FileUploadSingleOverviewExample } from './file-upload-single-overview/file-upload-single-overview-example';
 import { FileUploadMultipleCustomTextOverviewExample } from './file-upload-multiple-custom-text-overview/file-upload-multiple-custom-text-overview-example';
 import { FileUploadIndeterminateLoadingOverviewExample } from './file-upload-indeterminate-loading-overview/file-upload-indeterminate-loading-overview-example';
+import { FileUploadCvaOverviewExample } from './file-upload-cva-overview/file-upload-cva-overview-example';
 
 
 export {
@@ -19,7 +23,8 @@ export {
     FileUploadMultipleErrorOverviewExample,
     FileUploadMultipleCompactOverviewExample,
     FileUploadMultipleCustomTextOverviewExample,
-    FileUploadIndeterminateLoadingOverviewExample
+    FileUploadIndeterminateLoadingOverviewExample,
+    FileUploadCvaOverviewExample
 };
 
 const EXAMPLES = [
@@ -29,14 +34,18 @@ const EXAMPLES = [
     FileUploadMultipleErrorOverviewExample,
     FileUploadMultipleCompactOverviewExample,
     FileUploadMultipleCustomTextOverviewExample,
-    FileUploadIndeterminateLoadingOverviewExample
+    FileUploadIndeterminateLoadingOverviewExample,
+    FileUploadCvaOverviewExample
 ];
 
 @NgModule({
     imports: [
         CommonModule,
+        ReactiveFormsModule,
         KbqFileUploadModule,
-        KbqIconModule
+        KbqIconModule,
+        KbqButtonModule,
+        KbqCheckboxModule
     ],
     declarations: EXAMPLES,
     exports: EXAMPLES

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -4,26 +4,32 @@
 
 ```ts
 
+import { AfterViewInit } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { CanDisable } from '@koobiq/components/core';
 import { ChangeDetectorRef } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i10 from '@koobiq/components/form-field';
-import * as i11 from '@koobiq/components/ellipsis-center';
-import * as i12 from '@koobiq/components/core';
-import * as i13 from '@koobiq/components/link';
+import * as i10 from '@koobiq/components/list';
+import * as i11 from '@koobiq/components/form-field';
+import * as i12 from '@koobiq/components/ellipsis-center';
+import * as i13 from '@koobiq/components/core';
+import * as i14 from '@koobiq/components/link';
 import * as i4 from '@angular/common';
-import * as i5 from '@koobiq/components/tooltip';
-import * as i6 from '@koobiq/components/progress-spinner';
-import * as i7 from '@koobiq/components/icon';
-import * as i8 from '@koobiq/components/button';
-import * as i9 from '@koobiq/components/list';
+import * as i5 from '@angular/forms';
+import * as i6 from '@koobiq/components/tooltip';
+import * as i7 from '@koobiq/components/progress-spinner';
+import * as i8 from '@koobiq/components/icon';
+import * as i9 from '@koobiq/components/button';
 import { InjectionToken } from '@angular/core';
 import { KbqLocaleService } from '@koobiq/components/core';
+import { NgControl } from '@angular/forms';
+import { OnDestroy } from '@angular/core';
 import { ProgressSpinnerMode } from '@koobiq/components/progress-spinner';
 import { Renderer2 } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 
 // @public (undocumented)
@@ -85,7 +91,7 @@ export class KbqFileUploadModule {
     // Warning: (ae-forgotten-export) The symbol "i3" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<KbqFileUploadModule, [typeof i1.KbqFileDropDirective, typeof i2.KbqSingleFileUploadComponent, typeof i3.KbqMultipleFileUploadComponent], [typeof i4.CommonModule, typeof i5.KbqToolTipModule, typeof i6.KbqProgressSpinnerModule, typeof i7.KbqIconModule, typeof i8.KbqButtonModule, typeof i9.KbqListModule, typeof i10.KbqFormFieldModule, typeof i11.KbqEllipsisCenterModule, typeof i12.KbqDataSizeModule, typeof i13.KbqLinkModule], [typeof i2.KbqSingleFileUploadComponent, typeof i3.KbqMultipleFileUploadComponent, typeof i1.KbqFileDropDirective]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<KbqFileUploadModule, [typeof i1.KbqFileDropDirective, typeof i2.KbqSingleFileUploadComponent, typeof i3.KbqMultipleFileUploadComponent], [typeof i4.CommonModule, typeof i5.FormsModule, typeof i5.ReactiveFormsModule, typeof i6.KbqToolTipModule, typeof i7.KbqProgressSpinnerModule, typeof i8.KbqIconModule, typeof i9.KbqButtonModule, typeof i10.KbqListModule, typeof i11.KbqFormFieldModule, typeof i12.KbqEllipsisCenterModule, typeof i13.KbqDataSizeModule, typeof i14.KbqLinkModule], [typeof i2.KbqSingleFileUploadComponent, typeof i3.KbqMultipleFileUploadComponent, typeof i1.KbqFileDropDirective]>;
 }
 
 // @public (undocumented)
@@ -129,8 +135,8 @@ export interface KbqInputFileMultipleLabel extends KbqInputFileLabel {
 }
 
 // @public (undocumented)
-export class KbqMultipleFileUploadComponent implements KbqInputFile, CanDisable {
-    constructor(cdr: ChangeDetectorRef, renderer: Renderer2, configuration: KbqInputFileMultipleLabel, localeService?: KbqLocaleService | undefined);
+export class KbqMultipleFileUploadComponent implements AfterViewInit, OnDestroy, KbqInputFile, CanDisable, ControlValueAccessor {
+    constructor(cdr: ChangeDetectorRef, renderer: Renderer2, configuration: KbqInputFileMultipleLabel, localeService?: KbqLocaleService | undefined, ngControl?: NgControl | undefined);
     // (undocumented)
     accept?: string[];
     // (undocumented)
@@ -146,8 +152,8 @@ export class KbqMultipleFileUploadComponent implements KbqInputFile, CanDisable 
     readonly configuration: KbqInputFileMultipleLabel;
     // (undocumented)
     customFileIcon: TemplateRef<HTMLElement>;
-    // (undocumented)
     customValidation?: KbqFileValidatorFn[];
+    cvaOnChange: (_: KbqFileItem[]) => void;
     // (undocumented)
     deleteFile(index: number, event?: MouseEvent): void;
     // (undocumented)
@@ -157,7 +163,8 @@ export class KbqMultipleFileUploadComponent implements KbqInputFile, CanDisable 
     // (undocumented)
     fileQueueChanged: EventEmitter<KbqFileItem[]>;
     // (undocumented)
-    files: KbqFileItem[];
+    get files(): KbqFileItem[];
+    set files(currentFileList: KbqFileItem[]);
     // (undocumented)
     get hasErrors(): boolean;
     // (undocumented)
@@ -167,29 +174,42 @@ export class KbqMultipleFileUploadComponent implements KbqInputFile, CanDisable 
     // (undocumented)
     inputId: string;
     // (undocumented)
+    ngAfterViewInit(): void;
+    // (undocumented)
+    ngControl?: NgControl | undefined;
+    // (undocumented)
+    ngOnDestroy(): void;
+    // (undocumented)
     onFileDropped(files: FileList | KbqFile[]): void;
     // (undocumented)
     onFileListChange(): void;
     // (undocumented)
     onFileSelectedViaClick({ target }: Event): void;
+    onTouched: () => void;
     progressMode: ProgressSpinnerMode;
+    registerOnChange(fn: any): void;
+    registerOnTouched(fn: any): void;
     // (undocumented)
     separatedCaptionText: string[];
     // (undocumented)
     separatedCaptionTextForCompactSize: string[];
     // (undocumented)
     separatedCaptionTextWhenSelected: string[];
+    setDisabledState(isDisabled: boolean): void;
     // (undocumented)
     size: 'compact' | 'default';
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqMultipleFileUploadComponent, "kbq-multiple-file-upload,kbq-file-upload[multiple]", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "files": { "alias": "files"; "required": false; }; "size": { "alias": "size"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; }, { "fileQueueChanged": "fileQueueChanged"; }, ["customFileIcon"], ["[hint]"], false, never>;
+    statusChangeSubscription?: Subscription;
+    writeValue(files: FileList | KbqFileItem[] | null): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqMultipleFileUploadComponent, [null, null, { optional: true; }, { optional: true; }]>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqMultipleFileUploadComponent, "kbq-multiple-file-upload,kbq-file-upload[multiple]", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "size": { "alias": "size"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "files": { "alias": "files"; "required": false; }; }, { "fileQueueChanged": "fileQueueChanged"; }, ["customFileIcon"], ["[hint]"], false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqMultipleFileUploadComponent, [null, null, { optional: true; }, { optional: true; }, { optional: true; self: true; }]>;
 }
 
 // @public (undocumented)
-export class KbqSingleFileUploadComponent implements KbqInputFile, CanDisable {
-    constructor(cdr: ChangeDetectorRef, renderer: Renderer2, configuration: KbqInputFileLabel, localeService?: KbqLocaleService | undefined);
+export class KbqSingleFileUploadComponent implements AfterViewInit, OnDestroy, KbqInputFile, CanDisable, ControlValueAccessor {
+    constructor(cdr: ChangeDetectorRef, renderer: Renderer2, configuration: KbqInputFileLabel, localeService?: KbqLocaleService | undefined, ngControl?: NgControl | undefined);
     // (undocumented)
     accept?: string[];
     // (undocumented)
@@ -198,8 +218,8 @@ export class KbqSingleFileUploadComponent implements KbqInputFile, CanDisable {
     config: KbqInputFileLabel;
     // (undocumented)
     readonly configuration: KbqInputFileLabel;
-    // (undocumented)
     customValidation?: KbqFileValidatorFn[];
+    cvaOnChange: (_: KbqFileItem | null) => void;
     // (undocumented)
     deleteItem(event?: MouseEvent): void;
     // (undocumented)
@@ -207,7 +227,8 @@ export class KbqSingleFileUploadComponent implements KbqInputFile, CanDisable {
     // (undocumented)
     errors: string[];
     // (undocumented)
-    file: KbqFileItem | null;
+    get file(): KbqFileItem | null;
+    set file(currentFile: KbqFileItem | null);
     // (undocumented)
     fileQueueChange: EventEmitter<KbqFileItem | null>;
     // (undocumented)
@@ -215,16 +236,29 @@ export class KbqSingleFileUploadComponent implements KbqInputFile, CanDisable {
     // (undocumented)
     inputId: string;
     // (undocumented)
+    ngAfterViewInit(): void;
+    // (undocumented)
+    ngControl?: NgControl | undefined;
+    // (undocumented)
+    ngOnDestroy(): void;
+    // (undocumented)
     onFileDropped(files: FileList | KbqFile[]): void;
     // (undocumented)
     onFileSelectedViaClick({ target }: Event): void;
+    onTouched: () => void;
     progressMode: ProgressSpinnerMode;
+    registerOnChange(fn: any): void;
+    registerOnTouched(fn: any): void;
     // (undocumented)
     separatedCaptionText: string[];
+    setDisabledState(isDisabled: boolean): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSingleFileUploadComponent, "kbq-single-file-upload,kbq-file-upload:not([multiple])", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "file": { "alias": "file"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; }, { "fileQueueChange": "fileQueueChange"; }, never, ["[hint]", "[kbq-icon]"], false, never>;
+    statusChangeSubscription?: Subscription;
+    writeValue(file: File | KbqFileItem | null): void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqSingleFileUploadComponent, [null, null, { optional: true; }, { optional: true; }]>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSingleFileUploadComponent, "kbq-single-file-upload,kbq-file-upload:not([multiple])", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "file": { "alias": "file"; "required": false; }; }, { "fileQueueChange": "fileQueueChange"; }, never, ["[hint]", "[kbq-icon]"], false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqSingleFileUploadComponent, [null, null, { optional: true; }, { optional: true; }, { optional: true; self: true; }]>;
 }
 
 // (No @packageDocumentation comment for this package)


### PR DESCRIPTION
## Summary

Implemented `ControlValueAccessor` logic & FormControl's validation

## List of notable changes:

- **added** examples for CVA usage
- **updated** tests
