### PR TITLE
feat(tag-input,autocomplete): disable tag creation by the paste event (#DS-2455)

### DIFF
--- a/apps/docs/src/app/components/documentation-items.ts
+++ b/apps/docs/src/app/components/documentation-items.ts
@@ -414,7 +414,7 @@ const DOCS: { [key: string]: DocCategory[] } = {
                     svgPreview: 'tags autocomplete',
                     hasApi: true,
                     apiId: 'tag',
-                    hasExamples: false,
+                    hasExamples: true,
                     examples: ['tag-autocomplete-types']
                 },
                 {
@@ -423,7 +423,7 @@ const DOCS: { [key: string]: DocCategory[] } = {
                     svgPreview: 'tags input',
                     hasApi: true,
                     apiId: 'tag',
-                    hasExamples: false,
+                    hasExamples: true,
                     examples: ['tag-input-types']
                 },
                 {

--- a/packages/components-dev/tag/module.ts
+++ b/packages/components-dev/tag/module.ts
@@ -15,7 +15,15 @@ import { KbqAutocomplete, KbqAutocompleteModule, KbqAutocompleteSelectedEvent } 
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
 import { KbqIconModule } from '@koobiq/components/icon';
-import { KbqTagList, KbqTagsModule, KbqTagInputEvent, KbqTag, KbqTagInput } from '@koobiq/components/tags';
+import {
+    KbqTagList,
+    KbqTagsModule,
+    KbqTagInputEvent,
+    KbqTag,
+    KbqTagInput,
+    KBQ_TAGS_DEFAULT_OPTIONS,
+    KbqTagsDefaultOptions
+} from '@koobiq/components/tags';
 import { KbqTitleModule } from '@koobiq/components/title';
 import { merge, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -212,9 +220,66 @@ export class DemoComponent implements AfterViewInit {
     }
 }
 
+@Component({
+    selector: 'tag-input-default-options-override',
+    template: `
+        <h4 class="kbq-title">Tags with input</h4>
+        <kbq-form-field>
+            <kbq-tag-list #inputTagList>
+                <kbq-tag *ngFor="let tag of inputTags" [value]="tag" (removed)="inputOnRemoveTag(tag)">
+                    {{ tag }}
+                    <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
+                </kbq-tag>
 
+                <input placeholder="New tag..."
+                       kbqInput
+                       #inputTagInput
+                       [formControl]="tagCtrl"
+                       [kbqTagInputFor]="inputTagList"
+                       [kbqTagInputSeparatorKeyCodes]="separatorKeysCodes"
+                       [distinct]="true"
+                       (kbqTagInputTokenEnd)="inputOnCreate($event)">
+
+                <kbq-cleaner #kbqTagListCleaner (click)="onClear()"></kbq-cleaner>
+            </kbq-tag-list>
+        </kbq-form-field>
+
+        <h4 class="kbq-title">Tags with autocomplete</h4>
+        <kbq-form-field>
+            <kbq-tag-list #autocompleteTagList>
+                <kbq-tag *ngFor="let tag of autocompleteSelectedTags" [value]="tag" (removed)="autocompleteOnRemove(tag)">
+                    {{ tag }}
+                    <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
+                </kbq-tag>
+                <input placeholder="New Tag..."
+                       #autocompleteTagInput
+                       [formControl]="tagCtrl"
+                       [kbqAutocomplete]="autocomplete"
+                       [kbqTagInputAddOnBlur]="false"
+                       [kbqTagInputFor]="autocompleteTagList"
+                       (kbqTagInputTokenEnd)="autocompleteOnCreate($event)"
+                       [distinct]="true"
+                       (blur)="addOnBlurFunc($event)">
+            </kbq-tag-list>
+            <kbq-autocomplete #autocomplete (optionSelected)="autocompleteOnSelect($event)">
+                <kbq-option *ngIf="canCreate" [value]="{ new: true, value: autocompleteTagInput.value }">
+                    Создать: {{ autocompleteTagInput.value }}
+                </kbq-option>
+                <kbq-option *ngIf="hasDuplicates" [disabled]="true">Ничего не найдено</kbq-option>
+                <kbq-option *ngFor="let tag of autocompleteFilteredTags | async" [value]="tag">{{ tag }}</kbq-option>
+            </kbq-autocomplete>
+        </kbq-form-field>
+    `,
+    providers: [{
+        provide: KBQ_TAGS_DEFAULT_OPTIONS,
+        // tslint:disable-next-line: no-object-literal-type-assertion
+        useValue: { separatorKeyCodes: [ENTER], addOnPaste: false } as KbqTagsDefaultOptions
+    }]
+})
+
+export class TagInputDefaultOptionsOverrideComponent extends DemoComponent {}
 @NgModule({
-    declarations: [DemoComponent],
+    declarations: [DemoComponent, TagInputDefaultOptionsOverrideComponent],
     imports: [
         BrowserAnimationsModule,
         BrowserModule,

--- a/packages/components-dev/tag/module.ts
+++ b/packages/components-dev/tag/module.ts
@@ -222,54 +222,7 @@ export class DemoComponent implements AfterViewInit {
 
 @Component({
     selector: 'tag-input-default-options-override',
-    template: `
-        <h4 class="kbq-title">Tags with input</h4>
-        <kbq-form-field>
-            <kbq-tag-list #inputTagList>
-                <kbq-tag *ngFor="let tag of inputTags" [value]="tag" (removed)="inputOnRemoveTag(tag)">
-                    {{ tag }}
-                    <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
-                </kbq-tag>
-
-                <input placeholder="New tag..."
-                       kbqInput
-                       #inputTagInput
-                       [formControl]="tagCtrl"
-                       [kbqTagInputFor]="inputTagList"
-                       [kbqTagInputSeparatorKeyCodes]="separatorKeysCodes"
-                       [distinct]="true"
-                       (kbqTagInputTokenEnd)="inputOnCreate($event)">
-
-                <kbq-cleaner #kbqTagListCleaner (click)="onClear()"></kbq-cleaner>
-            </kbq-tag-list>
-        </kbq-form-field>
-
-        <h4 class="kbq-title">Tags with autocomplete</h4>
-        <kbq-form-field>
-            <kbq-tag-list #autocompleteTagList>
-                <kbq-tag *ngFor="let tag of autocompleteSelectedTags" [value]="tag" (removed)="autocompleteOnRemove(tag)">
-                    {{ tag }}
-                    <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
-                </kbq-tag>
-                <input placeholder="New Tag..."
-                       #autocompleteTagInput
-                       [formControl]="tagCtrl"
-                       [kbqAutocomplete]="autocomplete"
-                       [kbqTagInputAddOnBlur]="false"
-                       [kbqTagInputFor]="autocompleteTagList"
-                       (kbqTagInputTokenEnd)="autocompleteOnCreate($event)"
-                       [distinct]="true"
-                       (blur)="addOnBlurFunc($event)">
-            </kbq-tag-list>
-            <kbq-autocomplete #autocomplete (optionSelected)="autocompleteOnSelect($event)">
-                <kbq-option *ngIf="canCreate" [value]="{ new: true, value: autocompleteTagInput.value }">
-                    Создать: {{ autocompleteTagInput.value }}
-                </kbq-option>
-                <kbq-option *ngIf="hasDuplicates" [disabled]="true">Ничего не найдено</kbq-option>
-                <kbq-option *ngFor="let tag of autocompleteFilteredTags | async" [value]="tag">{{ tag }}</kbq-option>
-            </kbq-autocomplete>
-        </kbq-form-field>
-    `,
+    templateUrl: './tag-input-default-options-override.template.html',
     providers: [{
         provide: KBQ_TAGS_DEFAULT_OPTIONS,
         // tslint:disable-next-line: no-object-literal-type-assertion
@@ -278,6 +231,7 @@ export class DemoComponent implements AfterViewInit {
 })
 
 export class TagInputDefaultOptionsOverrideComponent extends DemoComponent {}
+
 @NgModule({
     declarations: [DemoComponent, TagInputDefaultOptionsOverrideComponent],
     imports: [

--- a/packages/components-dev/tag/styles.scss
+++ b/packages/components-dev/tag/styles.scss
@@ -9,3 +9,11 @@
     display: flex;
     gap: 8px
 }
+
+.dev-container {
+    width: 500px;
+
+    border: 1px solid red;
+
+    padding: 24px;
+}

--- a/packages/components-dev/tag/tag-input-default-options-override.template.html
+++ b/packages/components-dev/tag/tag-input-default-options-override.template.html
@@ -1,0 +1,44 @@
+<h4 class="kbq-title">Tags with input</h4>
+<kbq-form-field>
+    <kbq-tag-list #inputTagList>
+        <kbq-tag *ngFor="let tag of inputTags" [value]="tag" (removed)="inputOnRemoveTag(tag)">
+            {{ tag }}
+            <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
+        </kbq-tag>
+
+        <input placeholder="New tag..."
+               kbqInput
+               [formControl]="tagCtrl"
+               [kbqTagInputFor]="inputTagList"
+               [kbqTagInputSeparatorKeyCodes]="separatorKeysCodes"
+               [distinct]="true"
+               (kbqTagInputTokenEnd)="inputOnCreate($event)">
+        <kbq-cleaner (click)="onClear()"></kbq-cleaner>
+    </kbq-tag-list>
+</kbq-form-field>
+
+<h4 class="kbq-title">Tags with autocomplete</h4>
+<kbq-form-field>
+    <kbq-tag-list #autocompleteTagList>
+        <kbq-tag *ngFor="let tag of autocompleteSelectedTags" [value]="tag" (removed)="autocompleteOnRemove(tag)">
+            {{ tag }}
+            <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
+        </kbq-tag>
+        <input placeholder="New Tag..."
+               #autocompleteTagInput
+               [formControl]="tagCtrl"
+               [kbqAutocomplete]="autocomplete"
+               [kbqTagInputAddOnBlur]="false"
+               [kbqTagInputFor]="autocompleteTagList"
+               (kbqTagInputTokenEnd)="autocompleteOnCreate($event)"
+               [distinct]="true"
+               (blur)="addOnBlurFunc($event)">
+    </kbq-tag-list>
+    <kbq-autocomplete #autocomplete (optionSelected)="autocompleteOnSelect($event)">
+        <kbq-option *ngIf="canCreate" [value]="{ new: true, value: autocompleteTagInput.value }">
+            Создать: {{ autocompleteTagInput.value }}
+        </kbq-option>
+        <kbq-option *ngIf="hasDuplicates" [disabled]="true">Ничего не найдено</kbq-option>
+        <kbq-option *ngFor="let tag of autocompleteFilteredTags | async" [value]="tag">{{ tag }}</kbq-option>
+    </kbq-autocomplete>
+</kbq-form-field>

--- a/packages/components-dev/tag/template.html
+++ b/packages/components-dev/tag/template.html
@@ -1,4 +1,10 @@
 <div class="example-container">
+    <div class="dev-container">
+        <h1 class="kbq-headline">Tag-inputs without add tags on Paste</h1>
+        <h2 class="kbq-subheading">Provided with InjectionToken param addOnPaste=false</h2>
+        <tag-input-default-options-override></tag-input-default-options-override>
+    </div>
+
     <br><br><br>
 
     <h4 class="kbq-title">Tag list</h4>

--- a/packages/components/tags/examples.tag-autocomplete.md
+++ b/packages/components/tags/examples.tag-autocomplete.md
@@ -1,0 +1,3 @@
+Отключено создания тега по событию paste
+
+<!-- example(tags-autocomplete-onpaste-off) -->

--- a/packages/components/tags/examples.tag-input.md
+++ b/packages/components/tags/examples.tag-input.md
@@ -1,0 +1,4 @@
+Отключено создания тега по событию paste
+
+<!-- example(tags-input-onpaste-off) -->
+

--- a/packages/components/tags/tag-default-options.ts
+++ b/packages/components/tags/tag-default-options.ts
@@ -9,6 +9,7 @@ export interface KbqTagsDefaultOptions {
     /** The list of key codes that will trigger a chipEnd event. */
     separatorKeyCodes: number[];
     separators?: { [key: number]: KbqTagSeparator };
+    addOnPaste?: boolean;
 }
 
 /** Injection token to be used to override the default options for the chips module. */

--- a/packages/components/tags/tag-input.spec.ts
+++ b/packages/components/tags/tag-input.spec.ts
@@ -126,6 +126,39 @@ describe('KbqTagInput', () => {
         });
     });
 
+    describe('[addOnPaste]', () => {
+        const clipboardEventData = {
+            clipboardData: {
+                getData: (_) => 'test test test'
+            },
+            preventDefault: () => {},
+            stopPropagation: () => {}
+        };
+
+        it('allows (tagEnd) when true', () => {
+            spyOn(testTagInput, 'add');
+
+            testTagInput.addOnPaste = true;
+            fixture.detectChanges();
+
+            // tslint:disable-next-line:no-object-literal-type-assertion
+            tagInputDirective.onPaste(clipboardEventData as ClipboardEvent);
+            expect(testTagInput.add).toHaveBeenCalled();
+        });
+
+        it('disallows (tagEnd) when false', () => {
+            spyOn(testTagInput, 'add');
+
+            testTagInput.addOnPaste = false;
+            fixture.detectChanges();
+
+
+            // tslint:disable-next-line:no-object-literal-type-assertion
+            tagInputDirective.onPaste(clipboardEventData as ClipboardEvent);
+            expect(testTagInput.add).not.toHaveBeenCalled();
+        });
+    });
+
     describe('[separatorKeyCodes]', () => {
         it('does not emit (tagEnd) when a non-separator key is pressed', () => {
             const ENTER_EVENT = createKeyboardEvent('keydown', ENTER, inputNativeElement);
@@ -224,6 +257,7 @@ describe('KbqTagInput', () => {
             <kbq-tag-list #tagList></kbq-tag-list>
             <input [kbqTagInputFor]="tagList"
                    [kbqTagInputAddOnBlur]="addOnBlur"
+                   [kbqTagInputAddOnPaste]="addOnPaste"
                    (kbqTagInputTokenEnd)="add($event)"
                    [placeholder]="placeholder"/>
         </kbq-form-field>
@@ -233,6 +267,7 @@ class TestTagInput {
     @ViewChild(KbqTagList, {static: false}) tagListInstance: KbqTagList;
 
     addOnBlur: boolean = false;
+    addOnPaste: boolean = false;
     placeholder = '';
 
     add(_: KbqTagInputEvent) {}

--- a/packages/components/tags/tag-input.ts
+++ b/packages/components/tags/tag-input.ts
@@ -19,6 +19,7 @@ import { KBQ_TAGS_DEFAULT_OPTIONS, KbqTagsDefaultOptions } from './tag-default-o
 import { KbqTagList } from './tag-list.component';
 import { KbqTagTextControl } from './tag-text-control';
 import { KbqAutocompleteTrigger } from '@koobiq/components/autocomplete';
+import { isBoolean } from '@koobiq/components/core';
 
 
 const KbqTagInputDefaultSeparators: { [key: number]: KbqTagSeparator } = {
@@ -136,6 +137,20 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
 
     private _addOnBlur: boolean = true;
 
+    /**
+     * Whether the tagEnd event will be emitted when the text pasted.
+     */
+    @Input('kbqTagInputAddOnPaste')
+    get addOnPaste(): boolean {
+        return this._addOnPaste;
+    }
+
+    set addOnPaste(value: boolean) {
+        this._addOnPaste = coerceBooleanProperty(value);
+    }
+
+    private _addOnPaste: boolean;
+
     /** Whether the input is disabled. */
     @Input()
     get disabled(): boolean {
@@ -174,6 +189,7 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
         this.setDefaultInputWidth();
 
         this._separators = this.defaultOptions.separators || KbqTagInputDefaultSeparators;
+        this._addOnPaste = isBoolean(this.defaultOptions.addOnPaste) ? this.defaultOptions.addOnPaste : true;
     }
 
     ngOnChanges() {
@@ -242,7 +258,7 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
 
         const data = $event.clipboardData.getData('text');
 
-        if (data && data.length === 0) { return; }
+        if (data && data.length === 0 || !this.addOnPaste) { return; }
 
         const items: string[] = [];
 

--- a/packages/docs-examples/components/tag/index.ts
+++ b/packages/docs-examples/components/tag/index.ts
@@ -15,6 +15,8 @@ import { TagHugContentExample } from './tag-hug-content/tag-hug-content-example'
 import { TagInputExample } from './tag-input/tag-input-example';
 import { TagListExample } from './tag-list/tag-list-example';
 import { TagOverviewExample } from './tag-overview/tag-overview-example';
+import { TagsAutocompleteOnpasteOffExample } from './tags-autocomplete-onpaste-off/tags-autocomplete-onpaste-off-example';
+import { TagsInputOnpasteOffExample } from './tags-input-onpaste-off/tags-input-onpaste-off-example';
 
 
 export {
@@ -25,7 +27,9 @@ export {
     TagInputExample,
     TagListExample,
     TagAutocompleteExample,
-    TagAutocompleteOptionOperationsExample
+    TagAutocompleteOptionOperationsExample,
+    TagsInputOnpasteOffExample,
+    TagsAutocompleteOnpasteOffExample
 };
 
 const EXAMPLES = [
@@ -36,7 +40,9 @@ const EXAMPLES = [
     TagInputExample,
     TagListExample,
     TagAutocompleteExample,
-    TagAutocompleteOptionOperationsExample
+    TagAutocompleteOptionOperationsExample,
+    TagsInputOnpasteOffExample,
+    TagsAutocompleteOnpasteOffExample
 ];
 
 @NgModule({

--- a/packages/docs-examples/components/tag/tags-autocomplete-onpaste-off/tags-autocomplete-onpaste-off-example.css
+++ b/packages/docs-examples/components/tag/tags-autocomplete-onpaste-off/tags-autocomplete-onpaste-off-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/packages/docs-examples/components/tag/tags-autocomplete-onpaste-off/tags-autocomplete-onpaste-off-example.html
+++ b/packages/docs-examples/components/tag/tags-autocomplete-onpaste-off/tags-autocomplete-onpaste-off-example.html
@@ -1,0 +1,27 @@
+<kbq-form-field>
+    <kbq-tag-list #tagList>
+        <kbq-tag *ngFor="let tag of selectedTags" [value]="tag" (removed)="onRemove(tag)">
+            {{ tag }}
+            <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
+        </kbq-tag>
+
+        <!-- turn off tag add on paste with Input property -->
+        <input placeholder="New tag..."
+               #tagInput
+               [formControl]="control"
+               [kbqAutocomplete]="autocomplete"
+               [kbqTagInputFor]="tagList"
+               (kbqTagInputTokenEnd)="onCreate($event)"
+               [kbqTagInputAddOnBlur]="false"
+               [kbqTagInputAddOnPaste]="false"
+               [distinct]="true"
+               (blur)="addOnBlurFunc($event)">
+    </kbq-tag-list>
+    <kbq-autocomplete #autocomplete (optionSelected)="onSelect($event)">
+        <kbq-option *ngIf="canCreate" [value]="{ new: true, value: tagInput.value }">
+            Создать: {{ tagInput.value }}
+        </kbq-option>
+        <kbq-option *ngIf="hasDuplicates" [disabled]="true">Ничего не найдено</kbq-option>
+        <kbq-option *ngFor="let tag of filteredTags | async" [value]="tag">{{ tag }}</kbq-option>
+    </kbq-autocomplete>
+</kbq-form-field>

--- a/packages/docs-examples/components/tag/tags-autocomplete-onpaste-off/tags-autocomplete-onpaste-off-example.ts
+++ b/packages/docs-examples/components/tag/tags-autocomplete-onpaste-off/tags-autocomplete-onpaste-off-example.ts
@@ -1,0 +1,145 @@
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { ENTER } from '@koobiq/cdk/keycodes';
+import { KbqAutocomplete, KbqAutocompleteSelectedEvent } from '@koobiq/components/autocomplete';
+import {
+    KBQ_TAGS_DEFAULT_OPTIONS,
+    KbqTag,
+    KbqTagInput,
+    KbqTagInputEvent,
+    KbqTagList,
+    KbqTagsDefaultOptions
+} from '@koobiq/components/tags';
+import { merge } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+
+/**
+ * @title Tags Autocomplete Onpaste Off
+ */
+@Component({
+    selector: 'tags-autocomplete-onpaste-off-example',
+    templateUrl: 'tags-autocomplete-onpaste-off-example.html',
+    styleUrls: ['tags-autocomplete-onpaste-off-example.css'],
+    // turn off tag add on paste with InjectionToken
+    providers: [{
+        provide: KBQ_TAGS_DEFAULT_OPTIONS,
+        // tslint:disable-next-line: no-object-literal-type-assertion
+        useValue: { separatorKeyCodes: [ENTER], addOnPaste: false } as KbqTagsDefaultOptions
+    }]
+})
+export class TagsAutocompleteOnpasteOffExample {
+    @ViewChild('tagList', { static: false }) tagList: KbqTagList;
+    @ViewChild('tagInput', { static: false }) tagInput: ElementRef<HTMLInputElement>;
+    @ViewChild('tagInput', {read: KbqTagInput, static: false}) tagInputDirective: KbqTagInput;
+    @ViewChild('autocomplete', { static: false }) autocomplete: KbqAutocomplete;
+
+    control = new FormControl();
+
+    allTags: string[] = ['tag1', 'tag2', 'tag3', 'tag4', 'tag5', 'tag6', 'tag7', 'tag8', 'tag9', 'tag10'];
+    filteredTagsByInput: string[] = [];
+    selectedTags: string[] = ['tag1'];
+
+    filteredTags: any;
+    hasDuplicates: boolean;
+
+    get canCreate(): boolean {
+        const cleanedValue: string = (this.control.value || '').trim();
+
+        return !!cleanedValue && [...new Set(this.allTags.concat(this.selectedTags))]
+            .every((tag) => tag !== cleanedValue);
+    }
+
+    ngAfterViewInit(): void {
+        this.filteredTags = merge(
+            this.tagList.tagChanges.asObservable()
+                .pipe(map((selectedTags: KbqTag[]) => {
+                    const values = selectedTags.map((tag: any) => tag.value);
+
+                    return this.allTags.filter((tag) => !values.includes(tag));
+                })),
+            this.control.valueChanges
+                .pipe(map((value: any) => {
+                    const typedText = ((value?.new) ? value.value : value)?.trim();
+
+                    this.filteredTagsByInput = typedText ?
+                        this.filter(typedText) : this.allTags.slice();
+
+                    const inputAndSelectionTagsDiff = this.filteredTagsByInput
+                        .filter((tag) => !this.selectedTags.includes(tag));
+
+                    // check for scenario where duplicate exists but also can create/select other tags
+                    this.hasDuplicates = !inputAndSelectionTagsDiff.length && this.tagInputDirective.hasDuplicates;
+
+                    return inputAndSelectionTagsDiff;
+                }))
+        );
+    }
+
+    addOnBlurFunc(event: FocusEvent) {
+        const target: HTMLElement = event.relatedTarget as HTMLElement;
+
+        if (!target || target.tagName !== 'KBQ-OPTION') {
+            const mcTagEvent: KbqTagInputEvent = {
+                input: this.tagInput.nativeElement,
+                value : this.tagInput.nativeElement.value
+            };
+
+            this.onCreate(mcTagEvent);
+        }
+    }
+
+    onCreate({ input, value }: KbqTagInputEvent): void {
+        this.control.setValue(value);
+        const cleanedValue = (value || '').trim();
+
+        if (cleanedValue) {
+            const isOptionSelected = this.autocomplete.options.some((option) => option.selected);
+            if (!isOptionSelected && this.canCreate) {
+                this.selectedTags.push(cleanedValue);
+
+                // Reset the input value
+                if (input) {
+                    input.value = '';
+                }
+
+                this.control.setValue(null);
+
+                return;
+            }
+        }
+
+        // save input value on paste event to continue editing
+        if (!this.canCreate) {
+            input.value = cleanedValue;
+            this.control.setValue(cleanedValue);
+        }
+    }
+
+    onSelect({ option }: KbqAutocompleteSelectedEvent): void {
+        option.deselect();
+
+        if (option.value.new) {
+            this.selectedTags.push(option.value.value);
+        } else {
+            this.selectedTags.push(option.value);
+        }
+        this.tagInput.nativeElement.value = '';
+        this.control.setValue(null);
+    }
+
+    onRemove(fruit: any): void {
+        const index = this.selectedTags.indexOf(fruit);
+
+        if (index >= 0) {
+            this.selectedTags.splice(index, 1);
+        }
+    }
+
+    private filter(value: string): string[] {
+        const filterValue = value.toLowerCase();
+
+        return [...new Set(this.allTags.concat(this.selectedTags))]
+            .filter((tag) => tag.toLowerCase().indexOf(filterValue) === 0);
+    }
+}

--- a/packages/docs-examples/components/tag/tags-input-onpaste-off/tags-input-onpaste-off-example.css
+++ b/packages/docs-examples/components/tag/tags-input-onpaste-off/tags-input-onpaste-off-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/packages/docs-examples/components/tag/tags-input-onpaste-off/tags-input-onpaste-off-example.html
+++ b/packages/docs-examples/components/tag/tags-input-onpaste-off/tags-input-onpaste-off-example.html
@@ -1,0 +1,17 @@
+<kbq-form-field>
+    <kbq-tag-list #tagList>
+        <kbq-tag *ngFor="let tag of tags" [value]="tag" (removed)="onRemoveTag(tag)">
+            {{ tag }}
+            <i kbq-icon="mc-close-S_16" kbqTagRemove></i>
+        </kbq-tag>
+
+        <!-- turn off tag add on paste with Input property -->
+        <input placeholder="New tag..."
+               [formControl]="control"
+               [kbqTagInputFor]="tagList"
+               [kbqTagInputAddOnPaste]="false"
+               [kbqTagInputSeparatorKeyCodes]="separatorKeysCodes"
+               (kbqTagInputTokenEnd)="onCreate($event)" >
+        <kbq-cleaner (click)="onClear()"></kbq-cleaner>
+    </kbq-tag-list>
+</kbq-form-field>

--- a/packages/docs-examples/components/tag/tags-input-onpaste-off/tags-input-onpaste-off-example.ts
+++ b/packages/docs-examples/components/tag/tags-input-onpaste-off/tags-input-onpaste-off-example.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { COMMA, ENTER } from '@koobiq/cdk/keycodes';
+import { KBQ_TAGS_DEFAULT_OPTIONS, KbqTagInputEvent, KbqTagsDefaultOptions } from '@koobiq/components/tags';
+
+
+/**
+ * @title Tags Input Onpaste Off
+ */
+@Component({
+    selector: 'tags-input-onpaste-off-example',
+    templateUrl: 'tags-input-onpaste-off-example.html',
+    styleUrls: ['tags-input-onpaste-off-example.css'],
+    // turn off tag add on paste with InjectionToken
+    providers: [{
+        provide: KBQ_TAGS_DEFAULT_OPTIONS,
+        // tslint:disable-next-line: no-object-literal-type-assertion
+        useValue: { separatorKeyCodes: [ENTER], addOnPaste: false } as KbqTagsDefaultOptions
+    }]
+})
+export class TagsInputOnpasteOffExample {
+    control = new FormControl();
+
+    tags = ['tag', 'tag1', 'tag2', 'tag3', 'tag4'];
+
+    readonly separatorKeysCodes: number[] = [ENTER, COMMA];
+
+    onCreate(event: KbqTagInputEvent): void {
+        const input = event.input;
+        const value = event.value;
+
+        if ((value || '').trim()) {
+            this.tags.push(value.trim());
+        }
+
+        if (input) {
+            input.value = '';
+        }
+    }
+
+    onRemoveTag(tag: string): void {
+        const index = this.tags.indexOf(tag);
+
+        if (index >= 0) {
+            this.tags.splice(index, 1);
+        }
+    }
+
+    onClear(): void {
+        this.tags.length = 0;
+    }
+}

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -2976,6 +2976,42 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
       "importPath": "koobiq-docs-examples-components-tag"
     }
   },
+  "tags-autocomplete-onpaste-off": {
+    "packagePath": "components/tag/tags-autocomplete-onpaste-off",
+    "title": "Tags Autocomplete Onpaste Off",
+    "componentName": "TagsAutocompleteOnpasteOffExample",
+    "files": [
+      "tags-autocomplete-onpaste-off-example.ts",
+      "tags-autocomplete-onpaste-off-example.html",
+      "tags-autocomplete-onpaste-off-example.css"
+    ],
+    "selector": "tags-autocomplete-onpaste-off-example",
+    "additionalComponents": [],
+    "primaryFile": "tags-autocomplete-onpaste-off-example.ts",
+    "module": {
+      "name": "TagExamplesModule",
+      "importSpecifier": "components/tag",
+      "importPath": "koobiq-docs-examples-components-tag"
+    }
+  },
+  "tags-input-onpaste-off": {
+    "packagePath": "components/tag/tags-input-onpaste-off",
+    "title": "Tags Input Onpaste Off",
+    "componentName": "TagsInputOnpasteOffExample",
+    "files": [
+      "tags-input-onpaste-off-example.ts",
+      "tags-input-onpaste-off-example.html",
+      "tags-input-onpaste-off-example.css"
+    ],
+    "selector": "tags-input-onpaste-off-example",
+    "additionalComponents": [],
+    "primaryFile": "tags-input-onpaste-off-example.ts",
+    "module": {
+      "name": "TagExamplesModule",
+      "importSpecifier": "components/tag",
+      "importPath": "koobiq-docs-examples-components-tag"
+    }
+  },
   "text-area-overview": {
     "packagePath": "components/textarea/text-area-overview",
     "title": "Basic textarea",

--- a/tools/public_api_guard/components/tags.api.md
+++ b/tools/public_api_guard/components/tags.api.md
@@ -141,6 +141,8 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
     constructor(elementRef: ElementRef<HTMLInputElement>, renderer: Renderer2, defaultOptions: KbqTagsDefaultOptions, trimDirective: KbqTrim, ngControl: NgControl, autocompleteTrigger?: KbqAutocompleteTrigger | undefined);
     get addOnBlur(): boolean;
     set addOnBlur(value: boolean);
+    get addOnPaste(): boolean;
+    set addOnPaste(value: boolean);
     // (undocumented)
     autocompleteTrigger?: KbqAutocompleteTrigger | undefined;
     blur(event: FocusEvent): void;
@@ -179,7 +181,7 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
     // (undocumented)
     updateInputWidth(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<KbqTagInput, "input[kbqTagInputFor]", ["kbqTagInput", "kbqTagInputFor"], { "separatorKeyCodes": { "alias": "kbqTagInputSeparatorKeyCodes"; "required": false; }; "distinct": { "alias": "distinct"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "id": { "alias": "id"; "required": false; }; "tagList": { "alias": "kbqTagInputFor"; "required": false; }; "addOnBlur": { "alias": "kbqTagInputAddOnBlur"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "tagEnd": "kbqTagInputTokenEnd"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<KbqTagInput, "input[kbqTagInputFor]", ["kbqTagInput", "kbqTagInputFor"], { "separatorKeyCodes": { "alias": "kbqTagInputSeparatorKeyCodes"; "required": false; }; "distinct": { "alias": "distinct"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "id": { "alias": "id"; "required": false; }; "tagList": { "alias": "kbqTagInputFor"; "required": false; }; "addOnBlur": { "alias": "kbqTagInputAddOnBlur"; "required": false; }; "addOnPaste": { "alias": "kbqTagInputAddOnPaste"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, { "tagEnd": "kbqTagInputTokenEnd"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqTagInput, [null, null, null, { optional: true; self: true; }, { optional: true; self: true; }, { optional: true; self: true; }]>;
 }
@@ -323,6 +325,8 @@ export class KbqTagRemove {
 
 // @public
 export interface KbqTagsDefaultOptions {
+    // (undocumented)
+    addOnPaste?: boolean;
     separatorKeyCodes: number[];
     // (undocumented)
     separators?: {


### PR DESCRIPTION
## Summary
Added the ability to connect via Input or InjectionToken
Updated the tests, added examples (dev and in the dock)