### PR TITLE
fix(select,tree-select): item width calculation (#DS-2649)

### DIFF
--- a/packages/components/select/select.component.ts
+++ b/packages/components/select/select.component.ts
@@ -961,7 +961,7 @@ export class KbqSelect
         const width: number = parseInt(computedStyle.width as string);
         const marginLeft: number = parseInt(computedStyle.marginLeft as string);
         const marginRight: number = parseInt(computedStyle.marginRight as string);
-        // item width + margins + flex gap between each item
+
         return width + marginLeft + marginRight + parseInt(SelectSizeMultipleContentGap);
     }
 

--- a/packages/components/select/select.component.ts
+++ b/packages/components/select/select.component.ts
@@ -87,7 +87,7 @@ import {
 } from '@koobiq/components/core';
 import { KbqCleaner, KbqFormField, KbqFormFieldControl } from '@koobiq/components/form-field';
 import { KbqTag } from '@koobiq/components/tags';
-import { SizeXxs } from '@koobiq/design-tokens';
+import { SelectSizeMultipleContentGap } from '@koobiq/design-tokens';
 import { BehaviorSubject, Observable, Subject, Subscription, defer, merge } from 'rxjs';
 import { delay, distinctUntilChanged, filter, map, startWith, switchMap, take, takeUntil } from 'rxjs/operators';
 
@@ -952,8 +952,7 @@ export class KbqSelect
 
         triggerClone.remove();
 
-        // item width + flex gap between each item
-        return totalItemsWidth + parseInt(SizeXxs) * (selectedItemsViewValueContainers.length - 1);
+        return totalItemsWidth;
     }
 
     private getItemWidth(element: HTMLElement): number {
@@ -962,8 +961,8 @@ export class KbqSelect
         const width: number = parseInt(computedStyle.width as string);
         const marginLeft: number = parseInt(computedStyle.marginLeft as string);
         const marginRight: number = parseInt(computedStyle.marginRight as string);
-
-        return width + marginLeft + marginRight;
+        // item width + margins + flex gap between each item
+        return width + marginLeft + marginRight + parseInt(SelectSizeMultipleContentGap);
     }
 
     /** Handles keyboard events while the select is closed. */

--- a/packages/components/tree-select/tree-select.component.ts
+++ b/packages/components/tree-select/tree-select.component.ts
@@ -76,7 +76,7 @@ import {
 import { KbqCleaner, KbqFormField, KbqFormFieldControl } from '@koobiq/components/form-field';
 import { KbqTag } from '@koobiq/components/tags';
 import { KbqTree, KbqTreeOption, KbqTreeSelection } from '@koobiq/components/tree';
-import { SizeXxs } from '@koobiq/design-tokens';
+import { SelectSizeMultipleContentGap } from '@koobiq/design-tokens';
 import { Observable, Subject, Subscription, defer, merge } from 'rxjs';
 import { delay, distinctUntilChanged, filter, map, startWith, switchMap, take, takeUntil } from 'rxjs/operators';
 
@@ -920,8 +920,7 @@ export class KbqTreeSelect
 
         triggerClone.remove();
 
-        // item width + flex gap between each item
-        return totalItemsWidth + parseInt(SizeXxs) * (selectedItemsViewValueContainers.length - 1);
+        return totalItemsWidth;
     }
 
     private getTotalVisibleItems(): [number, number] {
@@ -960,8 +959,8 @@ export class KbqTreeSelect
         const width: number = parseInt(computedStyle.width as string);
         const marginLeft: number = parseInt(computedStyle.marginLeft as string);
         const marginRight: number = parseInt(computedStyle.marginRight as string);
-
-        return width + marginLeft + marginRight;
+        // item width + margins + flex gap between each item
+        return width + marginLeft + marginRight + parseInt(SelectSizeMultipleContentGap);
     }
 
     private handleClosedKeydown(event: KeyboardEvent) {

--- a/packages/components/tree-select/tree-select.component.ts
+++ b/packages/components/tree-select/tree-select.component.ts
@@ -959,7 +959,7 @@ export class KbqTreeSelect
         const width: number = parseInt(computedStyle.width as string);
         const marginLeft: number = parseInt(computedStyle.marginLeft as string);
         const marginRight: number = parseInt(computedStyle.marginRight as string);
-        // item width + margins + flex gap between each item
+
         return width + marginLeft + marginRight + parseInt(SelectSizeMultipleContentGap);
     }
 


### PR DESCRIPTION
## Summary

Fixed item width calculation, so hidden items can be represented correctly.
Fixed bug for specific window size, when 1 item is hidden but "show more" button not represented


### Before


https://github.com/user-attachments/assets/f5cfddd6-ad2c-465b-8669-8aab7eb38b49



### After

https://github.com/user-attachments/assets/465a9cdd-ccf2-438d-a4fe-bcb894bab686



