### PR TITLE
fix(textarea): canGrow properties initialization (#DS-2452)

### DIFF
--- a/packages/components/textarea/textarea.component.ts
+++ b/packages/components/textarea/textarea.component.ts
@@ -211,14 +211,16 @@ export class KbqTextarea extends KbqTextareaMixinBase implements KbqFormFieldCon
     }
 
     ngOnInit() {
-        this.lineHeight = parseInt(getComputedStyle(this.elementRef.nativeElement).lineHeight!, 10);
+        Promise.resolve().then(() => {
+            this.lineHeight = parseInt(getComputedStyle(this.elementRef.nativeElement).lineHeight!, 10);
 
-        const paddingTop = parseInt(getComputedStyle(this.elementRef.nativeElement).paddingTop!, 10);
-        const paddingBottom = parseInt(getComputedStyle(this.elementRef.nativeElement).paddingBottom!, 10);
+            const paddingTop = parseInt(getComputedStyle(this.elementRef.nativeElement).paddingTop!, 10);
+            const paddingBottom = parseInt(getComputedStyle(this.elementRef.nativeElement).paddingBottom!, 10);
 
-        // tslint:disable-next-line:no-magic-numbers
-        this.minHeight = this.lineHeight * 2 + paddingTop + paddingBottom;
-        this.freeRowsHeight = this.lineHeight;
+            // tslint:disable-next-line:no-magic-numbers
+            this.minHeight = this.lineHeight * 2 + paddingTop + paddingBottom;
+            this.freeRowsHeight = this.lineHeight;
+        })
 
         setTimeout(this.grow, 0);
     }


### PR DESCRIPTION
## Summary

Updated initialization of properties responsible for height calculation. It's specific case: in modal, container attached in afterViewInit, so these properites won't be initialized correctly, so in this PR initialization deferred.

## List of notable changes:
- **updated** nitialization of properties responsible for height calculation 


P.S. there is another idea to replace `KBQ_PARENT_ANIMATION_COMPONENT` with observable and use factory:

```
{
    provide: KBQ_PARENT_ANIMATION_COMPONENT,
    deps: [KbqTabGroup],
    useFactory: (tabGroup: KbqTabGroup) => tabGroup.animationDone
}
```

And for modal use similar subject


