### PR TITLE
feat: added default type value for modal return value

### DIFF
--- a/packages/components/modal/modal-ref.class.ts
+++ b/packages/components/modal/modal-ref.class.ts
@@ -5,7 +5,7 @@ import { KbqModalComponent } from './modal.component';
  * API class that public to users to handle the modal instance.
  * KbqModalRef is aim to avoid accessing to the modal instance directly by users.
  */
-export abstract class KbqModalRef<C = any, R = any> {
+export abstract class KbqModalRef<C = any, R = unknown> {
     abstract afterOpen: Observable<void>;
     abstract afterClose: Observable<R>;
 

--- a/packages/components/modal/modal.service.ts
+++ b/packages/components/modal/modal.service.ts
@@ -86,7 +86,7 @@ export class KbqModalService {
         this.modalControl.closeAll();
     }
 
-    create<C, R>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
+    create<C, R = unknown>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
         if (typeof options.kbqOnCancel !== 'function') {
             // Leave a empty function to close this modal by default
             options.kbqOnCancel = () => {};
@@ -111,7 +111,10 @@ export class KbqModalService {
         return new ModalBuilderForService(this.overlay, options).getInstance()!;
     }
 
-    confirm<C, R>(options: IModalOptionsForService<C> = {}, confirmType: ConfirmType = 'confirm'): KbqModalRef<C, R> {
+    confirm<C, R = unknown>(
+        options: IModalOptionsForService<C> = {},
+        confirmType: ConfirmType = 'confirm'
+    ): KbqModalRef<C, R> {
         if ('kbqFooter' in options) {
             console.warn(`The Confirm-Modal doesn't support "kbqFooter", this property will be ignored.`);
         }
@@ -128,17 +131,17 @@ export class KbqModalService {
         return this.create<C, R>(options);
     }
 
-    open<C, R>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
+    open<C, R = unknown>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
         options.kbqModalType = 'custom';
 
         return this.create<C, R>(options);
     }
 
-    success<C, R>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
+    success<C, R = unknown>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
         return this.confirm<C, R>(options, 'success');
     }
 
-    delete<C, R>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
+    delete<C, R = unknown>(options: IModalOptionsForService<C> = {}): KbqModalRef<C, R> {
         return this.confirm<C, R>(options, 'warn');
     }
 }

--- a/packages/docs-examples/components/modal/modal-component/modal-component-example.ts
+++ b/packages/docs-examples/components/modal/modal-component/modal-component-example.ts
@@ -11,12 +11,12 @@ import { KbqModalRef, KbqModalService } from '@koobiq/components/modal';
     encapsulation: ViewEncapsulation.None
 })
 export class ModalComponentExample {
-    componentModal: KbqModalRef;
+    modalRef: KbqModalRef<KbqModalCustomComponent, 'save' | 'close'>;
 
     constructor(private modalService: KbqModalService) {}
 
     openModal() {
-        this.componentModal = this.modalService.open({
+        this.modalRef = this.modalService.open({
             kbqComponent: KbqModalCustomComponent,
             kbqComponentParams: {
                 title: 'Title',
@@ -24,11 +24,11 @@ export class ModalComponentExample {
             }
         });
 
-        this.componentModal.afterOpen.subscribe(() => {
+        this.modalRef.afterOpen.subscribe(() => {
             console.log('[afterOpen] emitted!');
         });
 
-        this.componentModal.afterClose.subscribe((action: 'save' | 'close') => {
+        this.modalRef.afterClose.subscribe((action) => {
             console.log(`[afterClose] emitted, chosen action: ${action}`);
         });
     }
@@ -76,7 +76,7 @@ export class KbqModalCustomComponent {
     @Input() title: string;
     @Input() subtitle: string;
 
-    constructor(private modal: KbqModalRef) {}
+    constructor(private modal: KbqModalRef<KbqModalCustomComponent, 'save' | 'close'>) {}
 
     destroyModal(action: 'save' | 'close') {
         this.modal.destroy(action);

--- a/tools/public_api_guard/components/modal.api.md
+++ b/tools/public_api_guard/components/modal.api.md
@@ -274,7 +274,7 @@ export class KbqModalModule {
 }
 
 // @public
-export abstract class KbqModalRef<C = any, R = any> {
+export abstract class KbqModalRef<C = any, R = unknown> {
     // (undocumented)
     abstract afterClose: Observable<R>;
     // (undocumented)
@@ -302,17 +302,17 @@ export class KbqModalService {
     // (undocumented)
     closeAll(): void;
     // (undocumented)
-    confirm<C, R>(options?: IModalOptionsForService<C>, confirmType?: ConfirmType): KbqModalRef<C, R>;
+    confirm<C, R = unknown>(options?: IModalOptionsForService<C>, confirmType?: ConfirmType): KbqModalRef<C, R>;
     // (undocumented)
-    create<C, R>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
+    create<C, R = unknown>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
     // (undocumented)
-    delete<C, R>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
+    delete<C, R = unknown>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
     // (undocumented)
-    open<C, R>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
+    open<C, R = unknown>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
     // (undocumented)
     get openModals(): KbqModalRef[];
     // (undocumented)
-    success<C, R>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
+    success<C, R = unknown>(options?: IModalOptionsForService<C>): KbqModalRef<C, R>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqModalService, never>;
     // (undocumented)


### PR DESCRIPTION
```
Expected 2 type arguments, but got 1.
return this.modalService.open<UsersActionModalComponent>({
```