### PR TITLE
fix(splitter): Splitter isn't working with dynamic data (#DS-2487)

### DIFF
--- a/packages/components/splitter/spliltter.spec.ts
+++ b/packages/components/splitter/spliltter.spec.ts
@@ -114,6 +114,24 @@ class KbqSplitterGhost {
     @ViewChild('areaB', { static: false, read: KbqSplitterAreaDirective }) areaB: KbqSplitterAreaDirective;
 }
 
+@Component({
+    selector: 'kbq-demo-spllitter',
+    template: `
+        <kbq-splitter [direction]="direction" [useGhost]="true" style="width: 500px;">
+            <div #areaA kbq-splitter-area style="flex: 1" *ngIf="isFirstRendered">first</div>
+            <div #areaB kbq-splitter-area style="min-width: 50px">second</div>
+        </kbq-splitter>
+    `
+})
+class DynamicData {
+    direction: Direction = Direction.Horizontal;
+    isFirstRendered = true;
+    @ViewChild(KbqSplitterComponent, { static: false }) splitter: KbqSplitterComponent;
+    @ViewChild('areaA', { static: false, read: KbqSplitterAreaDirective }) areaA: KbqSplitterAreaDirective;
+    @ViewChild('areaB', { static: false, read: KbqSplitterAreaDirective }) areaB: KbqSplitterAreaDirective;
+}
+
+
 
 describe('KbqSplitter', () => {
     describe('direction', () => {
@@ -248,7 +266,7 @@ describe('KbqSplitter', () => {
 
             const areaAInitialSize: number = fixture.componentInstance.areaA.getSize();
             const areaBInitialSize: number = fixture.componentInstance.areaB.getSize();
-            const mouseOffset: number = -10;
+            const mouseOffset = -10;
 
             const gutters = fixture.debugElement.queryAll(By.directive(KbqGutterDirective));
             gutters[0].nativeElement.dispatchEvent(new MouseEvent('mousedown', { screenX: 0, screenY: 0 }));
@@ -298,4 +316,27 @@ describe('KbqSplitter', () => {
             expect(fixture.componentInstance.areaB.getSize()).toBe(areaBMinimalSize);
         }));
     });
+
+    describe('dynamic data', () => {
+        it('should work with dynamic areas', fakeAsync(() => {
+            const update = () => {
+                fixture.detectChanges();
+                tick();
+            }
+
+            const fixture = createTestComponent(DynamicData);
+            const componentInstance = fixture.componentInstance;
+            update();
+
+            expect(componentInstance.areaA).toBeTruthy();
+            expect(+(componentInstance.areaA as any).elementRef.nativeElement.style.order).toBe(0);
+            const areaBInitialOrder = +(componentInstance.areaB as any).elementRef.nativeElement.style.order;
+
+            componentInstance.isFirstRendered = false;
+            update();
+
+            expect(componentInstance.areaA).toBeFalsy();
+            expect(+(componentInstance.areaB as any).elementRef.nativeElement.style.order).not.toEqual(areaBInitialOrder);
+        }));
+    })
 });

--- a/packages/components/splitter/splitter.md
+++ b/packages/components/splitter/splitter.md
@@ -9,3 +9,6 @@
 
 ### Nested
 <!-- example(splitter-nested) -->
+
+### With *ngIf
+<!-- example(splitter-dynamic-data) -->

--- a/packages/docs-examples/components/splitter/index.ts
+++ b/packages/docs-examples/components/splitter/index.ts
@@ -6,26 +6,33 @@ import { SplitterFixedExample } from './splitter-fixed/splitter-fixed-example';
 import { SplitterNestedExample } from './splitter-nested/splitter-nested-example';
 import { SplitterOverviewExample } from './splitter-overview/splitter-overview-example';
 import { SplitterVerticalExample } from './splitter-vertical/splitter-vertical-example';
+import { SplitterDynamicDataExample } from './splitter-dynamic-data/splitter-dynamic-data-example';
+import { KbqButtonModule } from '@koobiq/components/button';
+import { CommonModule } from '@angular/common';
 
 
 export {
     SplitterOverviewExample,
     SplitterFixedExample,
     SplitterVerticalExample,
-    SplitterNestedExample
+    SplitterNestedExample,
+    SplitterDynamicDataExample
 };
 
 const EXAMPLES = [
     SplitterOverviewExample,
     SplitterFixedExample,
     SplitterVerticalExample,
-    SplitterNestedExample
+    SplitterNestedExample,
+    SplitterDynamicDataExample
 ];
 
 @NgModule({
     imports: [
+        CommonModule,
         FormsModule,
-        KbqSplitterModule
+        KbqSplitterModule,
+        KbqButtonModule
     ],
     declarations: EXAMPLES,
     exports: EXAMPLES

--- a/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.css
+++ b/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.css
@@ -1,0 +1,14 @@
+kbq-splitter {
+    display: flex;
+    border: 1px solid black;
+    height: 100px;
+    margin: 2px;
+}
+
+.kbq-splitter-area_fixed-width {
+    min-width: 200px;
+}
+
+div[kbq-splitter-area] {
+    background: #c5c0c0
+}

--- a/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.html
+++ b/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.html
@@ -1,0 +1,7 @@
+<button kbq-button (click)="isFirstVisible = !isFirstVisible">Change first area visibility</button>
+
+<kbq-splitter>
+    <div kbq-splitter-area *ngIf="isFirstVisible">first</div>
+    <div kbq-splitter-area class="flex">second</div>
+    <div kbq-splitter-area>third</div>
+</kbq-splitter>

--- a/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.ts
+++ b/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.ts
@@ -1,0 +1,15 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+
+
+/**
+ * @title Splitter with dynamic data
+ */
+@Component({
+    selector: 'splitter-dynamic-data-example',
+    templateUrl: 'splitter-dynamic-data-example.html',
+    styleUrls: ['splitter-dynamic-data-example.css'],
+    encapsulation: ViewEncapsulation.None
+})
+export class SplitterDynamicDataExample {
+    isFirstVisible = true;
+}

--- a/tools/public_api_guard/components/splitter.api.md
+++ b/tools/public_api_guard/components/splitter.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AfterViewInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
@@ -78,7 +79,7 @@ export class KbqGutterGhostDirective {
 }
 
 // @public (undocumented)
-export class KbqSplitterAreaDirective implements OnInit, OnDestroy {
+export class KbqSplitterAreaDirective implements AfterViewInit, OnDestroy {
     constructor(elementRef: ElementRef, renderer: Renderer2, splitter: KbqSplitterComponent);
     // (undocumented)
     disableFlex(): void;
@@ -91,9 +92,9 @@ export class KbqSplitterAreaDirective implements OnInit, OnDestroy {
     // (undocumented)
     isResizing(): boolean;
     // (undocumented)
-    ngOnDestroy(): void;
+    ngAfterViewInit(): void;
     // (undocumented)
-    ngOnInit(): void;
+    ngOnDestroy(): void;
     // (undocumented)
     setOrder(order: number): void;
     // (undocumented)
@@ -111,10 +112,12 @@ export class KbqSplitterComponent implements OnInit {
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, ngZone: NgZone, renderer: Renderer2);
     // (undocumented)
     addArea(area: KbqSplitterAreaDirective): void;
+    // (undocumented)
+    areaRefs: QueryList<KbqSplitterAreaDirective>;
     // Warning: (ae-forgotten-export) The symbol "IArea" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    readonly areas: IArea[];
+    areas: IArea[];
     // (undocumented)
     changeDetectorRef: ChangeDetectorRef;
     // (undocumented)
@@ -142,6 +145,10 @@ export class KbqSplitterComponent implements OnInit {
     // (undocumented)
     isVertical(): boolean;
     // (undocumented)
+    ngAfterContentInit(): void;
+    // (undocumented)
+    ngOnDestroy(): void;
+    // (undocumented)
     ngOnInit(): void;
     // (undocumented)
     onMouseDown(event: MouseEvent, leftAreaIndex: number, rightAreaIndex: number): void;
@@ -153,7 +160,7 @@ export class KbqSplitterComponent implements OnInit {
     get useGhost(): boolean;
     set useGhost(useGhost: boolean);
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSplitterComponent, "kbq-splitter", ["kbqSplitter"], { "hideGutters": { "alias": "hideGutters"; "required": false; }; "direction": { "alias": "direction"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "useGhost": { "alias": "useGhost"; "required": false; }; "gutterSize": { "alias": "gutterSize"; "required": false; }; }, { "gutterPositionChange": "gutterPositionChange"; }, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSplitterComponent, "kbq-splitter", ["kbqSplitter"], { "hideGutters": { "alias": "hideGutters"; "required": false; }; "direction": { "alias": "direction"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "useGhost": { "alias": "useGhost"; "required": false; }; "gutterSize": { "alias": "gutterSize"; "required": false; }; }, { "gutterPositionChange": "gutterPositionChange"; }, ["areaRefs"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqSplitterComponent, never>;
 }


### PR DESCRIPTION
## Summary

Updated splitter to work with dynamic data including `*ngIf`

## List of notable changes:

- **added** subscription to observe view areas update and update `areas` property.
- **updated** area addition from `ngOnInit` to `ngAfterViewInit` hook to save rendering order as in HTML

