### PR TITLE
fix(docs): example start command change (#DS-2529)

### DIFF
--- a/apps/docs/src/app/components/stackblitz/stackblitz-writer.ts
+++ b/apps/docs/src/app/components/stackblitz/stackblitz-writer.ts
@@ -91,7 +91,7 @@ export class StackblitzWriter {
                 .replace(/{{version}}/g, koobiqVersion);
         } else if (fileName === '.stackblitzrc') {
             fileContent = fileContent
-                .replace(/\${startCommand}/, 'turbo start');
+                .replace(/\${startCommand}/, 'npm start');
         } else if (fileName === 'src/app/app.module.ts') {
             const joinedComponentNames = data.componentNames.join(', ');
             // Replace the component name in `main.ts`.

--- a/firebase.json
+++ b/firebase.json
@@ -68,7 +68,7 @@
                     ]
                 }
             ],
-            "ignore": ["firebase.json", "**/node_modules/**", "**/.*"]
+            "ignore": ["firebase.json", "**/node_modules/**"]
         },
         {
             "target": "next",
@@ -142,7 +142,7 @@
                     ]
                 }
             ],
-            "ignore": ["firebase.json", "**/node_modules/**", "**/.*"]
+            "ignore": ["firebase.json", "**/node_modules/**"]
         },
         {
             "target": "v16",
@@ -154,7 +154,7 @@
                     "destination": "/index.html"
                 }
             ],
-            "ignore": ["firebase.json", "**/node_modules/**", "**/.*"]
+            "ignore": ["firebase.json", "**/node_modules/**"]
         }
     ]
 }

--- a/firebase.json
+++ b/firebase.json
@@ -49,6 +49,21 @@
                     ]
                 },
                 {
+                    "source": "/assets/versions.json",
+                    "headers": [
+                        {
+                            "key": "Access-Control-Allow-Origin",
+                            "value": "*"
+                        },
+                        {
+                            "key": "Cache-Control",
+                            // The versions file should not be cached as it may change
+                            // at any time and otherwise old versions would be rendered.
+                            "value": "no-cache"
+                        }
+                    ]
+                },
+                {
                     "source": "/assets/stackblitz/**",
                     "headers": [
                         {
@@ -119,6 +134,21 @@
                         {
                             "key": "Cache-Control",
                             "value": "public, max-age=15811200, s-maxage=31536000"
+                        }
+                    ]
+                },
+                {
+                    "source": "/assets/versions.json",
+                    "headers": [
+                        {
+                            "key": "Access-Control-Allow-Origin",
+                            "value": "*"
+                        },
+                        {
+                            "key": "Cache-Control",
+                            // The versions file should not be cached as it may change
+                            // at any time and otherwise old versions would be rendered.
+                            "value": "no-cache"
                         }
                     ]
                 },

--- a/firebase.json
+++ b/firebase.json
@@ -49,6 +49,16 @@
                     ]
                 },
                 {
+                    "source": "/assets/stackblitz/**",
+                    "headers": [
+                        {
+                            "key": "Cache-Control",
+                            // StackBlitz assets are not hashed and should not be cached.
+                            "value": "no-cache"
+                        }
+                    ]
+                },
+                {
                     "source": "/*.@(js|css)",
                     "headers": [
                         {
@@ -109,6 +119,16 @@
                         {
                             "key": "Cache-Control",
                             "value": "public, max-age=15811200, s-maxage=31536000"
+                        }
+                    ]
+                },
+                {
+                    "source": "/assets/stackblitz/**",
+                    "headers": [
+                        {
+                            "key": "Cache-Control",
+                            // StackBlitz assets are not hashed and should not be cached.
+                            "value": "no-cache"
                         }
                     ]
                 },


### PR DESCRIPTION
## Summary

changed to `npm` since `turbo` removed in stackblitz: https://developer.stackblitz.com/platform/webcontainers/turbo-package-manager

