### PR TITLE
feat(cdk): added truncate util

### DIFF
--- a/packages/cdk/utils/index.ts
+++ b/packages/cdk/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './truncate.directive';

--- a/packages/cdk/utils/ng-package.json
+++ b/packages/cdk/utils/ng-package.json
@@ -1,0 +1,5 @@
+{
+    "lib": {
+        "entryFile": "index.ts"
+    }
+}

--- a/packages/cdk/utils/truncate.directive.spec.ts
+++ b/packages/cdk/utils/truncate.directive.spec.ts
@@ -1,0 +1,57 @@
+import { Component, DebugElement, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { KbqTruncateDirective } from './truncate.directive';
+
+describe('TruncateDirective', () => {
+    let component: TestComponent;
+    let fixture: ComponentFixture<TestComponent>;
+    let truncate: DebugElement[];
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestComponent],
+            imports: [KbqTruncateDirective]
+        });
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+        component.truncateLength = 100;
+
+        fixture.detectChanges();
+
+        truncate = fixture.debugElement.queryAll(By.directive(KbqTruncateDirective));
+    });
+
+    it('should create an instance', () => {
+        expect(truncate).toBeTruthy();
+    });
+
+    it('Should truncate when isTruncate is true', () => {
+        expect(truncate[0].nativeElement.style.maxWidth).toBe(`${component.truncateLength}px`);
+        expect(truncate[2].nativeElement.style.maxWidth).toBe(`250px`);
+    });
+
+    it('Should not truncate when isTruncate is false', () => {
+        expect(truncate[1].nativeElement.style.maxWidth).toBe('');
+    });
+
+    it("Should preserve element's default style", () => {
+        expect(truncate[2].nativeElement.style.color).toEqual('red');
+    });
+});
+
+@Component({
+    template: `
+        <span kbqTruncate [isTruncate]="true" [truncateLength]="truncateLength">This element should by truncated</span>
+        <span kbqTruncate [isTruncate]="false" [truncateLength]="truncateLength">
+            This element should not be truncated
+        </span>
+        <span [style.color]="'red'" kbqTruncate [isTruncate]="true">
+            This element should by truncated and apply color Red
+        </span>
+    `
+})
+class TestComponent {
+    @Input() truncateLength: number;
+}

--- a/packages/cdk/utils/truncate.directive.ts
+++ b/packages/cdk/utils/truncate.directive.ts
@@ -1,0 +1,81 @@
+import { coerceNumberProperty } from '@angular/cdk/coercion';
+import {
+    AfterViewInit,
+    booleanAttribute,
+    Directive,
+    ElementRef,
+    inject,
+    Input,
+    OnChanges,
+    Renderer2
+} from '@angular/core';
+
+/**
+ * Directive to truncate the text within an element to a specified width.
+ * The text will be truncated with ellipsis (...) if it exceeds the specified width.
+ */
+@Directive({
+    selector: '[kbqTruncate]',
+    standalone: true
+})
+export class KbqTruncateDirective implements OnChanges, AfterViewInit {
+    private readonly elementRef = inject(ElementRef);
+    private readonly renderer = inject(Renderer2);
+
+    /**
+     * Boolean attribute to enable or disable truncation.
+     */
+    @Input({ transform: booleanAttribute }) isTruncate = false;
+
+    /**
+     * The maximum width for truncation in pixels.
+     * This property is coerced to a number.
+     */
+    @Input({ transform: coerceNumberProperty })
+    set truncateLength(value: number) {
+        this._truncateLength = value;
+    }
+
+    private _truncateLength = 250;
+
+    private truncateElement: HTMLElement | null = null;
+    private truncationCSSStyle: string;
+    private originalCSS: string;
+    private takeDefaultCSSStyleOnce = true;
+
+    ngAfterViewInit(): void {
+        this.initializeElement();
+        this.truncate();
+    }
+
+    ngOnChanges(): void {
+        this.truncate();
+    }
+
+    /**
+     * Initializes the element and captures its original CSS style.
+     * This is done only once to ensure we can revert back to the original style if truncation is disabled.
+     */
+    private initializeElement(): void {
+        this.truncateElement = this.elementRef.nativeElement;
+        if (this.truncateElement && this.takeDefaultCSSStyleOnce) {
+            this.originalCSS = this.truncateElement.style.cssText;
+            this.takeDefaultCSSStyleOnce = false;
+        }
+    }
+
+    /**
+     * Applies the truncation CSS style to the element if truncation is enabled.
+     * Reverts to the original CSS style if truncation is disabled.
+     */
+    private truncate(): void {
+        if (!this.truncateElement) {
+            return;
+        }
+
+        this.truncationCSSStyle = `${this.originalCSS} max-width: ${this._truncateLength}px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;`;
+        const cssText = this.isTruncate ? this.truncationCSSStyle : this.originalCSS;
+
+        this.renderer.setAttribute(this.truncateElement, 'style', cssText);
+    }
+}


### PR DESCRIPTION
**Overview**

`KbqTruncateDirective`, which provides a convenient way to truncate text within an element to a specified width. The directive ensures that text exceeding the defined width will be truncated and displayed with an ellipsis (...).

**Purpose**

The primary purpose of adding this directive is to improve the user interface by preventing overflow of text content in specific UI elements. This is particularly useful in scenarios where the available space is limited, such as in list items, cards, or any other components with constrained dimensions. The directive allows developers to easily manage text overflow and maintain a clean, readable layout.

**Features**

**Configurable Truncate Width**: Allows setting a maximum width for the text container. Any text exceeding this width will be truncated.
**Boolean Control for Truncation**: Provides a boolean input to enable or disable truncation dynamically.
**Automatic Style Management**: Captures and reverts to the original CSS styles of the element when truncation is disabled.


```html
<div kbqTruncate [truncateLength]="200" [isTruncate]="true">
  This is some very long text that will be truncated if it exceeds the specified width.
</div>
```