### PR TITLE
feat: migrated to takeUntilDestroyed (#DS-2784)

### DIFF
--- a/apps/docs/src/app/components/sidenav/sidenav.component.ts
+++ b/apps/docs/src/app/components/sidenav/sidenav.component.ts
@@ -1,11 +1,11 @@
 import { ViewportScroller } from '@angular/common';
-import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, inject, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
 import { KbqScrollbar } from '@koobiq/components/scrollbar';
 import { FlatTreeControl, KbqTreeFlatDataSource, KbqTreeFlattener, KbqTreeSelection } from '@koobiq/components/tree';
-import { Subject, delay } from 'rxjs';
-import { map, takeUntil } from 'rxjs/operators';
-
+import { delay } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { DocCategory, DocumentationItems, documentationItemSections } from '../documentation-items';
 import { DocStates } from '../doс-states';
 
@@ -58,7 +58,7 @@ export function buildTree(categories: DocCategory[]): TreeNode[] {
     },
     encapsulation: ViewEncapsulation.None
 })
-export class ComponentSidenav implements AfterViewInit, OnInit, OnDestroy {
+export class ComponentSidenav implements AfterViewInit, OnInit {
     @ViewChild(KbqScrollbar) sidenavMenuContainer: KbqScrollbar;
     @ViewChild('tree') tree: KbqTreeSelection;
 
@@ -98,8 +98,7 @@ export class ComponentSidenav implements AfterViewInit, OnInit, OnDestroy {
     }
 
     private _selectedItem: string;
-
-    private destroy: Subject<void> = new Subject();
+    private readonly destroyRef = inject(DestroyRef);
 
     constructor(
         public docStates: DocStates,
@@ -133,7 +132,7 @@ export class ComponentSidenav implements AfterViewInit, OnInit, OnDestroy {
                     return first.path;
                 }),
                 delay(0),
-                takeUntil(this.destroy)
+                takeUntilDestroyed(this.destroyRef)
             )
             .subscribe((url: string) => {
                 if (!url) {
@@ -146,11 +145,6 @@ export class ComponentSidenav implements AfterViewInit, OnInit, OnDestroy {
         this.treeControl.expandAll();
 
         this.docStates.registerNavbarScrollContainer(this.sidenavMenuContainer.contentElement.nativeElement);
-    }
-
-    ngOnDestroy() {
-        this.destroy.next();
-        this.destroy.complete();
     }
 
     needSelectDefaultItem = () => {

--- a/apps/docs/src/app/components/welcome/welcome.component.ts
+++ b/apps/docs/src/app/components/welcome/welcome.component.ts
@@ -1,7 +1,8 @@
-import { Component, ElementRef, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewEncapsulation } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ThemeService } from '@koobiq/components/core';
-import { Observable, Subject, fromEvent } from 'rxjs';
-import { debounceTime, map, takeUntil } from 'rxjs/operators';
+import { fromEvent, Observable } from 'rxjs';
+import { debounceTime, map } from 'rxjs/operators';
 import { DocCategory, DocumentationItems } from '../documentation-items';
 import { DocStates } from '../doс-states';
 
@@ -14,8 +15,7 @@ import { DocStates } from '../doс-states';
     },
     encapsulation: ViewEncapsulation.None
 })
-export class WelcomeComponent implements OnInit, OnDestroy {
-    readonly destroyed = new Subject<void>();
+export class WelcomeComponent implements OnInit {
     docCategories: DocCategory[];
     currentTheme$: Observable<string>;
 
@@ -26,7 +26,7 @@ export class WelcomeComponent implements OnInit, OnDestroy {
         private themeService: ThemeService
     ) {
         fromEvent(elementRef.nativeElement, 'scroll')
-            .pipe(debounceTime(10), takeUntil(this.destroyed))
+            .pipe(debounceTime(10), takeUntilDestroyed())
             .subscribe(this.checkOverflow);
     }
 
@@ -36,10 +36,6 @@ export class WelcomeComponent implements OnInit, OnDestroy {
             map((currentTheme) => currentTheme.className.replace('kbq-theme-', ''))
         );
         this.docStates.registerHeaderScrollContainer(this.elementRef.nativeElement);
-    }
-
-    ngOnDestroy(): void {
-        this.destroyed.next();
     }
 
     checkOverflow = () => {

--- a/packages/components/popover/popover-confirm.component.ts
+++ b/packages/components/popover/popover-confirm.component.ts
@@ -10,8 +10,8 @@ import {
     Output,
     ViewEncapsulation
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { kbqPopoverAnimations } from './popover-animations';
 import { KbqPopoverComponent, KbqPopoverTrigger } from './popover.component';
 
@@ -93,7 +93,7 @@ export class KbqPopoverConfirmTrigger extends KbqPopoverTrigger {
     }
 
     setupButtonEvents() {
-        this.instance.onConfirm.pipe(takeUntil(this.destroyed)).subscribe(() => {
+        this.instance.onConfirm.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
             this.confirm.emit();
             this.hide();
         });

--- a/packages/components/toast/toast.component.ts
+++ b/packages/components/toast/toast.component.ts
@@ -11,9 +11,10 @@ import {
     ViewEncapsulation,
     forwardRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ThemePalette } from '@koobiq/components/core';
-import { BehaviorSubject, Subject, merge } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { BehaviorSubject, merge } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { kbqToastAnimations } from './toast-animations';
 import { KbqToastService } from './toast.service';
 import { KbqToastData, KbqToastStyle } from './toast.type';
@@ -73,8 +74,6 @@ export class KbqToastComponent implements OnDestroy {
         return this.hovered.getValue() || this.focused.getValue();
     }
 
-    private destroyed: Subject<boolean> = new Subject();
-
     constructor(
         readonly data: KbqToastData,
         @Inject(forwardRef(() => KbqToastService)) readonly service: KbqToastService,
@@ -98,7 +97,7 @@ export class KbqToastComponent implements OnDestroy {
         merge(this.hovered, this.focused)
             .pipe(
                 filter((value) => value),
-                takeUntil(this.destroyed)
+                takeUntilDestroyed()
             )
             .subscribe(() => {
                 if (this.ttl === 0) {
@@ -114,8 +113,6 @@ export class KbqToastComponent implements OnDestroy {
 
         this.hovered.next(false);
         this.focused.next(false);
-
-        this.destroyed.next(true);
     }
 
     close(): void {

--- a/packages/components/tree/padding.directive.ts
+++ b/packages/components/tree/padding.directive.ts
@@ -1,9 +1,8 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { coerceNumberProperty } from '@angular/cdk/coercion';
-import { AfterViewInit, Directive, ElementRef, Input, OnDestroy, Optional, Renderer2 } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input, Optional, Renderer2 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TreeSizeIndentLevel } from '@koobiq/design-tokens';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { KbqTreeBase, KbqTreeNode } from './tree-base';
 import { KbqTreeOption } from './tree-option.component';
 
@@ -14,7 +13,7 @@ const cssUnitPattern = /([A-Za-z%]+)$/;
     selector: '[kbqTreeNodePadding]',
     exportAs: 'kbqTreeNodePadding'
 })
-export class KbqTreeNodePadding<T> implements OnDestroy, AfterViewInit {
+export class KbqTreeNodePadding<T> implements AfterViewInit {
     get level(): number {
         return this._level;
     }
@@ -48,8 +47,6 @@ export class KbqTreeNodePadding<T> implements OnDestroy, AfterViewInit {
     withIcon: boolean;
     iconWidth: number = 24;
 
-    private destroyed = new Subject<void>();
-
     constructor(
         protected treeNode: KbqTreeNode<T>,
         protected tree: KbqTreeBase<T>,
@@ -58,17 +55,12 @@ export class KbqTreeNodePadding<T> implements OnDestroy, AfterViewInit {
         private option: KbqTreeOption,
         @Optional() private dir: Directionality
     ) {
-        this.dir?.change?.pipe(takeUntil(this.destroyed)).subscribe(() => this.setPadding());
+        this.dir?.change?.pipe(takeUntilDestroyed()).subscribe(() => this.setPadding());
     }
 
     ngAfterViewInit(): void {
         this.withIcon = this.option.isToggleInDefaultPlace;
         this.setPadding();
-    }
-
-    ngOnDestroy() {
-        this.destroyed.next();
-        this.destroyed.complete();
     }
 
     paddingIndent(): string | null {

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -18,6 +18,7 @@ import { DateAdapter as DateAdapter_2 } from '@koobiq/date-adapter';
 import { DateFormats } from '@koobiq/date-adapter';
 import { DateFormatter as DateFormatter_2 } from '@koobiq/date-formatter';
 import { DateTimeOptions } from '@koobiq/date-formatter';
+import { DestroyRef } from '@angular/core';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
@@ -1425,7 +1426,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
     protected _customClass: string;
     // (undocumented)
-    protected readonly destroyed: Subject<void>;
+    protected readonly destroyRef: DestroyRef;
     // (undocumented)
     detach: () => void;
     // (undocumented)

--- a/tools/public_api_guard/components/list.api.md
+++ b/tools/public_api_guard/components/list.api.md
@@ -175,7 +175,7 @@ export class KbqListSelectAllEvent<T> {
 }
 
 // @public (undocumented)
-export class KbqListSelection extends KbqListSelectionMixinBase implements CanDisable, HasTabIndex, AfterContentInit, ControlValueAccessor, OnDestroy {
+export class KbqListSelection extends KbqListSelectionMixinBase implements CanDisable, HasTabIndex, AfterContentInit, ControlValueAccessor {
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, multiple: MultipleMode, clipboard: Clipboard_2);
     // (undocumented)
     get autoSelect(): boolean;
@@ -207,8 +207,6 @@ export class KbqListSelection extends KbqListSelectionMixinBase implements CanDi
     static ngAcceptInputType_horizontal: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
-    // (undocumented)
-    ngOnDestroy(): void;
     // (undocumented)
     get noUnselectLast(): boolean;
     set noUnselectLast(value: boolean);

--- a/tools/public_api_guard/components/navbar.api.md
+++ b/tools/public_api_guard/components/navbar.api.md
@@ -37,15 +37,17 @@ export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
     // (undocumented)
     blur(): void;
     // (undocumented)
-    protected changeDetectorRef: ChangeDetectorRef;
-    // (undocumented)
-    protected readonly destroyed: Subject<void>;
+    protected readonly changeDetectorRef: ChangeDetectorRef;
     // (undocumented)
     protected dropSubscriptions(): void;
+    // (undocumented)
+    protected readonly elementRef: ElementRef;
     // (undocumented)
     focus(): void;
     // (undocumented)
     focusableItems: QueryList<KbqNavbarFocusableItem>;
+    // (undocumented)
+    protected readonly focusMonitor: FocusMonitor;
     // (undocumented)
     keyManager: FocusKeyManager<KbqNavbarFocusableItem>;
     // (undocumented)
@@ -70,6 +72,12 @@ export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
 // @public (undocumented)
 export class KbqNavbar extends KbqFocusableComponent implements AfterViewInit, AfterContentInit, OnDestroy {
     constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, focusMonitor: FocusMonitor);
+    // (undocumented)
+    protected readonly changeDetectorRef: ChangeDetectorRef;
+    // (undocumented)
+    protected readonly elementRef: ElementRef;
+    // (undocumented)
+    protected readonly focusMonitor: FocusMonitor;
     // (undocumented)
     navbarItems: QueryList<KbqNavbarItem>;
     // (undocumented)
@@ -101,7 +109,7 @@ export class KbqNavbarBento {
 }
 
 // @public (undocumented)
-export class KbqNavbarBrand implements AfterContentInit, OnDestroy {
+export class KbqNavbarBrand implements AfterContentInit {
     constructor(navbar: KbqVerticalNavbar);
     // (undocumented)
     get hasBento(): boolean;
@@ -111,8 +119,6 @@ export class KbqNavbarBrand implements AfterContentInit, OnDestroy {
     logo: KbqNavbarLogo;
     // (undocumented)
     ngAfterContentInit(): void;
-    // (undocumented)
-    ngOnDestroy(): void;
     // (undocumented)
     title: KbqNavbarTitle;
     // (undocumented)

--- a/tools/public_api_guard/components/tree.api.md
+++ b/tools/public_api_guard/components/tree.api.md
@@ -16,6 +16,7 @@ import { Clipboard as Clipboard_2 } from '@angular/cdk/clipboard';
 import { CollectionViewer } from '@angular/cdk/collections';
 import { ControlValueAccessor } from '@angular/forms';
 import { DataSource } from '@angular/cdk/collections';
+import { DestroyRef } from '@angular/core';
 import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
@@ -173,6 +174,8 @@ export class KbqTreeBase<T> implements AfterContentChecked, CollectionViewer, On
     protected dataDiffer: IterableDiffer<T>;
     get dataSource(): DataSource<T> | Observable<T[]> | T[];
     set dataSource(dataSource: DataSource<T> | Observable<T[]> | T[]);
+    // (undocumented)
+    protected readonly destroyRef: DestroyRef;
     // (undocumented)
     protected differs: IterableDiffers;
     getNodeDef(data: T, i: number): KbqTreeNodeDef<T>;
@@ -353,7 +356,7 @@ export class KbqTreeNodeOutletContext<T> {
 }
 
 // @public (undocumented)
-export class KbqTreeNodePadding<T> implements OnDestroy, AfterViewInit {
+export class KbqTreeNodePadding<T> implements AfterViewInit {
     constructor(treeNode: KbqTreeNode<T>, tree: KbqTreeBase<T>, renderer: Renderer2, element: ElementRef<HTMLElement>, option: KbqTreeOption, dir: Directionality);
     // (undocumented)
     baseLeftPadding: number;
@@ -370,8 +373,6 @@ export class KbqTreeNodePadding<T> implements OnDestroy, AfterViewInit {
     set level(value: number);
     // (undocumented)
     ngAfterViewInit(): void;
-    // (undocumented)
-    ngOnDestroy(): void;
     // (undocumented)
     paddingIndent(): string | null;
     // (undocumented)
@@ -551,7 +552,7 @@ export class KbqTreeSelectAllEvent<T> {
 }
 
 // @public (undocumented)
-export class KbqTreeSelection extends KbqTreeBase<any> implements ControlValueAccessor, AfterContentInit, CanDisable, HasTabIndex, OnDestroy {
+export class KbqTreeSelection extends KbqTreeBase<any> implements ControlValueAccessor, AfterContentInit, CanDisable, HasTabIndex {
     constructor(elementRef: ElementRef, scheduler: AsyncScheduler, differs: IterableDiffers, changeDetectorRef: ChangeDetectorRef, multiple: MultipleMode, clipboard: Clipboard_2);
     // (undocumented)
     get autoSelect(): boolean;
@@ -587,8 +588,6 @@ export class KbqTreeSelection extends KbqTreeBase<any> implements ControlValueAc
     readonly navigationChange: EventEmitter<KbqTreeNavigationChange<KbqTreeOption>>;
     // (undocumented)
     ngAfterContentInit(): void;
-    // (undocumented)
-    ngOnDestroy(): void;
     // (undocumented)
     nodeOutlet: KbqTreeNodeOutlet;
     // (undocumented)


### PR DESCRIPTION
https://angular.dev/api/core/rxjs-interop/takeUntilDestroyed

меньше рутины, не нужно управлять переменной `destroy`

если решим использовать, распространю на остальной код
