### PR TITLE
feat(input): input password font -> mono (#DS-2502)

### DIFF
--- a/packages/components/input/_input-theme.scss
+++ b/packages/components/input/_input-theme.scss
@@ -11,4 +11,8 @@
     .kbq-input.kbq-input-password::placeholder {
         @include kbq-typography-level-to-styles($config, map.get($tokens, input-font-text));
     }
+
+    .kbq-input.kbq-input-password {
+        @include kbq-typography-level-to-styles($config, mono-normal);
+    }
 }


### PR DESCRIPTION
## Summary
Changed input password font when filled with text

![image](https://github.com/koobiq/angular-components/assets/42917304/703a359c-477e-45b0-b49c-b887d7b8ab3f)
