### PR TITLE
fix(code-block): scroll with keyboard (#DS-2336)

### DIFF
--- a/packages/components/code-block/_code-block-theme.scss
+++ b/packages/components/code-block/_code-block-theme.scss
@@ -11,12 +11,22 @@
     $actionbar: map.get($style, actionbar);
     $collapse: map.get($style, collapse);
 
-    border-color: map.get($container, border);
     background: map.get($container, background);
 
     & .kbq-tab-header {
         $header: map.get($style, header);
         background: map.get($header, background) !important;
+        border-color: map.get($container, border);
+    }
+
+    .kbq-tab-body__wrapper {
+        border-color: map.get($container, border);
+    }
+
+    &:not(.kbq-code-block_no-header) {
+        .kbq-tab-body__wrapper {
+            border-top-color: transparent;
+        }
     }
 
     & .kbq-code-block-actionbar {
@@ -333,6 +343,13 @@
 
         &.kbq-code-block_filled {
             @include kbq-code-block-style(map.get($code-block, filled));
+        }
+
+        .kbq-tab-group.kbq-focused {
+            .kbq-tab-body__wrapper {
+                border-width: 2px;
+                border-color: map.get(map.get($theme, states), focused-color);
+            }
         }
 
         .kbq-tab-header {

--- a/packages/components/code-block/_code-block-theme.scss
+++ b/packages/components/code-block/_code-block-theme.scss
@@ -346,9 +346,14 @@
         }
 
         .kbq-tab-group.kbq-focused {
+            // paint focus border from the top since because of border constraints
+            .kbq-tab-header {
+                box-shadow: 0 3px 0 -1px map.get(map.get($theme, states), focused-color);
+            }
+
             .kbq-tab-body__wrapper {
-                border-width: 2px;
                 border-color: map.get(map.get($theme, states), focused-color);
+                box-shadow: inset 0 0 0 1px map.get(map.get($theme, states), focused-color);
             }
         }
 

--- a/packages/components/code-block/actionbar.component.scss
+++ b/packages/components/code-block/actionbar.component.scss
@@ -38,7 +38,7 @@ $tokens: meta.module-variables(tokens) !default;
             --kbq-code-block-size-actionbar-fade-gradient-width,
             map.get($tokens, code-block-size-actionbar-fade-gradient-width)
         );
-        height: 40px;
+        height: 32px;
 
         margin-top: calc(
             var(

--- a/packages/components/code-block/actionbar.component.scss
+++ b/packages/components/code-block/actionbar.component.scss
@@ -16,7 +16,7 @@ $tokens: meta.module-variables(tokens) !default;
     top: -1px;
     right: 0;
 
-    padding:
+    margin:
         var(
             --kbq-code-block-size-actionbar-padding-vertical,
             map.get($tokens, code-block-size-actionbar-padding-vertical)

--- a/packages/components/code-block/code-block.component.html
+++ b/packages/components/code-block/code-block.component.html
@@ -11,25 +11,26 @@
              [class.kbq-code-block__code_soft-wrap]="softWrap"
              [class.kbq-code-block__code_view-all]="viewAll"
              (scroll)="checkOverflow(codeContent)"
-            ><code class="hljs"
+            ><kbq-actionbar-block
+            [class.kbq-actionbar-block_floating]="noHeader"
+            [config]="config"
+            [codeFiles]="codeFiles"
+            [selectedTabIndex]="selectedTabIndex"
+            [lessContrast]="filled"
+            [multiLine]="multiLine"
+            [softWrap]="softWrap"
+            (toggleSoftWrap)="toggleSoftWrap()"
+            (downloadCode)="downloadCode()"
+            (copyCode)="copyCode()"
+            (openExternalSystem)="openExternalSystem()">
+            </kbq-actionbar-block><code class="hljs"
                [id]="codeFile.filename + '_' + i"
                [class.hljs-line-numbers]="lineNumbers"
                [highlight]="codeFiles[i].content"
                [lineNumbers]="true"
+               [tabIndex]="canShowFocus(codeContent) ? 0 : -1"
                (highlighted)="onHighlighted()">
-            </code><kbq-actionbar-block
-                [class.kbq-actionbar-block_floating]="noHeader"
-                [config]="config"
-                [codeFiles]="codeFiles"
-                [selectedTabIndex]="selectedTabIndex"
-                [lessContrast]="filled"
-                [multiLine]="multiLine"
-                [softWrap]="softWrap"
-                (toggleSoftWrap)="toggleSoftWrap()"
-                (downloadCode)="downloadCode()"
-                (copyCode)="copyCode()"
-                (openExternalSystem)="openExternalSystem()">
-            </kbq-actionbar-block></pre>
+            </code></pre>
 
         <div class="kbq-code-block__show-more"
              *ngIf="maxHeight"
@@ -40,6 +41,7 @@
                     [color]="'theme'"
                     [kbqStyle]="'transparent'"
                     kbq-button
+                    (keydown.enter)="onEnter(codeContent)"
                     (click)="onShowMoreClick(codeContent)">
                 <i kbq-icon="mc-angle-down-L_16" *ngIf="!viewAll"></i>
                 <i kbq-icon="mc-angle-up-L_16" *ngIf="viewAll"></i>

--- a/packages/components/code-block/code-block.component.html
+++ b/packages/components/code-block/code-block.component.html
@@ -1,4 +1,6 @@
-<kbq-tab-group (selectedTabChange)="onSelectTab($event)">
+<kbq-tab-group
+    [class.kbq-focused]="hasFocus"
+    (selectedTabChange)="onSelectTab($event)">
     <kbq-tab
         *ngFor="let codeFile of codeFiles; let i = index"
         [disabled]="singleFile">
@@ -29,7 +31,8 @@
                [highlight]="codeFiles[i].content"
                [lineNumbers]="true"
                [tabIndex]="canShowFocus(codeContent) ? 0 : -1"
-               (highlighted)="onHighlighted()">
+               (highlighted)="onHighlighted()"
+               (blur)="hasFocus = false">
             </code></pre>
 
         <div class="kbq-code-block__show-more"

--- a/packages/components/code-block/code-block.component.ts
+++ b/packages/components/code-block/code-block.component.ts
@@ -60,6 +60,11 @@ export const KBQ_CODE_BLOCK_DEFAULT_CONFIGURATION = {
 
 const actionBarBlockLeftMargin = 24;
 
+const hasScroll = (element: HTMLElement) => {
+    const { scrollHeight, scrollWidth, clientHeight, clientWidth} = element;
+    return scrollHeight > clientHeight || scrollWidth > clientWidth;
+}
+
 @Component({
     selector: 'kbq-code-block',
     exportAs: 'kbqCodeBlock',
@@ -195,6 +200,15 @@ export class KbqCodeBlockComponent implements OnDestroy {
         }
     }
 
+    // TODO: replace with property to reduce calculations
+    canShowFocus(currentCodeContent: HTMLPreElement): boolean {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const currentCodeBlock = currentCodeContent.querySelector('code')!;
+
+        return (hasScroll(currentCodeContent) || hasScroll(currentCodeBlock))
+            && (!!this.maxHeight && this.viewAll || !this.maxHeight);
+    }
+
     private updateMultiline = () => {
         this.multiLine = this.elementRef.nativeElement
             .querySelectorAll('.hljs-ln-numbers').length > 1;
@@ -209,5 +223,15 @@ export class KbqCodeBlockComponent implements OnDestroy {
         const extension = LANGUAGES_EXTENSIONS[codeFile.language] || DEFAULT_EXTENSION;
 
         return `${fileName}.${extension}`;
+    }
+
+    onEnter(currentCodeBlock: HTMLPreElement) {
+        // defer execution after toggle view mode
+        setTimeout(() => {
+            if (this.canShowFocus(currentCodeBlock)) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                currentCodeBlock.querySelector('code')!.focus();
+            }
+        }, 0);
     }
 }

--- a/packages/components/code-block/code-block.scss
+++ b/packages/components/code-block/code-block.scss
@@ -4,6 +4,12 @@
 
 $tokens: meta.module-variables(tokens) !default;
 
+$border-radius: var(
+    --kbq-code-block-size-container-border-radius, map.get($tokens, code-block-size-container-border-radius)
+);
+$border-width: var(
+        --kbq-code-block-size-container-border-width, map.get($tokens, code-block-size-container-border-width)
+);
 
 /* stylelint-disable no-descending-specificity */
 .kbq-code-block {
@@ -18,13 +24,8 @@ $tokens: meta.module-variables(tokens) !default;
     -moz-hyphens: none;
     -webkit-hyphens: none;
 
-    border-width: var(
-        --kbq-code-block-size-container-border-width, map.get($tokens, code-block-size-container-border-width)
-    );
-    border-style: solid;
-    border-radius: var(
-        --kbq-code-block-size-container-border-radius, map.get($tokens, code-block-size-container-border-radius)
-    );
+    border-radius: $border-radius;
+    border-width: 0;
 
     .kbq-tab-header {
         // 4 buttons + margin
@@ -46,6 +47,11 @@ $tokens: meta.module-variables(tokens) !default;
                 --kbq-code-block-size-header-padding-left,
                 map.get($tokens, code-block-size-header-padding-left)
             );
+
+        border-width: $border-width;
+        border-bottom-width: 0;
+        border-style: solid;
+        border-radius: $border-radius $border-radius 0 0;
     }
 
     .kbq-code-block__code {
@@ -66,6 +72,12 @@ $tokens: meta.module-variables(tokens) !default;
                     --kbq-code-block-size-with-header-content-padding-horizontal,
                     map.get($tokens, code-block-size-with-header-content-padding-horizontal)
                 );
+
+            border-radius: $border-radius;
+
+            &:focus-visible {
+                outline: none;
+            }
         }
 
         .hljs-ln-numbers {
@@ -95,6 +107,11 @@ $tokens: meta.module-variables(tokens) !default;
     &.kbq-code-block_no-header {
         .kbq-tab-header {
             display: none;
+        }
+
+        .kbq-tab-body__wrapper {
+            border-width: $border-width;
+            border-radius: $border-radius;
         }
 
         .kbq-code-block__code {
@@ -134,6 +151,10 @@ $tokens: meta.module-variables(tokens) !default;
     .kbq-tab-body__wrapper {
         flex-direction: column;
         position: unset;
+
+        border-width: $border-width;
+        border-style: solid;
+        border-radius: 0 0 $border-radius $border-radius;
     }
 
     .kbq-tab-body.kbq-tab-body__active {
@@ -176,10 +197,11 @@ $tokens: meta.module-variables(tokens) !default;
     justify-content: center;
     overflow: hidden;
 
-    width: 100%;
+    width: calc(100% - $border-width * 2);
 
     position: absolute;
-    bottom: 0;
+    bottom: $border-width;
+    border-radius: $border-radius;
 
     &.kbq-code-block__show-more_collapsed {
         padding-top: var(

--- a/packages/components/code-block/code-block.scss
+++ b/packages/components/code-block/code-block.scss
@@ -48,8 +48,7 @@ $border-width: var(
                 map.get($tokens, code-block-size-header-padding-left)
             );
 
-        border-width: $border-width;
-        border-bottom-width: 0;
+        border-width: $border-width $border-width 0 $border-width;
         border-style: solid;
         border-radius: $border-radius $border-radius 0 0;
     }
@@ -101,6 +100,12 @@ $border-width: var(
             &:hover {
                 background: transparent !important;
             }
+        }
+    }
+
+    &:not(.kbq-code-block_no-header) {
+        .kbq-tab-body__wrapper {
+            border-top-width: 0;
         }
     }
 

--- a/packages/docs-examples/components/code-block/code-block-noborder/code-block-noborder-example.css
+++ b/packages/docs-examples/components/code-block/code-block-noborder/code-block-noborder-example.css
@@ -1,16 +1,7 @@
-.code-block_no-border {
+.code-block_no-border .kbq-tab-group {
+    height: 100%;
+}
+
+.code-block_no-border .kbq-tab-body__wrapper {
     border: none;
-}
-
-.kbq-code-block.code-block_no-border,
-.kbq-code-block.code-block_no-border .kbq-tab-body__wrapper,
-.kbq-code-block.code-block_no-border .kbq-tab-body,
-.kbq-code-block.code-block_no-border .kbq-tab-body__content,
-.kbq-code-block.code-block_no-border .kbq-code-block__code,
-.kbq-code-block.code-block_no-border .kbq-code-block__code > code.hljs.hljs-line-numbers {
-    overflow: visible;
-}
-
-.kbq-code-block.code-block_no-border .kbq-code-block__code > code {
-    width: 100%;
 }


### PR DESCRIPTION
## Summary

Added scroll with keyboard

## List of notable changes:

- **added** `focusMonitor` for keyboard origin track
- **updated** `action-block` and `code` order for tab sequence
- **removed** border from `code-block` host and delegated to `tab-header` and `tab-body-wrapper`, so `tab-body-wrapper` can be focused separately.
- **added** `tabIndex` to `code` so element can be focused and scrolled with keyboard

## What should reviewers focus on?
`ngAfterViewInit` and `onBlur` logic