### PR TITLE
fix(tabs): prevent closing popover on scroll in tab (#DS-2749)

### DIFF
--- a/packages/components-dev/tabs/module.ts
+++ b/packages/components-dev/tabs/module.ts
@@ -3,6 +3,7 @@ import { FormsModule, UntypedFormControl } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { KbqButtonModule } from '@koobiq/components/button';
+import { KbqPopoverModule } from '@koobiq/components/popover';
 import { KbqSelectModule } from '@koobiq/components/select';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 import { Observable, Observer } from 'rxjs';
@@ -90,7 +91,8 @@ export class TabsDemoComponent {
         KbqInputModule,
         KbqToolTipModule,
         KbqSelectModule,
-        KbqButtonModule
+        KbqButtonModule,
+        KbqPopoverModule
     ],
     bootstrap: [TabsDemoComponent]
 })

--- a/packages/components-dev/tabs/template.html
+++ b/packages/components-dev/tabs/template.html
@@ -8,7 +8,21 @@
         >
             Content 4
         </kbq-tab>
-        <kbq-tab [label]="'label 5'">Content 5</kbq-tab>
+        <kbq-tab [label]="'label 5'">
+            <div style="height: 200px">
+                <div style="height: 300px"></div>
+                <button
+                    kbq-button
+                    kbqPopover
+                    [kbqPopoverContent]="
+                        'Сегодня этот текст используют практически все дизайнеры, набирающие рыбу латиницей. Абзац считается каноническим во всех справочниках по типографике и предлагается к использованию в статьях, посвященных изготовлению макета верстки при отсутствии финальных текстов. В руководствах по работе с фирменным стилем крупных международных компаний именно с этих слов начинаются образцы верстки. Существуют даже издания с названием Lorem ipsum'
+                    "
+                >
+                    Button
+                </button>
+                <div style="height: 300px"></div>
+            </div>
+        </kbq-tab>
         <kbq-tab [label]="'label 6'">Content 6</kbq-tab>
         <kbq-tab [label]="'label 7'">Content 7</kbq-tab>
         <kbq-tab [label]="'label 8'">Content 8</kbq-tab>

--- a/packages/components/popover/popover.component.ts
+++ b/packages/components/popover/popover.component.ts
@@ -1,6 +1,7 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
+    CdkScrollable,
     FlexibleConnectedPositionStrategy,
     Overlay,
     OverlayConfig,
@@ -278,6 +279,17 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> {
         @Optional() direction: Directionality
     ) {
         super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction);
+
+        this.scrollDispatcher.scrolled().subscribe((scrollable: CdkScrollable | void) => {
+            if (!scrollable) return;
+
+            const parentRects = scrollable.getElementRef().nativeElement.getBoundingClientRect();
+            const childRects = elementRef.nativeElement.getBoundingClientRect();
+
+            if (childRects.bottom < parentRects.top || childRects.top > parentRects.bottom) {
+                this.hide();
+            }
+        });
     }
 
     updateData() {

--- a/packages/components/tabs/tab-body.html
+++ b/packages/components/tabs/tab-body.html
@@ -1,7 +1,7 @@
 <div
     #content
     cdk-scrollable
-    class="kbq-tab-body__content kbq-scrollbar"
+    class="kbq-tab-body__content kbq-scrollbar kbq-hide-nested-popup"
     (@translateTab.done)="onTranslateTabComplete($event)"
     (@translateTab.start)="onTranslateTabStarted($event)"
     [@translateTab]="{

--- a/packages/components/tabs/tab.component.ts
+++ b/packages/components/tabs/tab.component.ts
@@ -22,7 +22,6 @@ import {
     mixinDisabled
 } from '@koobiq/components/core';
 import { KBQ_DROPDOWN_SCROLL_STRATEGY } from '@koobiq/components/dropdown';
-import { KBQ_POPOVER_SCROLL_STRATEGY } from '@koobiq/components/popover';
 import { Subject } from 'rxjs';
 import { KbqTabContent } from './tab-content.directive';
 import { KBQ_TAB_LABEL, KbqTabLabel } from './tab-label.directive';
@@ -44,7 +43,7 @@ export const KbqTabMixinBase: CanDisableCtor & typeof KbqTabBase = mixinDisabled
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     providers: [
-        ...[KBQ_SELECT_SCROLL_STRATEGY, KBQ_DROPDOWN_SCROLL_STRATEGY, KBQ_POPOVER_SCROLL_STRATEGY].map((token) =>
+        ...[KBQ_SELECT_SCROLL_STRATEGY, KBQ_DROPDOWN_SCROLL_STRATEGY].map((token) =>
             KBQ_CUSTOM_SCROLL_STRATEGY_PROVIDER(token, (overlay) => () => overlay.scrollStrategies.close())
         )
     ]

--- a/tools/public_api_guard/components/popover.api.md
+++ b/tools/public_api_guard/components/popover.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AfterContentInit } from '@angular/core';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { ChangeDetectorRef } from '@angular/core';
@@ -131,11 +132,11 @@ export class KbqPopoverModule {
 export function kbqPopoverScrollStrategyFactory(overlay: Overlay): () => ScrollStrategy;
 
 // @public (undocumented)
-export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> {
+export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> implements AfterContentInit {
     constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality);
     // (undocumented)
     backdropClass: string;
-    get closeOnScroll(): boolean;
+    get closeOnScroll(): boolean | null;
     set closeOnScroll(value: boolean);
     // (undocumented)
     closingActions(): Observable<void | MouseEvent | CdkScrollable>;
@@ -163,6 +164,8 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> {
     // (undocumented)
     get header(): string | TemplateRef<any>;
     set header(value: string | TemplateRef<any>);
+    // (undocumented)
+    ngAfterContentInit(): void;
     // (undocumented)
     protected originSelector: string;
     // (undocumented)

--- a/tools/public_api_guard/components/popover.api.md
+++ b/tools/public_api_guard/components/popover.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import { AnimationTriggerMetadata } from '@angular/animations';
-import { CdkScrollable } from '@angular/cdk/scrolling';
+import { CdkScrollable } from '@angular/cdk/overlay';
 import { ChangeDetectorRef } from '@angular/core';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';


### PR DESCRIPTION
Убрал скрытие при скролле внутри таба.

Добавил немного логики для скрытия поповера внутри таба если триггер выходит за границы.

![chrome_x4C6XTrPSv](https://github.com/user-attachments/assets/c315d215-6240-4cc6-9a29-29b8fe798d42)
