### PR TITLE
fix(docs): examples, api sections selection and scroll after link opened (#DS-2478)

### DIFF
--- a/apps/docs/src/app/components/anchors/anchors.component.ts
+++ b/apps/docs/src/app/components/anchors/anchors.component.ts
@@ -15,6 +15,8 @@ interface KbqDocsAnchor {
     element: HTMLElement;
 }
 
+const NEXT_ROUTE_KEY = 'KBQ_nextRoute';
+
 @Component({
     selector: 'docs-anchors',
     templateUrl: './anchors.component.html',
@@ -76,7 +78,7 @@ export class AnchorsComponent implements OnDestroy {
         }
 
         this.pathName = router.url.split('#')[0];
-        localStorage.setItem('PT_nextRoute', this.pathName);
+        localStorage.setItem(NEXT_ROUTE_KEY, this.pathName);
 
         this.router.events
             .pipe(
@@ -87,7 +89,7 @@ export class AnchorsComponent implements OnDestroy {
                 const [rootUrl] = router.url.split('#');
 
                 if (rootUrl !== this.pathName) {
-                    localStorage.setItem('PT_nextRoute', rootUrl);
+                    localStorage.setItem(NEXT_ROUTE_KEY, rootUrl);
 
                     this.pathName = rootUrl;
                 }

--- a/apps/docs/src/app/components/anchors/anchors.component.ts
+++ b/apps/docs/src/app/components/anchors/anchors.component.ts
@@ -75,9 +75,8 @@ export class AnchorsComponent implements OnDestroy {
             this.debounceTime = this.noSmoothScrollDebounce;
         }
 
-        this.currentUrl = router.url.split('#')[0];
-        localStorage.setItem('PT_nextRoute', this.currentUrl);
-        this.pathName = this.router.url;
+        this.pathName = router.url.split('#')[0];
+        localStorage.setItem('PT_nextRoute', this.pathName);
 
         this.router.events
             .pipe(
@@ -87,11 +86,10 @@ export class AnchorsComponent implements OnDestroy {
             .subscribe((event) => {
                 const [rootUrl] = router.url.split('#');
 
-                if (rootUrl !== this.currentUrl) {
+                if (rootUrl !== this.pathName) {
                     localStorage.setItem('PT_nextRoute', rootUrl);
 
-                    this.currentUrl = rootUrl;
-                    this.pathName = this.router.url;
+                    this.pathName = rootUrl;
                 }
             });
     }
@@ -121,7 +119,8 @@ export class AnchorsComponent implements OnDestroy {
 
         if (target) {
             target.scrollTop += this.headerHeight;
-            target.scrollIntoView();
+            // scroll after docs-sidepanel scrolled
+            setTimeout(() => target.scrollIntoView());
         } else {
             this.scrollContainer.scroll(0, 0);
         }

--- a/apps/docs/src/app/components/documentation-items.ts
+++ b/apps/docs/src/app/components/documentation-items.ts
@@ -26,6 +26,8 @@ function updatePackageName(categories, name) {
     categories.forEach((category) => category.items.forEach((doc) => (doc.packageName = name)));
 }
 
+export const documentationItemSections = ['overview',  'api', 'examples'];
+
 const MAIN = 'main';
 const COMPONENTS = 'components';
 const OTHER = 'other';

--- a/apps/docs/src/app/components/sidenav/sidenav.component.ts
+++ b/apps/docs/src/app/components/sidenav/sidenav.component.ts
@@ -6,7 +6,8 @@ import { KbqScrollbar } from '@koobiq/components/scrollbar';
 import { FlatTreeControl, KbqTreeFlatDataSource, KbqTreeFlattener, KbqTreeSelection } from '@koobiq/components/tree';
 import { Subject, delay } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
-import { DocCategory, DocumentationItems } from '../documentation-items';
+
+import { DocCategory, DocumentationItems, documentationItemSections } from '../documentation-items';
 import { DocStates } from '../doс-states';
 
 enum TreeNodeType {
@@ -154,7 +155,11 @@ export class ComponentSidenav implements AfterViewInit, OnInit, OnDestroy {
     }
 
     needSelectDefaultItem = () => {
-        this._selectedItem = this.router.url.replace('/', '').replace('/overview', '');
+        // remove extra path endpoints so tree node can be selected
+        this._selectedItem = documentationItemSections.reduce(
+            (resUrl, currentValue) => resUrl.replace(new RegExp(`\\/${currentValue}.*`), ''),
+            this.router.url.replace('/', '')
+        );
 
         setTimeout(() => this.tree.highlightSelectedOption());
     };


### PR DESCRIPTION
## Summary

Fixed UX while using docs 

- **Fixed** incorrect link redirect when clicked on anchor within ToC and browser has link with fragment: (https://koobiq.io/components/datepicker/api#KbqDatepickerToggleIcon)
- **Fixed** sidepanel section highlight when `examples` or `api` subsections opened