### PR TITLE
fix(toast): improved toastService timer performance (#DS-2521)

### DIFF
--- a/packages/components/toast/toast.service.ts
+++ b/packages/components/toast/toast.service.ts
@@ -55,6 +55,12 @@ export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> im
     readonly focused = new BehaviorSubject<boolean>(false);
     readonly animation = new BehaviorSubject<AnimationEvent | null>(null);
 
+    timer = timer(CHECK_INTERVAL, CHECK_INTERVAL)
+        .pipe(
+            filter(() => this.toasts.length > 0 && !this.hovered.getValue() && !this.focused.getValue()),
+            shareReplay()
+        );
+
     private containerInstance: KbqToastContainerComponent;
     private overlayRef: OverlayRef;
     private portal: ComponentPortal<KbqToastContainerComponent>;
@@ -62,12 +68,6 @@ export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> im
 
     private toastsDict: { [id: number]: ComponentRef<T> } = {};
     private templatesDict: { [id: number]: EmbeddedViewRef<T> } = {};
-
-    timer = timer(CHECK_INTERVAL, CHECK_INTERVAL)
-        .pipe(
-            filter(() => this.toasts.length > 0 && !this.hovered.getValue() && !this.focused.getValue()),
-            shareReplay()
-        );
 
     constructor(
         private overlay: Overlay,

--- a/tools/public_api_guard/components/toast.api.md
+++ b/tools/public_api_guard/components/toast.api.md
@@ -180,7 +180,7 @@ export enum KbqToastPosition {
 
 // @public (undocumented)
 export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> {
-    constructor(overlay: Overlay, injector: Injector, overlayContainer: OverlayContainer, toastFactory: any, toastConfig: KbqToastConfig);
+    constructor(overlay: Overlay, injector: Injector, overlayContainer: OverlayContainer, ngZone: NgZone, toastFactory: any, toastConfig: KbqToastConfig);
     // (undocumented)
     readonly animation: BehaviorSubject<AnimationEvent_2 | null>;
     // (undocumented)
@@ -206,7 +206,7 @@ export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> {
     // (undocumented)
     get toasts(): ComponentRef<T>[];
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqToastService<any>, [null, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqToastService<any>, [null, null, null, null, null, { optional: true; }]>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<KbqToastService<any>>;
 }

--- a/tools/public_api_guard/components/toast.api.md
+++ b/tools/public_api_guard/components/toast.api.md
@@ -21,6 +21,7 @@ import * as i7 from '@koobiq/components/button';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { NgZone } from '@angular/core';
+import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { Overlay } from '@angular/cdk/overlay';
 import { OverlayContainer } from '@angular/cdk/overlay';
@@ -203,6 +204,8 @@ export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> {
     };
     // (undocumented)
     get templates(): EmbeddedViewRef<T>[];
+    // (undocumented)
+    timer: Observable<number>;
     // (undocumented)
     get toasts(): ComponentRef<T>[];
     // (undocumented)

--- a/tools/public_api_guard/components/toast.api.md
+++ b/tools/public_api_guard/components/toast.api.md
@@ -180,7 +180,7 @@ export enum KbqToastPosition {
 }
 
 // @public (undocumented)
-export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> {
+export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> implements OnDestroy {
     constructor(overlay: Overlay, injector: Injector, overlayContainer: OverlayContainer, ngZone: NgZone, toastFactory: any, toastConfig: KbqToastConfig);
     // (undocumented)
     readonly animation: BehaviorSubject<AnimationEvent_2 | null>;
@@ -192,6 +192,8 @@ export class KbqToastService<T extends KbqToastComponent = KbqToastComponent> {
     hideTemplate(id: number): void;
     // (undocumented)
     readonly hovered: BehaviorSubject<boolean>;
+    // (undocumented)
+    ngOnDestroy(): void;
     // (undocumented)
     show(data: KbqToastData, duration?: number, onTop?: boolean): {
         ref: ComponentRef<T>;


### PR DESCRIPTION
When running with change detection default, the whole app is triggering every 500ms.

### Performance screenshot before applying changes
[Trace-20240624T103127.json](https://github.com/user-attachments/files/15951422/Trace-20240624T103127.json)
![image](https://github.com/koobiq/angular-components/assets/42917304/994d54da-ef11-401a-b7ec-91d66c3eeaef)

On the blue background there are actions in the test app. Some getters were added to the template represent activity.

Every 500ms timer is called (`setTimeout` initially). So, timer call will trigger lots of actions via Change Detection.

https://stackblitz.com/edit/hoxups?file=src%2Fapp%2Ftoast-types-overview-example.ts,src%2Fapp%2Ftoast-types-overview-example.html


So decided to run timer outside angular and run hide Toast inside angular.

### Performance screenshot after applying changes

[Trace-20240624T103726.json](https://github.com/user-attachments/files/15951430/Trace-20240624T103726.json)

![image](https://github.com/koobiq/angular-components/assets/42917304/97b96bdf-dc74-40e3-84a9-d981e78c7088)

On ther screen every 500ms timer is called is it was previously. But timer call now is not triggering any action if not needed. [Check for possible actions](https://koobiq.io/components/toast/overview#%D0%B8%D1%81%D1%87%D0%B5%D0%B7%D0%BD%D0%BE%D0%B2%D0%B5%D0%BD%D0%B8%D0%B5)


- [x] TC