### PR TITLE
fix(code-block): "show all" position when expanded (#DS-2518)

### DIFF
--- a/packages/components/code-block/code-block.scss
+++ b/packages/components/code-block/code-block.scss
@@ -53,6 +53,15 @@ $border-width: var(
         border-radius: $border-radius $border-radius 0 0;
     }
 
+    &:has(.kbq-code-block__show-more) {
+        .kbq-code-block__code {
+            & > code {
+                padding-bottom: map.get($tokens, size-3xl) !important;
+                overflow-x: scroll;
+            }
+        }
+    }
+
     .kbq-code-block__code {
         > code {
             padding:


### PR DESCRIPTION
## Summary
Moved "Show all" button under content when expanded.

![chrome_s43nHRgIye](https://github.com/koobiq/angular-components/assets/42917304/dc3c0032-433b-42d2-b339-6a70bd96363f)
