### PR TITLE
fix(docs,chore): removed dependency from nodeJS version (#DS-2476)

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
         "docs:prod-build": "ng build koobiq-docs",
         "docs:prod-build:aot": "ng build koobiq-docs --configuration production",
         "docs:update-versions": "ts-node --project tools/update-doc-versions/tsconfig.json tools/update-doc-versions/update-doc-versions.ts",
-        "docs:api-gen": "ts-node --esm --project tools/api-gen/tsconfig.json tools/api-gen/generate-api-docs.ts",
+        "docs:api-gen": "TS_NODE_PROJECT=tools/api-gen/tsconfig.json node --loader ts-node/esm tools/api-gen/generate-api-docs.ts",
         "preinstall": "node tools/npm/check-npm.js",
         "prepare": "husky",
         "postinstall": "tsc -p tools/builders/tsconfig.json",

--- a/tools/api-gen/extraction/helpers.ts
+++ b/tools/api-gen/extraction/helpers.ts
@@ -1,10 +1,10 @@
-import { ClassEntry, DocEntry, MemberEntry, MemberTags } from '../rendering/entities.js';
-import { isClassEntry } from '../rendering/entities/categorization.js';
+import { ClassEntry, DocEntry, MemberEntry, MemberTags } from '../rendering/entities.ts';
+import { isClassEntry } from '../rendering/entities/categorization.ts';
 import fs from 'fs';
 import ts from 'typescript';
-import { ClassEntryMetadata, PackageMetadata } from '../types/types.js';
+import { ClassEntryMetadata, PackageMetadata } from '../types/types.ts';
 import { relative } from 'path';
-import { isPublic } from '../manifest/helpers.js';
+import { isPublic } from '../manifest/helpers.ts';
 
 type FunctionProps = keyof Function | string;
 const fProps: FunctionProps[] = ['call', 'caller', 'apply', '[Symbol.hasInstance]', 'toString', 'arguments', 'bind', '[Symbol.metadata]', 'name', 'length'];
@@ -52,7 +52,7 @@ export function entryHandler(entrySrc: string) {
     sourceFile.forEachChild((node) => {
         if (!node || !ts.isClassDeclaration(node)) { return; }
 
-        let baseClass = null;
+        let baseClass: string | null = null;
         if (node.heritageClauses) {
             for (let clause of node.heritageClauses) {
                 if (clause.token === ts.SyntaxKind.ExtendsKeyword) {

--- a/tools/api-gen/extraction/index.ts
+++ b/tools/api-gen/extraction/index.ts
@@ -2,11 +2,9 @@ import { basename, join } from 'path';
 import ts from 'typescript';
 import { NgtscProgram } from '@angular/compiler-cli';
 
-// @ts-ignore
-import { src } from '../utils.js';
-// @ts-ignore
-import { PackageMetadata, EntryCollection, ClassEntryMetadata } from '../types/types.js';
-import { entryHandler, updateEntries, prepareMergedMetadata } from './helpers.js';
+import { src } from '../utils.ts';
+import { PackageMetadata, EntryCollection, ClassEntryMetadata } from '../types/types.ts';
+import { entryHandler, updateEntries, prepareMergedMetadata } from './helpers.ts';
 
 
 const getMetadataFrom = (moduleName: string, packageName: string): PackageMetadata => {

--- a/tools/api-gen/generate-api-docs.ts
+++ b/tools/api-gen/generate-api-docs.ts
@@ -1,9 +1,6 @@
-// @ts-ignore
-import { extractApiToJson } from './extraction/index.js';
-// @ts-ignore
-import { generateApiToHtml } from './rendering/index.js';
-// @ts-ignore
-import { generateManifest } from './manifest/index.js';
+import { extractApiToJson } from './extraction/index.ts';
+import { generateApiToHtml } from './rendering/index.ts';
+import { generateManifest } from './manifest/index.ts';
 
 export const generateApiDocs = () => {
     const data = extractApiToJson();

--- a/tools/api-gen/manifest/helpers.ts
+++ b/tools/api-gen/manifest/helpers.ts
@@ -1,4 +1,4 @@
-import { DocEntry, JsDocTagEntry } from '../rendering/entities.js';
+import { DocEntry, JsDocTagEntry } from '../rendering/entities.ts';
 
 /* Add mapping to use nunjucks rendering */
 

--- a/tools/api-gen/manifest/index.ts
+++ b/tools/api-gen/manifest/index.ts
@@ -1,6 +1,6 @@
-import { EntryCollection, ManifestEntry, PackageApiInfo } from '../types/types.js';
-import { DocEntry } from '../rendering/entities.js';
-import { computeApiDocumentUrl, getApiLookupKey, isPublic } from './helpers.js';
+import { EntryCollection, ManifestEntry, PackageApiInfo } from '../types/types.ts';
+import { DocEntry } from '../rendering/entities.ts';
+import { computeApiDocumentUrl, getApiLookupKey, isPublic } from './helpers.ts';
 
 export function generateManifest(apiCollections: EntryCollection[]): EntryCollection<ManifestEntry>[] {
     // Filter out repeated entries for function overloads, but also keep track of

--- a/tools/api-gen/rendering/entities/categorization.ts
+++ b/tools/api-gen/rendering/entities/categorization.ts
@@ -10,26 +10,14 @@ import {
     MemberType,
     MethodEntry,
     PropertyEntry,
-    TypeAliasEntry,//@ts-ignore
-} from '../entities.js';
+    TypeAliasEntry
+} from '../entities.ts';
 
-/*import {
-  ClassEntryRenderable,
-  ConstantEntryRenderable,
-  DocEntryRenderable,
-  EnumEntryRenderable,
-  FunctionEntryRenderable,
-  InterfaceEntryRenderable,
-  MemberEntryRenderable,
-  MethodEntryRenderable,
-  TypeAliasEntryRenderable,//@ts-ignore
-} from './renderables.ts';*///@ts-ignore
-import {HasJsDocTags} from './traits.js';
-import { ClassEntryRenderable, DocEntryRenderable, InterfaceEntryRenderable } from './renderables.js';
+import {HasJsDocTags} from './traits.ts';
+import { ClassEntryRenderable, DocEntryRenderable, InterfaceEntryRenderable } from './renderables.ts';
 
 
 /** Gets whether the given entry represents a class */
-// @ts-ignore
 export function isClassEntry(entry: DocEntryRenderable): entry is ClassEntryRenderable;
 export function isClassEntry(entry: DocEntry): entry is ClassEntry;
 export function isClassEntry(entry: DocEntry): entry is ClassEntry {
@@ -67,7 +55,6 @@ export function isEnumEntry(entry: DocEntry): entry is EnumEntry {
 }
 
 /** Gets whether the given entry represents an interface. */
-//@ts-ignore
 export function isInterfaceEntry(entry: DocEntryRenderable): entry is InterfaceEntryRenderable;
 export function isInterfaceEntry(entry: DocEntry): entry is InterfaceEntry;
 export function isInterfaceEntry(entry: DocEntry): entry is InterfaceEntry {

--- a/tools/api-gen/rendering/entities/renderables.ts
+++ b/tools/api-gen/rendering/entities/renderables.ts
@@ -8,11 +8,7 @@ import {
     MemberEntry,
     ParameterEntry,
     TypeAliasEntry,
-} from '../entities.js';
-
-//@ts-ignore
-// import {HasRenderableToc} from './traits.ts';
-// import { InitializerApiFunctionEntry } from '../entities';
+} from '../entities.ts';
 
 /** JsDoc tag info augmented with transformed content for rendering. */
 export interface JsDocTagRenderable extends JsDocTagEntry {

--- a/tools/api-gen/rendering/entities/traits.ts
+++ b/tools/api-gen/rendering/entities/traits.ts
@@ -1,4 +1,4 @@
-import { JsDocTagEntry, MemberEntry, ParameterEntry } from '../entities.js';
+import { JsDocTagEntry, MemberEntry, ParameterEntry } from '../entities.ts';
 
 import {
     CodeLineRenderable,
@@ -7,7 +7,7 @@ import {
     MemberEntryRenderable,
     ParameterEntryRenderable,
     PropertyEntryRenderable,
-} from './renderables.js';
+} from './renderables.ts';
 
 /** A doc entry that has jsdoc tags. */
 export interface HasJsDocTags {

--- a/tools/api-gen/rendering/helpers.ts
+++ b/tools/api-gen/rendering/helpers.ts
@@ -1,6 +1,6 @@
-import { ClassEntryRenderable, DocEntryRenderable } from './entities/renderables.js';
-import { isClassEntry, isDeprecatedEntry } from './entities/categorization.js';
-import { EntryType } from './entities.js';
+import { ClassEntryRenderable, DocEntryRenderable } from './entities/renderables.ts';
+import { isClassEntry, isDeprecatedEntry } from './entities/categorization.ts';
+import { EntryType } from './entities.ts';
 
 export const isClass = (renderable: DocEntryRenderable) => {
     return isClassEntry(renderable) && renderable.entryType === EntryType.UndecoratedClass

--- a/tools/api-gen/rendering/index.ts
+++ b/tools/api-gen/rendering/index.ts
@@ -1,16 +1,11 @@
-// import nunjucks from 'nunjucks';
-
-//@ts-ignore
-import { EntryCollection, ManifestEntry, PackageApiInfo } from '../types/types.js';
-//@ts-ignore
-import { configureMarkedGlobally } from './marked/configuration.js';
-//@ts-ignore
-import { getRenderable } from './processing.js';
-//@ts-ignore
-import { renderEntry } from './rendering.js';
 import { writeFileSync } from 'fs';
-import { createDirIfNotExists } from '../utils.js';
-import { entryPointGrouper } from './helpers.js';
+
+import { configureMarkedGlobally } from './marked/configuration.ts';
+import { getRenderable } from './processing.ts';
+import { renderEntry } from './rendering.ts';
+import { createDirIfNotExists } from '../utils.ts';
+import { EntryCollection, ManifestEntry, PackageApiInfo } from '../types/types.ts';
+import { entryPointGrouper } from './helpers.ts';
 
 export function generateApiToHtml(entryCollections: EntryCollection<ManifestEntry>[]) {
     configureMarkedGlobally();

--- a/tools/api-gen/rendering/marked/configuration.ts
+++ b/tools/api-gen/rendering/marked/configuration.ts
@@ -1,6 +1,5 @@
 import {marked} from 'marked';
-//@ts-ignore
-import {renderer} from './renderer.js';
+import {renderer} from './renderer.ts';
 
 /** Globally configures marked for rendering JsDoc content to HTML. */
 export function configureMarkedGlobally() {

--- a/tools/api-gen/rendering/marked/renderer.ts
+++ b/tools/api-gen/rendering/marked/renderer.ts
@@ -8,23 +8,12 @@
 
 import highlightJs from 'highlight.js';
 import { Renderer as MarkedRenderer } from 'marked';
-// @ts-ignore
-// import { splitLines } from '../transforms/code-transforms.ts';
+import { splitLines } from '../transforms/code-transforms.ts';
 
 /**
  * Custom renderer for marked that will be used to transform markdown files to HTML
  * files that can be used in the Angular docs.
  */
-/** Split generated code with syntax highlighting into single lines */
-
-// TODO: temporarily added here
-export function splitLines(text: string): string[] {
-    if (text.length === 0) {
-        return [];
-    }
-    return text.split(/\r\n|\r|\n/g);
-}
-
 export const renderer: Partial<MarkedRenderer> = {
     code(code: string, language: string): string {
         let highlightResult: HighlightResult;

--- a/tools/api-gen/rendering/nunjucks-tags/highlight.ts
+++ b/tools/api-gen/rendering/nunjucks-tags/highlight.ts
@@ -1,4 +1,4 @@
-import { highlightCodeBlock } from './highlight-code-block.js';
+import { highlightCodeBlock } from './highlight-code-block.ts';
 
 /**
  * Nunjucks extension that supports rendering highlighted content. Content that is placed in

--- a/tools/api-gen/rendering/processing.ts
+++ b/tools/api-gen/rendering/processing.ts
@@ -1,29 +1,28 @@
-//@ts-ignore
-import { DocEntryRenderable } from './entities/renderables.js';
+import { DocEntryRenderable } from './entities/renderables.ts';
 import {
     isClassEntry,
     isConstantEntry,
     isEnumEntry,
     isFunctionEntry,
-    isInterfaceEntry, isTypeAliasEntry//@ts-ignore
-} from './entities/categorization.js';//@ts-ignore
-import { getClassRenderable } from './transforms/class-transforms.js';
-import { getConstantRenderable } from './transforms/constant-transforms.js';
-import { getEnumRenderable } from './transforms/enum-transforms.js';
-import { getInterfaceRenderable } from './transforms/interface-transforms.js';
-import { getFunctionRenderable } from './transforms/function-transforms.js';
-import { getTypeAliasRenderable } from './transforms/type-alias-transforms.js';
+    isInterfaceEntry,
+    isTypeAliasEntry
+} from './entities/categorization.ts';
+
+import { getClassRenderable } from './transforms/class-transforms.ts';
+import { getConstantRenderable } from './transforms/constant-transforms.ts';
+import { getEnumRenderable } from './transforms/enum-transforms.ts';
+import { getInterfaceRenderable } from './transforms/interface-transforms.ts';
+import { getFunctionRenderable } from './transforms/function-transforms.ts';
+import { getTypeAliasRenderable } from './transforms/type-alias-transforms.ts';
 
 import {
     addHtmlAdditionalLinks,
     addHtmlDescription, addHtmlJsDocTagComments,
     addHtmlUsageNotes,
-    setEntryFlags//@ts-ignore
-} from './transforms/jsdoc-transforms.js';
-//@ts-ignore
-import { addModuleName } from './transforms/module-name.js';
-//@ts-ignore
-import { DocEntry } from './entities.js';
+    setEntryFlags
+} from './transforms/jsdoc-transforms.ts';
+import { addModuleName } from './transforms/module-name.ts';
+import { DocEntry } from './entities.ts';
 
 export function getRenderable(entry: DocEntry, moduleName: string): DocEntryRenderable {
     if (isClassEntry(entry)) {

--- a/tools/api-gen/rendering/rendering.ts
+++ b/tools/api-gen/rendering/rendering.ts
@@ -1,8 +1,9 @@
 import nunjucks from 'nunjucks';
-import { HighlightNunjucksExtension } from './nunjucks-tags/highlight.js';
-import path from 'node:path';
+import { join } from 'path';
 
-const TEMPLATE_DIR = path.join(process.cwd(), 'tools', 'api-gen', 'rendering', 'templates');
+import { HighlightNunjucksExtension } from './nunjucks-tags/highlight.ts';
+
+const TEMPLATE_DIR = join(process.cwd(), 'tools', 'api-gen', 'rendering', 'templates');
 const env = nunjucks.configure(TEMPLATE_DIR, {
     autoescape: false,
     tags: {

--- a/tools/api-gen/rendering/transforms/class-transforms.ts
+++ b/tools/api-gen/rendering/transforms/class-transforms.ts
@@ -6,18 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ClassEntry} from '../entities.js';
-import {ClassEntryRenderable} from '../entities/renderables.js';
-import {addRenderableCodeToc} from './code-transforms.js';
+import {ClassEntry} from '../entities.ts';
+import {ClassEntryRenderable} from '../entities/renderables.ts';
+import {addRenderableCodeToc} from './code-transforms.ts';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
   addHtmlJsDocTagComments,
   addHtmlUsageNotes,
   setEntryFlags,
-} from './jsdoc-transforms.js';
-import {addRenderableGroupMembers} from './member-transforms.js';
-import {addModuleName} from './module-name.js';
+} from './jsdoc-transforms.ts';
+import {addRenderableGroupMembers} from './member-transforms.ts';
+import {addModuleName} from './module-name.ts';
 
 /** Given an unprocessed class entry, get the fully renderable class entry. */
 export function getClassRenderable(

--- a/tools/api-gen/rendering/transforms/code-transforms.ts
+++ b/tools/api-gen/rendering/transforms/code-transforms.ts
@@ -4,11 +4,10 @@ import {
   MemberEntry,
   MemberTags,
   ParameterEntry,
-  PropertyEntry,// @ts-ignore
-} from '../entities.js';
+  PropertyEntry,
+} from '../entities.ts';
 import highlightJs from 'highlight.js';
 
-// @ts-ignore
 import {
   isClassEntry,
   isClassMethodEntry,
@@ -20,14 +19,11 @@ import {
   // isInitializerApiFunctionEntry,
   isInterfaceEntry,
   isSetterEntry,
-  isTypeAliasEntry,// @ts-ignore
-} from '../entities/categorization.js';
-// @ts-ignore
-import {CodeLineRenderable} from '../entities/renderables.js';
-// @ts-ignore
-import {HasModuleName, HasRenderableToc} from '../entities/traits.js';
-// @ts-ignore
-import {filterLifecycleMethods, mergeGettersAndSetters} from './member-transforms.js';
+  isTypeAliasEntry
+} from '../entities/categorization.ts';
+import {CodeLineRenderable} from '../entities/renderables.ts';
+import {HasModuleName, HasRenderableToc} from '../entities/traits.ts';
+import {filterLifecycleMethods, mergeGettersAndSetters} from './member-transforms.ts';
 
 // Allows to generate links for code lines.
 interface CodeTableOfContentsData {
@@ -71,7 +67,6 @@ export function addRenderableCodeToc<T extends DocEntry & HasModuleName>(
   const groups = groupCodeLines(lines, metadata);
 
   return {
-      // @ts-ignore
     ...entry,
     codeLinesGroups: groups,
   };
@@ -296,6 +291,7 @@ function getNumberOfLinesOfCode(contents: string): number {
 }
 
 /** Prints an initializer function signature into a single line. */
+/*
 export function printInitializerFunctionSignatureLine(
   name: string,
   signature: FunctionEntry,
@@ -337,6 +333,7 @@ export function printInitializerFunctionSignatureLine(
   res += ';';
   return res;
 }
+*/
 
 function appendPrefixAndSuffix(entry: DocEntry, codeTocData: CodeTableOfContentsData): void {
   const appendFirstAndLastLines = (

--- a/tools/api-gen/rendering/transforms/constant-transforms.ts
+++ b/tools/api-gen/rendering/transforms/constant-transforms.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ConstantEntry} from '../entities.js';
-import {ConstantEntryRenderable} from '../entities/renderables.js';
-import {addRenderableCodeToc} from './code-transforms.js';
+import {ConstantEntry} from '../entities.ts';
+import {ConstantEntryRenderable} from '../entities/renderables.ts';
+import {addRenderableCodeToc} from './code-transforms.ts';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
   addHtmlJsDocTagComments,
   addHtmlUsageNotes,
   setEntryFlags,
-} from './jsdoc-transforms.js';
-import {addModuleName} from './module-name.js';
+} from './jsdoc-transforms.ts';
+import {addModuleName} from './module-name.ts';
 
 /** Given an unprocessed constant entry, get the fully renderable constant entry. */
 export function getConstantRenderable(

--- a/tools/api-gen/rendering/transforms/enum-transforms.ts
+++ b/tools/api-gen/rendering/transforms/enum-transforms.ts
@@ -6,18 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {EnumEntry} from '../entities.js';
-import {EnumEntryRenderable} from '../entities/renderables.js';
-import {addRenderableCodeToc} from './code-transforms.js';
+import {EnumEntry} from '../entities.ts';
+import {EnumEntryRenderable} from '../entities/renderables.ts';
+import {addRenderableCodeToc} from './code-transforms.ts';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
   addHtmlJsDocTagComments,
   addHtmlUsageNotes,
   setEntryFlags,
-} from './jsdoc-transforms.js';
-import {addRenderableMembers} from './member-transforms.js';
-import {addModuleName} from './module-name.js';
+} from './jsdoc-transforms.ts';
+import {addRenderableMembers} from './member-transforms.ts';
+import {addModuleName} from './module-name.ts';
 
 /** Given an unprocessed enum entry, get the fully renderable enum entry. */
 export function getEnumRenderable(classEntry: EnumEntry, moduleName: string): EnumEntryRenderable {

--- a/tools/api-gen/rendering/transforms/function-transforms.ts
+++ b/tools/api-gen/rendering/transforms/function-transforms.ts
@@ -6,18 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {FunctionEntry} from '../entities.js';
-import {FunctionEntryRenderable} from '../entities/renderables.js';
-import {addRenderableCodeToc} from './code-transforms.js';
+import {FunctionEntry} from '../entities.ts';
+import {FunctionEntryRenderable} from '../entities/renderables.ts';
+import {addRenderableCodeToc} from './code-transforms.ts';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
   addHtmlJsDocTagComments,
   addHtmlUsageNotes,
   setEntryFlags,
-} from './jsdoc-transforms.js';
-import {addModuleName} from './module-name.js';
-import {addRenderableFunctionParams} from './params-transforms.js';
+} from './jsdoc-transforms.ts';
+import {addModuleName} from './module-name.ts';
+import {addRenderableFunctionParams} from './params-transforms.ts';
 
 /** Given an unprocessed function entry, get the fully renderable function entry. */
 export function getFunctionRenderable(

--- a/tools/api-gen/rendering/transforms/interface-transforms.ts
+++ b/tools/api-gen/rendering/transforms/interface-transforms.ts
@@ -6,18 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InterfaceEntry} from '../entities.js';
-import {InterfaceEntryRenderable} from '../entities/renderables.js';
-import {addRenderableCodeToc} from './code-transforms.js';
+import {InterfaceEntry} from '../entities.ts';
+import {InterfaceEntryRenderable} from '../entities/renderables.ts';
+import {addRenderableCodeToc} from './code-transforms.ts';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
   addHtmlJsDocTagComments,
   addHtmlUsageNotes,
   setEntryFlags,
-} from './jsdoc-transforms.js';
-import {addRenderableGroupMembers} from './member-transforms.js';
-import {addModuleName} from './module-name.js';
+} from './jsdoc-transforms.ts';
+import {addRenderableGroupMembers} from './member-transforms.ts';
+import {addModuleName} from './module-name.ts';
 
 /** Given an unprocessed interface entry, get the fully renderable interface entry. */
 export function getInterfaceRenderable(

--- a/tools/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/tools/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-//@ts-ignore
-import {JsDocTagEntry} from '../entities.js';
+import {JsDocTagEntry} from '../entities.ts';
 import {marked} from 'marked';
 
 // import {rewriteLinks} from '../backwards-compatibility/links-mapper';
-import {isDeprecatedEntry, isDeveloperPreview} from '../entities/categorization.js';
-import {LinkEntryRenderable} from '../entities/renderables.js';
+import {isDeprecatedEntry, isDeveloperPreview} from '../entities/categorization.ts';
+import {LinkEntryRenderable} from '../entities/renderables.ts';
 import {
   HasAdditionalLinks,
   HasDeprecatedFlag,
@@ -23,9 +22,9 @@ import {
   HasJsDocTags,
   HasModuleName,
   HasRenderableJsDocTags,
-} from '../entities/traits.js';
+} from '../entities/traits.ts';
 
-import {getLinkToModule} from './url-transforms.js';
+import {getLinkToModule} from './url-transforms.ts';
 
 export const JS_DOC_USAGE_NOTES_TAG = 'usageNotes';
 export const JS_DOC_SEE_TAG = 'see';

--- a/tools/api-gen/rendering/transforms/member-transforms.ts
+++ b/tools/api-gen/rendering/transforms/member-transforms.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { MemberEntry, MemberTags, MemberType } from '../entities.js';
+import { MemberEntry, MemberTags, MemberType } from '../entities.ts';
 
-import { isClassMethodEntry } from '../entities/categorization.js';
-import { MemberEntryRenderable } from '../entities/renderables.js';
-import { HasMembers, HasRenderableMembers, HasRenderableMembersGroups } from '../entities/traits.js';
+import { isClassMethodEntry } from '../entities/categorization.ts';
+import { MemberEntryRenderable } from '../entities/renderables.ts';
+import { HasMembers, HasRenderableMembers, HasRenderableMembersGroups } from '../entities/traits.ts';
 
-import { addHtmlDescription, addHtmlJsDocTagComments, setEntryFlags } from './jsdoc-transforms.js';
-import { sortCategorizedMethodMembers, sortCategorizedPropertyMembers } from '../../utils.js';
+import { addHtmlDescription, addHtmlJsDocTagComments, setEntryFlags } from './jsdoc-transforms.ts';
+import { sortCategorizedMethodMembers, sortCategorizedPropertyMembers } from '../../utils.ts';
 // import { MethodEntry } from '@angular/compiler-cli';
 
 const lifecycleMethods = [

--- a/tools/api-gen/rendering/transforms/module-name.ts
+++ b/tools/api-gen/rendering/transforms/module-name.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '../entities.js';
+import {DocEntry} from '../entities.ts';
 
-import {HasModuleName} from '../entities/traits.js';
+import {HasModuleName} from '../entities/traits.ts';
 
 export function addModuleName<T extends DocEntry>(entry: T, moduleName: string): T & HasModuleName {
   return {

--- a/tools/api-gen/rendering/transforms/params-transforms.ts
+++ b/tools/api-gen/rendering/transforms/params-transforms.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HasParams, HasRenderableParams} from '../entities/traits.js';
-import {addHtmlDescription} from './jsdoc-transforms.js';
-import { ParameterEntry } from '../entities.js';
+import {HasParams, HasRenderableParams} from '../entities/traits.ts';
+import {addHtmlDescription} from './jsdoc-transforms.ts';
+import { ParameterEntry } from '../entities.ts';
 
 export function addRenderableFunctionParams<T extends HasParams>(
   entry: T,

--- a/tools/api-gen/rendering/transforms/type-alias-transforms.ts
+++ b/tools/api-gen/rendering/transforms/type-alias-transforms.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TypeAliasEntry} from '../entities.js';
-import {TypeAliasEntryRenderable} from '../entities/renderables.js';
-import {addRenderableCodeToc} from './code-transforms.js';
+import {TypeAliasEntry} from '../entities.ts';
+import {TypeAliasEntryRenderable} from '../entities/renderables.ts';
+import {addRenderableCodeToc} from './code-transforms.ts';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
   addHtmlJsDocTagComments,
   addHtmlUsageNotes,
   setEntryFlags,
-} from './jsdoc-transforms.js';
-import {addModuleName} from './module-name.js';
+} from './jsdoc-transforms.ts';
+import {addModuleName} from './module-name.ts';
 
 /** Given an unprocessed type alias entry, get the fully renderable type alias entry. */
 export function getTypeAliasRenderable(

--- a/tools/api-gen/types/types.ts
+++ b/tools/api-gen/types/types.ts
@@ -1,4 +1,4 @@
-import { DocEntry, MemberEntry } from '../rendering/entities.js';
+import { DocEntry, MemberEntry } from '../rendering/entities.ts';
 
 export type PackageMetadata = { resolvedPath: string, tsCompilerPath: string, packageName: string };
 

--- a/tools/api-gen/utils.ts
+++ b/tools/api-gen/utils.ts
@@ -1,22 +1,22 @@
-import pkg from 'glob';
+import glob from 'glob';
 import { access, mkdir } from 'fs/promises';
-const { GlobSync } = pkg;
 import ts from 'typescript';
+
 import {
     MemberEntryRenderable,
     PropertyEntryRenderable
-} from './rendering/entities/renderables.js';
+} from './rendering/entities/renderables.ts';
 
 export const src = (path: string | string[]): string[] => {
     let res: string[];
     if (Array.isArray(path)) {
         res = path.reduce((result: string[], curPath) => {
-            const files: string[] = new GlobSync(curPath).found;
+            const files: string[] = new glob.GlobSync(curPath).found;
             result.push(...files);
             return result;
         }, []);
     } else {
-        res = new GlobSync(path).found;
+        res = new glob.GlobSync(path).found;
     }
 
     return res;
@@ -46,7 +46,6 @@ export function getDirectiveMetadata(classPath: ts.SourceFile): Map<string, any>
     // TODO: update with new interface
     const declaration: ts.Node = classPath;
 
-    // @ts-ignore
     const decorators = declaration && ts.isClassDeclaration(declaration) ? ts.getDecorators(declaration) : null;
 
     if (!decorators?.length) { return null; }


### PR DESCRIPTION
## Summary

Checked for 18, 20, 21 versions

## List of notable changes:

- **changed** `js` to `ts` extensions to support ts-node/esm loader (ts-node can't load `ts` files without extension mentioned)
- **updated** ts-node loader usage for newer versions because of issue https://github.com/TypeStrong/ts-node/issues/2094
