### PR TITLE
fix(textarea): title & required attributes behavior (#DS-2449)

### DIFF
--- a/packages/components-dev/textarea/template.html
+++ b/packages/components-dev/textarea/template.html
@@ -42,6 +42,6 @@
     <header>Invalid:</header>
 
     <kbq-form-field>
-        <textarea kbqTextarea [(ngModel)]="value" placeholder="Placeholder" [required]="true"></textarea>
+        <textarea kbqTextarea [(ngModel)]="value" placeholder="Placeholder" [required]="true" title="Field is required"></textarea>
     </kbq-form-field>
 </div>

--- a/packages/components/textarea/textarea.component.ts
+++ b/packages/components/textarea/textarea.component.ts
@@ -66,8 +66,8 @@ export const KbqTextareaMixinBase: CanUpdateErrorStateCtor & typeof KbqTextareaB
         '[attr.id]': 'id',
         '[attr.placeholder]': 'placeholder',
         '[attr.aria-invalid]': 'errorState',
-        '[attr.disabled]': 'disabled || null',
-        '[attr.required]': 'required || null',
+        '[disabled]': 'disabled',
+        '[required]': 'required',
 
         '(blur)': 'onBlur()',
         '(focus)': 'focusChanged(true)'

--- a/packages/components/textarea/textarea.component.ts
+++ b/packages/components/textarea/textarea.component.ts
@@ -67,7 +67,7 @@ export const KbqTextareaMixinBase: CanUpdateErrorStateCtor & typeof KbqTextareaB
         '[attr.placeholder]': 'placeholder',
         '[attr.aria-invalid]': 'errorState',
         '[attr.disabled]': 'disabled || null',
-        '[attr.required]': 'required',
+        '[attr.required]': 'required || null',
 
         '(blur)': 'onBlur()',
         '(focus)': 'focusChanged(true)'


### PR DESCRIPTION
## Summary
Aligned `required` attribute with native html realization

## List of notable changes:
- **updated** `required` attribute with `null` default value to align with native html declaration