### PR TITLE
feat(pop-up): refactoring KbqPopUpTrigger, KbqPopUp (#DS-2852)

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -40,6 +40,7 @@ const scope_types = [
     'popover',
     'progress-bar',
     'progress-spinner',
+    'pop-up',
     'radio',
     'schematics',
     'scrolling',

--- a/packages/components/core/pop-up/pop-up-styles.ts
+++ b/packages/components/core/pop-up/pop-up-styles.ts
@@ -1,15 +1,14 @@
-import { ElementRef, inject, Renderer2 } from '@angular/core';
+import { Renderer2 } from '@angular/core';
 
-export const applyPopupMargins = (element: ElementRef, name: string, value: string) => {
-    const renderer = inject(Renderer2);
-    const classList = element.nativeElement.classList;
+export const applyPopupMargins = (renderer: Renderer2, element: HTMLElement, name: string, value: string) => {
+    const classList = element.classList;
 
     if (
         classList.contains(`${name}_placement-top`) ||
         classList.contains(`${name}_placement-top-left`) ||
         classList.contains(`${name}_placement-top-right`)
     ) {
-        renderer.setStyle(element.nativeElement, 'margin-bottom', value);
+        renderer.setStyle(element, 'margin-bottom', value);
     }
 
     if (
@@ -17,7 +16,7 @@ export const applyPopupMargins = (element: ElementRef, name: string, value: stri
         classList.contains(`${name}_placement-right-top`) ||
         classList.contains(`${name}_placement-right-bottom`)
     ) {
-        renderer.setStyle(element.nativeElement, 'margin-left', value);
+        renderer.setStyle(element, 'margin-left', value);
     }
 
     if (
@@ -25,7 +24,7 @@ export const applyPopupMargins = (element: ElementRef, name: string, value: stri
         classList.contains(`${name}_placement-bottom-left`) ||
         classList.contains(`${name}_placement-bottom-right`)
     ) {
-        renderer.setStyle(element.nativeElement, 'margin-top', value);
+        renderer.setStyle(element, 'margin-top', value);
     }
 
     if (
@@ -33,6 +32,6 @@ export const applyPopupMargins = (element: ElementRef, name: string, value: stri
         classList.contains(`${name}_placement-left-top`) ||
         classList.contains(`${name}_placement-left-bottom`)
     ) {
-        renderer.setStyle(element.nativeElement, 'margin-right', value);
+        renderer.setStyle(element, 'margin-right', value);
     }
 };

--- a/packages/components/core/pop-up/pop-up-trigger.ts
+++ b/packages/components/core/pop-up/pop-up-trigger.ts
@@ -36,12 +36,12 @@ import { PopUpPlacements, PopUpTriggers } from './constants';
 
 @Directive()
 export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
-    protected overlay: Overlay = inject(Overlay);
-    protected elementRef: ElementRef = inject(ElementRef);
-    protected ngZone: NgZone = inject(NgZone);
-    protected scrollDispatcher: ScrollDispatcher = inject(ScrollDispatcher);
-    protected hostView: ViewContainerRef = inject(ViewContainerRef);
-    protected direction = inject(Directionality, { optional: true });
+    protected readonly overlay: Overlay = inject(Overlay);
+    protected readonly elementRef: ElementRef = inject(ElementRef);
+    protected readonly ngZone: NgZone = inject(NgZone);
+    protected readonly scrollDispatcher: ScrollDispatcher = inject(ScrollDispatcher);
+    protected readonly hostView: ViewContainerRef = inject(ViewContainerRef);
+    protected readonly direction = inject(Directionality, { optional: true });
 
     protected abstract scrollStrategy: () => ScrollStrategy;
 

--- a/packages/components/core/pop-up/pop-up.ts
+++ b/packages/components/core/pop-up/pop-up.ts
@@ -5,8 +5,8 @@ import { PopUpVisibility } from './constants';
 
 @Directive()
 export abstract class KbqPopUp implements OnDestroy {
-    protected renderer: Renderer2 = inject(Renderer2);
-    protected changeDetectorRef: ChangeDetectorRef = inject(ChangeDetectorRef);
+    protected readonly renderer: Renderer2 = inject(Renderer2);
+    protected readonly changeDetectorRef: ChangeDetectorRef = inject(ChangeDetectorRef);
 
     header: string | TemplateRef<any>;
     content: string | TemplateRef<any>;

--- a/packages/components/core/pop-up/pop-up.ts
+++ b/packages/components/core/pop-up/pop-up.ts
@@ -1,10 +1,13 @@
 import { AnimationEvent } from '@angular/animations';
-import { ChangeDetectorRef, Directive, EventEmitter, OnDestroy, TemplateRef } from '@angular/core';
+import { ChangeDetectorRef, Directive, EventEmitter, inject, OnDestroy, Renderer2, TemplateRef } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { PopUpVisibility } from './constants';
 
 @Directive()
 export abstract class KbqPopUp implements OnDestroy {
+    protected renderer: Renderer2 = inject(Renderer2);
+    protected changeDetectorRef: ChangeDetectorRef = inject(ChangeDetectorRef);
+
     header: string | TemplateRef<any>;
     content: string | TemplateRef<any>;
     context: { $implicit: any } | null;
@@ -28,8 +31,6 @@ export abstract class KbqPopUp implements OnDestroy {
 
     private showTimeoutId: any;
     private hideTimeoutId: any;
-
-    protected constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
     ngOnDestroy() {
         clearTimeout(this.showTimeoutId);

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -1,21 +1,5 @@
-import { FocusMonitor } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
-import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
-import {
-    AfterViewInit,
-    Directive,
-    ElementRef,
-    Inject,
-    Input,
-    NgModule,
-    NgZone,
-    OnDestroy,
-    OnInit,
-    Optional,
-    Renderer2,
-    ViewContainerRef
-} from '@angular/core';
-import { KBQ_TOOLTIP_SCROLL_STRATEGY, KbqTooltipTrigger } from '@koobiq/components/tooltip';
+import { AfterViewInit, Directive, Input, NgModule, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -44,18 +28,8 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
 
     private readonly debounceInterval: number = 50;
 
-    constructor(
-        overlay: Overlay,
-        elementRef: ElementRef<HTMLElement>,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy: any,
-        @Optional() direction: Directionality,
-        focusMonitor: FocusMonitor,
-        private renderer: Renderer2
-    ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+    constructor(private renderer: Renderer2) {
+        super();
     }
 
     override ngOnInit(): void {

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Directive, Input, NgModule, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { AfterViewInit, Directive, inject, Input, NgModule, OnDestroy, OnInit, Renderer2 } from '@angular/core';
 import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
@@ -13,6 +13,8 @@ const MIN_VISIBLE_LENGTH = 50;
     }
 })
 export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnInit, AfterViewInit, OnDestroy {
+    private renderer: Renderer2 = inject(Renderer2);
+
     @Input() set kbqEllipsisCenter(value: string) {
         this._kbqEllipsisCenter = value;
         this.refresh();
@@ -27,10 +29,6 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
     private resizeSubscription = Subscription.EMPTY;
 
     private readonly debounceInterval: number = 50;
-
-    constructor(private renderer: Renderer2) {
-        super();
-    }
 
     override ngOnInit(): void {
         super.ngOnInit();

--- a/packages/components/form-field/password-toggle.ts
+++ b/packages/components/form-field/password-toggle.ts
@@ -1,25 +1,18 @@
-import { FocusMonitor } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
-import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    ElementRef,
     Inject,
     Input,
-    NgZone,
-    Optional,
     TemplateRef,
     ViewChild,
-    ViewContainerRef,
     ViewEncapsulation,
     forwardRef
 } from '@angular/core';
 import { KBQ_FORM_FIELD_REF, KbqFormFieldRef, PopUpTriggers } from '@koobiq/components/core';
 import { KbqIconButton } from '@koobiq/components/icon';
-import { KBQ_TOOLTIP_SCROLL_STRATEGY, KbqTooltipTrigger } from '@koobiq/components/tooltip';
+import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 
 @Component({
     selector: `kbq-password-toggle`,
@@ -66,18 +59,10 @@ export class KbqPasswordToggle extends KbqTooltipTrigger implements AfterViewIni
     }
 
     constructor(
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        focusMonitor: FocusMonitor,
-        @Optional() direction: Directionality,
         @Inject(forwardRef(() => KBQ_FORM_FIELD_REF)) private formField: KbqFormFieldRef,
         private changeDetector: ChangeDetectorRef
     ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+        super();
 
         this.trigger = `${PopUpTriggers.Hover}`;
     }

--- a/packages/components/navbar/navbar-item.component.ts
+++ b/packages/components/navbar/navbar-item.component.ts
@@ -1,7 +1,5 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
 import { DOCUMENT } from '@angular/common';
 import {
     AfterContentInit,
@@ -18,7 +16,6 @@ import {
     OnDestroy,
     Optional,
     TemplateRef,
-    ViewContainerRef,
     ViewEncapsulation
 } from '@angular/core';
 import { IFocusableOption } from '@koobiq/cdk/a11y';
@@ -28,7 +25,7 @@ import { PopUpPlacements, PopUpTriggers, toBoolean } from '@koobiq/components/co
 import { KbqDropdownTrigger } from '@koobiq/components/dropdown';
 import { KbqFormField } from '@koobiq/components/form-field';
 import { KbqIcon } from '@koobiq/components/icon';
-import { KBQ_TOOLTIP_SCROLL_STRATEGY, KbqTooltipTrigger, TooltipModifier } from '@koobiq/components/tooltip';
+import { KbqTooltipTrigger, TooltipModifier } from '@koobiq/components/tooltip';
 import { EMPTY, Subject, merge } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { KbqVerticalNavbar } from './vertical-navbar.component';
@@ -456,18 +453,10 @@ export class KbqNavbarItem extends KbqTooltipTrigger implements AfterContentInit
         public rectangleElement: KbqNavbarRectangleElement,
         public navbarFocusableItem: KbqNavbarFocusableItem,
         private changeDetectorRef: ChangeDetectorRef,
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        focusMonitor: FocusMonitor,
-        @Optional() direction: Directionality,
         @Optional() private dropdownTrigger: KbqDropdownTrigger,
         @Optional() private bento: KbqNavbarBento
     ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+        super();
 
         if (this.hasDropDownTrigger) {
             this.dropdownTrigger.openByArrowDown = false;
@@ -588,17 +577,9 @@ export class KbqNavbarToggle extends KbqTooltipTrigger implements OnDestroy {
     constructor(
         public navbar: KbqVerticalNavbar,
         private changeDetectorRef: ChangeDetectorRef,
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        focusMonitor: FocusMonitor,
-        @Optional() direction: Directionality,
         @Optional() @Inject(DOCUMENT) private document: any
     ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+        super();
 
         this.placement = PopUpPlacements.Right;
 

--- a/packages/components/popover/popover-confirm.component.ts
+++ b/packages/components/popover/popover-confirm.component.ts
@@ -32,10 +32,6 @@ export class KbqPopoverConfirmComponent extends KbqPopoverComponent {
     confirmButtonText: string;
 
     confirmText: string;
-
-    constructor() {
-        super();
-    }
 }
 
 @Directive({

--- a/packages/components/popover/popover-confirm.component.ts
+++ b/packages/components/popover/popover-confirm.component.ts
@@ -1,25 +1,19 @@
-import { Directionality } from '@angular/cdk/bidi';
-import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
 import {
     ChangeDetectionStrategy,
-    ChangeDetectorRef,
     Component,
     Directive,
-    ElementRef,
     EventEmitter,
     Inject,
     InjectionToken,
     Input,
-    NgZone,
     Optional,
     Output,
-    ViewContainerRef,
     ViewEncapsulation
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { kbqPopoverAnimations } from './popover-animations';
-import { KBQ_POPOVER_SCROLL_STRATEGY, KbqPopoverComponent, KbqPopoverTrigger } from './popover.component';
+import { KbqPopoverComponent, KbqPopoverTrigger } from './popover.component';
 
 export const KBQ_POPOVER_CONFIRM_TEXT = new InjectionToken<string>('');
 export const KBQ_POPOVER_CONFIRM_BUTTON_TEXT = new InjectionToken<string>('');
@@ -39,8 +33,8 @@ export class KbqPopoverConfirmComponent extends KbqPopoverComponent {
 
     confirmText: string;
 
-    constructor(changeDetectorRef: ChangeDetectorRef) {
-        super(changeDetectorRef);
+    constructor() {
+        super();
     }
 }
 
@@ -83,17 +77,10 @@ export class KbqPopoverConfirmTrigger extends KbqPopoverTrigger {
     private _confirmButtonText: string = 'Да';
 
     constructor(
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_POPOVER_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality,
         @Optional() @Inject(KBQ_POPOVER_CONFIRM_TEXT) confirmText: string,
         @Optional() @Inject(KBQ_POPOVER_CONFIRM_BUTTON_TEXT) confirmButtonText: string
     ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction);
+        super();
 
         this.confirmText = confirmText || 'Вы уверены, что хотите продолжить?';
         this.confirmButtonText = confirmButtonText || 'Да';

--- a/packages/components/popover/popover.component.ts
+++ b/packages/components/popover/popover.component.ts
@@ -1,33 +1,26 @@
-import { Directionality } from '@angular/cdk/bidi';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
     CdkScrollable,
     FlexibleConnectedPositionStrategy,
     Overlay,
     OverlayConfig,
-    ScrollDispatcher,
     ScrollStrategy
 } from '@angular/cdk/overlay';
 import {
     AfterContentInit,
     AfterViewInit,
     ChangeDetectionStrategy,
-    ChangeDetectorRef,
     Component,
     DestroyRef,
     Directive,
     ElementRef,
     EventEmitter,
-    Inject,
     InjectionToken,
     Input,
-    NgZone,
-    Optional,
     Output,
     TemplateRef,
     Type,
     ViewChild,
-    ViewContainerRef,
     ViewEncapsulation,
     inject
 } from '@angular/core';
@@ -73,8 +66,8 @@ export class KbqPopoverComponent extends KbqPopUp implements AfterViewInit {
     isContentTopOverflow: boolean = false;
     isContentBottomOverflow: boolean = false;
 
-    constructor(changeDetectorRef: ChangeDetectorRef) {
-        super(changeDetectorRef);
+    constructor() {
+        super();
     }
 
     ngAfterViewInit() {
@@ -144,6 +137,8 @@ export function getKbqPopoverInvalidPositionError(position: string) {
     }
 })
 export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> implements AfterContentInit {
+    protected scrollStrategy: () => ScrollStrategy = inject(KBQ_POPOVER_SCROLL_STRATEGY);
+
     @Input('kbqPopoverVisible')
     get popoverVisible(): boolean {
         return this.visible;
@@ -323,16 +318,8 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> impl
         };
     }
 
-    constructor(
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_POPOVER_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality
-    ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction);
+    constructor() {
+        super();
     }
 
     ngAfterContentInit(): void {

--- a/packages/components/popover/popover.component.ts
+++ b/packages/components/popover/popover.component.ts
@@ -66,10 +66,6 @@ export class KbqPopoverComponent extends KbqPopUp implements AfterViewInit {
     isContentTopOverflow: boolean = false;
     isContentBottomOverflow: boolean = false;
 
-    constructor() {
-        super();
-    }
-
     ngAfterViewInit() {
         if (!this.popoverContent) return;
 
@@ -316,10 +312,6 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> impl
             hasBackdrop: this.hasBackdrop,
             backdropClass: this.backdropClass
         };
-    }
-
-    constructor() {
-        super();
     }
 
     ngAfterContentInit(): void {

--- a/packages/components/select/select-option.directive.ts
+++ b/packages/components/select/select-option.directive.ts
@@ -1,18 +1,6 @@
-import { FocusMonitor } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
-import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
-import {
-    AfterViewInit,
-    Directive,
-    ElementRef,
-    Inject,
-    NgZone,
-    OnDestroy,
-    Optional,
-    ViewContainerRef
-} from '@angular/core';
+import { AfterViewInit, Directive, OnDestroy } from '@angular/core';
 import { KbqOption } from '@koobiq/components/core';
-import { KBQ_TOOLTIP_SCROLL_STRATEGY, KbqTooltipTrigger } from '@koobiq/components/tooltip';
+import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 
 @Directive({
     selector: 'kbq-option',
@@ -35,18 +23,8 @@ export class KbqOptionTooltip extends KbqTooltipTrigger implements AfterViewInit
         return this.textElement.clientWidth < this.textElement.scrollWidth;
     }
 
-    constructor(
-        private option: KbqOption,
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality,
-        focusMonitor: FocusMonitor
-    ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+    constructor(private option: KbqOption) {
+        super();
     }
 
     ngAfterViewInit() {

--- a/packages/components/timezone/timezone-option.directive.ts
+++ b/packages/components/timezone/timezone-option.directive.ts
@@ -1,19 +1,6 @@
-import { FocusMonitor } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
-import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
-import {
-    AfterViewInit,
-    ChangeDetectorRef,
-    Directive,
-    ElementRef,
-    Inject,
-    NgZone,
-    OnDestroy,
-    Optional,
-    ViewContainerRef
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Directive, OnDestroy } from '@angular/core';
 import { PopUpPlacements } from '@koobiq/components/core';
-import { KBQ_TOOLTIP_SCROLL_STRATEGY, KbqTooltipTrigger } from '@koobiq/components/tooltip';
+import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { KbqTimezoneOption } from './timezone-option.component';
 
 export const TOOLTIP_VISIBLE_ROWS_COUNT = 3;
@@ -30,17 +17,9 @@ export class KbqTimezoneOptionTooltip extends KbqTooltipTrigger implements After
 
     constructor(
         private changeDetectorRef: ChangeDetectorRef,
-        private option: KbqTimezoneOption,
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality,
-        focusMonitor: FocusMonitor
+        private option: KbqTimezoneOption
     ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+        super();
         this.tooltipPlacement = PopUpPlacements.Right;
     }
 

--- a/packages/components/title/title.directive.ts
+++ b/packages/components/title/title.directive.ts
@@ -1,20 +1,6 @@
-import { FocusMonitor } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
-import { Overlay, ScrollDispatcher } from '@angular/cdk/overlay';
-import {
-    AfterViewInit,
-    ContentChild,
-    Directive,
-    ElementRef,
-    Host,
-    Inject,
-    NgZone,
-    OnDestroy,
-    Optional,
-    ViewContainerRef
-} from '@angular/core';
+import { AfterViewInit, ContentChild, Directive, ElementRef, Host, Inject, OnDestroy, Optional } from '@angular/core';
 import { KBQ_TITLE_TEXT_REF, KbqTitleTextRef } from '@koobiq/components/core';
-import { KBQ_TOOLTIP_SCROLL_STRATEGY, KbqTooltipTrigger } from '@koobiq/components/tooltip';
+import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { Observable, Subject, Subscription, throttleTime } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -58,18 +44,8 @@ export class KbqTitleDirective extends KbqTooltipTrigger implements AfterViewIni
     @ContentChild('kbqTitleContainer')
     private parentContainer: ElementRef;
 
-    constructor(
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        focusMonitor: FocusMonitor,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality,
-        @Host() @Optional() @Inject(KBQ_TITLE_TEXT_REF) private componentInstance?: KbqTitleTextRef
-    ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+    constructor(@Host() @Optional() @Inject(KBQ_TITLE_TEXT_REF) private componentInstance?: KbqTitleTextRef) {
+        super();
     }
 
     ngAfterViewInit() {

--- a/packages/components/tooltip/tooltip.component.ts
+++ b/packages/components/tooltip/tooltip.component.ts
@@ -1,30 +1,24 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { Overlay, OverlayConfig, ScrollDispatcher, ScrollStrategy } from '@angular/cdk/overlay';
+import { Overlay, OverlayConfig, ScrollStrategy } from '@angular/cdk/overlay';
 import {
     ChangeDetectionStrategy,
-    ChangeDetectorRef,
     Component,
     Directive,
     ElementRef,
     EventEmitter,
     Inject,
     InjectionToken,
-    Injector,
     Input,
-    NgZone,
     OnDestroy,
-    Optional,
     Output,
     TemplateRef,
     Type,
     ViewChild,
-    ViewContainerRef,
     ViewEncapsulation,
     booleanAttribute,
-    numberAttribute,
-    runInInjectionContext
+    inject,
+    numberAttribute
 } from '@angular/core';
 import {
     KbqComponentColors,
@@ -68,12 +62,8 @@ export class KbqTooltipComponent extends KbqPopUp {
 
     @ViewChild('tooltip') elementRef: ElementRef;
 
-    constructor(
-        changeDetectorRef: ChangeDetectorRef,
-        private injector: Injector,
-        @Inject(KBQ_TOOLTIP_OPEN_TIME) private openTime
-    ) {
-        super(changeDetectorRef);
+    constructor(@Inject(KBQ_TOOLTIP_OPEN_TIME) private openTime) {
+        super();
     }
 
     show(delay: number) {
@@ -84,8 +74,11 @@ export class KbqTooltipComponent extends KbqPopUp {
         super.show(Date.now() - this.openTime.value < MIN_TIME_FOR_DELAY ? 0 : delay);
 
         if (this.offset !== null) {
-            runInInjectionContext(this.injector, () =>
-                applyPopupMargins(this.elementRef, this.prefix, `${this.offset!.toString()}px`)
+            applyPopupMargins(
+                this.renderer,
+                this.elementRef.nativeElement,
+                this.prefix,
+                `${this.offset!.toString()}px`
             );
         }
 
@@ -126,6 +119,9 @@ export const KBQ_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER = {
     }
 })
 export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> implements OnDestroy {
+    protected scrollStrategy: () => ScrollStrategy = inject(KBQ_TOOLTIP_SCROLL_STRATEGY);
+    protected focusMonitor: FocusMonitor = inject(FocusMonitor);
+
     @Input('kbqVisible')
     get tooltipVisible(): boolean {
         return this.visible;
@@ -254,17 +250,8 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
 
     protected modifier: TooltipModifier = TooltipModifier.Default;
 
-    constructor(
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality,
-        protected focusMonitor: FocusMonitor
-    ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction);
+    constructor() {
+        super();
 
         this.focusMonitor.monitor(this.elementRef.nativeElement);
     }
@@ -342,17 +329,8 @@ export class KbqWarningTooltipTrigger extends KbqTooltipTrigger {
 
     protected modifier: TooltipModifier = TooltipModifier.Warning;
 
-    constructor(
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality,
-        focusMonitor: FocusMonitor
-    ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+    constructor() {
+        super();
     }
 }
 
@@ -393,17 +371,8 @@ export class KbqExtendedTooltipTrigger extends KbqTooltipTrigger {
 
     protected modifier: TooltipModifier = TooltipModifier.Extended;
 
-    constructor(
-        overlay: Overlay,
-        elementRef: ElementRef,
-        ngZone: NgZone,
-        scrollDispatcher: ScrollDispatcher,
-        hostView: ViewContainerRef,
-        @Inject(KBQ_TOOLTIP_SCROLL_STRATEGY) scrollStrategy,
-        @Optional() direction: Directionality,
-        focusMonitor: FocusMonitor
-    ) {
-        super(overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction, focusMonitor);
+    constructor() {
+        super();
     }
 
     updateData() {

--- a/packages/components/tooltip/tooltip.component.ts
+++ b/packages/components/tooltip/tooltip.component.ts
@@ -328,10 +328,6 @@ export class KbqWarningTooltipTrigger extends KbqTooltipTrigger {
     }
 
     protected modifier: TooltipModifier = TooltipModifier.Warning;
-
-    constructor() {
-        super();
-    }
 }
 
 @Directive({
@@ -370,10 +366,6 @@ export class KbqExtendedTooltipTrigger extends KbqTooltipTrigger {
     private _header: string | TemplateRef<any>;
 
     protected modifier: TooltipModifier = TooltipModifier.Extended;
-
-    constructor() {
-        super();
-    }
 
     updateData() {
         if (!this.instance) {

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -109,7 +109,7 @@ export enum AnimationCurves {
 }
 
 // @public (undocumented)
-export const applyPopupMargins: (element: ElementRef, name: string, value: string) => void;
+export const applyPopupMargins: (renderer: Renderer2, element: HTMLElement, name: string, value: string) => void;
 
 // @public (undocumented)
 export const BOTTOM_LEFT_POSITION_PRIORITY: ConnectionPositionPair[];
@@ -1345,7 +1345,6 @@ export class KbqOptionSelectionChange<T = KbqOption> {
 
 // @public (undocumented)
 export abstract class KbqPopUp implements OnDestroy {
-    protected constructor(changeDetectorRef: ChangeDetectorRef);
     afterHidden(): Observable<void>;
     // (undocumented)
     animationDone({ toState }: AnimationEvent_2): void;
@@ -1353,6 +1352,8 @@ export abstract class KbqPopUp implements OnDestroy {
     animationStart(): void;
     // (undocumented)
     arrow: boolean;
+    // (undocumented)
+    protected changeDetectorRef: ChangeDetectorRef;
     // (undocumented)
     classMap: {};
     // (undocumented)
@@ -1384,6 +1385,8 @@ export abstract class KbqPopUp implements OnDestroy {
     // (undocumented)
     protected prefix: string;
     // (undocumented)
+    protected renderer: Renderer2;
+    // (undocumented)
     show(delay: number): void;
     // (undocumented)
     updateClassMap(placement: string, customClass: string, classMap?: any): void;
@@ -1401,7 +1404,6 @@ export abstract class KbqPopUp implements OnDestroy {
 
 // @public (undocumented)
 export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
-    protected constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction?: Directionality | undefined);
     // (undocumented)
     protected readonly availablePositions: {
         [key: string]: ConnectionPositionPair;
@@ -1426,7 +1428,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
     detach: () => void;
     // (undocumented)
-    protected direction?: Directionality | undefined;
+    protected direction: Directionality | null;
     // (undocumented)
     abstract disabled: boolean;
     // (undocumented)
@@ -1486,7 +1488,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
     protected scrollDispatcher: ScrollDispatcher;
     // (undocumented)
-    protected scrollStrategy: any;
+    protected abstract scrollStrategy: () => ScrollStrategy;
     // (undocumented)
     show(delay?: number): void;
     // (undocumented)

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -1353,7 +1353,7 @@ export abstract class KbqPopUp implements OnDestroy {
     // (undocumented)
     arrow: boolean;
     // (undocumented)
-    protected changeDetectorRef: ChangeDetectorRef;
+    protected readonly changeDetectorRef: ChangeDetectorRef;
     // (undocumented)
     classMap: {};
     // (undocumented)
@@ -1385,7 +1385,7 @@ export abstract class KbqPopUp implements OnDestroy {
     // (undocumented)
     protected prefix: string;
     // (undocumented)
-    protected renderer: Renderer2;
+    protected readonly renderer: Renderer2;
     // (undocumented)
     show(delay: number): void;
     // (undocumented)
@@ -1428,13 +1428,13 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
     detach: () => void;
     // (undocumented)
-    protected direction: Directionality | null;
+    protected readonly direction: Directionality | null;
     // (undocumented)
     abstract disabled: boolean;
     // (undocumented)
     protected _disabled: boolean;
     // (undocumented)
-    protected elementRef: ElementRef;
+    protected readonly elementRef: ElementRef;
     // (undocumented)
     enterDelay: number;
     // (undocumented)
@@ -1450,7 +1450,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
     hide(delay?: number): void;
     // (undocumented)
-    protected hostView: ViewContainerRef;
+    protected readonly hostView: ViewContainerRef;
     // (undocumented)
     initListeners(): void;
     // (undocumented)
@@ -1466,13 +1466,13 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
-    protected ngZone: NgZone;
+    protected readonly ngZone: NgZone;
     // (undocumented)
     onPositionChange: ($event: ConnectedOverlayPositionChange) => void;
     // (undocumented)
     protected abstract originSelector: string;
     // (undocumented)
-    protected overlay: Overlay;
+    protected readonly overlay: Overlay;
     // (undocumented)
     protected abstract overlayConfig: OverlayConfig;
     // (undocumented)
@@ -1486,7 +1486,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
     protected portal: ComponentPortal<T>;
     // (undocumented)
-    protected scrollDispatcher: ScrollDispatcher;
+    protected readonly scrollDispatcher: ScrollDispatcher;
     // (undocumented)
     protected abstract scrollStrategy: () => ScrollStrategy;
     // (undocumented)

--- a/tools/public_api_guard/components/form-field.api.md
+++ b/tools/public_api_guard/components/form-field.api.md
@@ -11,7 +11,6 @@ import { AfterViewInit } from '@angular/core';
 import { CanColor } from '@koobiq/components/core';
 import { CanColorCtor } from '@koobiq/components/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
@@ -25,16 +24,12 @@ import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { KbqValidationOptions } from '@koobiq/components/core';
 import { NgControl } from '@angular/forms';
 import { NgForm } from '@angular/forms';
-import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
-import { Overlay } from '@angular/cdk/overlay';
 import { QueryList } from '@angular/core';
-import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { TemplateRef } from '@angular/core';
 import { Validator } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';
-import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
 export function getKbqFormFieldMissingControlError(): Error;
@@ -250,7 +245,7 @@ export class KbqPasswordHint extends KbqHint implements AfterContentInit {
 
 // @public (undocumented)
 export class KbqPasswordToggle extends KbqTooltipTrigger implements AfterViewInit {
-    constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, focusMonitor: FocusMonitor, direction: Directionality, formField: KbqFormFieldRef, changeDetector: ChangeDetectorRef);
+    constructor(formField: KbqFormFieldRef, changeDetector: ChangeDetectorRef);
     // (undocumented)
     get content(): string | TemplateRef<any>;
     set content(content: string | TemplateRef<any>);
@@ -271,7 +266,7 @@ export class KbqPasswordToggle extends KbqTooltipTrigger implements AfterViewIni
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<KbqPasswordToggle, "kbq-password-toggle", ["kbqPasswordToggle"], { "content": { "alias": "kbqTooltipNotHidden"; "required": false; }; "kbqTooltipHidden": { "alias": "kbqTooltipHidden"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqPasswordToggle, [null, null, null, null, null, null, null, { optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqPasswordToggle, never>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/components/navbar.api.md
+++ b/tools/public_api_guard/components/navbar.api.md
@@ -7,7 +7,6 @@
 import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { FocusKeyManager } from '@koobiq/cdk/a11y';
 import { FocusMonitor } from '@angular/cdk/a11y';
@@ -28,13 +27,10 @@ import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
-import { Overlay } from '@angular/cdk/overlay';
 import { QueryList } from '@angular/core';
-import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TooltipModifier } from '@koobiq/components/tooltip';
-import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
 export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
@@ -198,7 +194,7 @@ export interface KbqNavbarFocusableItemEvent {
 
 // @public (undocumented)
 export class KbqNavbarItem extends KbqTooltipTrigger implements AfterContentInit {
-    constructor(rectangleElement: KbqNavbarRectangleElement, navbarFocusableItem: KbqNavbarFocusableItem, changeDetectorRef: ChangeDetectorRef, overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, focusMonitor: FocusMonitor, direction: Directionality, dropdownTrigger: KbqDropdownTrigger, bento: KbqNavbarBento);
+    constructor(rectangleElement: KbqNavbarRectangleElement, navbarFocusableItem: KbqNavbarFocusableItem, changeDetectorRef: ChangeDetectorRef, dropdownTrigger: KbqDropdownTrigger, bento: KbqNavbarBento);
     // (undocumented)
     get collapsable(): boolean;
     set collapsable(value: boolean);
@@ -245,7 +241,7 @@ export class KbqNavbarItem extends KbqTooltipTrigger implements AfterContentInit
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<KbqNavbarItem, "kbq-navbar-item, [kbq-navbar-item]", ["kbqNavbarItem"], { "collapsedText": { "alias": "collapsedText"; "required": false; }; "trigger": { "alias": "kbqTrigger"; "required": false; }; "collapsable": { "alias": "collapsable"; "required": false; }; }, {}, ["title", "icon"], ["[kbq-icon]", "kbq-navbar-title, [kbq-navbar-title]", "*"], false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqNavbarItem, [null, null, null, null, null, null, null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqNavbarItem, [null, null, null, { optional: true; }, { optional: true; }]>;
 }
 
 // @public (undocumented)
@@ -325,7 +321,7 @@ export class KbqNavbarTitle implements AfterViewInit {
 
 // @public (undocumented)
 export class KbqNavbarToggle extends KbqTooltipTrigger implements OnDestroy {
-    constructor(navbar: KbqVerticalNavbar, changeDetectorRef: ChangeDetectorRef, overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, focusMonitor: FocusMonitor, direction: Directionality, document: any);
+    constructor(navbar: KbqVerticalNavbar, changeDetectorRef: ChangeDetectorRef, document: any);
     // (undocumented)
     get content(): string | TemplateRef<any>;
     set content(content: string | TemplateRef<any>);
@@ -346,7 +342,7 @@ export class KbqNavbarToggle extends KbqTooltipTrigger implements OnDestroy {
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<KbqNavbarToggle, "kbq-navbar-toggle", never, { "content": { "alias": "kbqCollapsedTooltip"; "required": false; }; }, {}, ["customIcon"], ["[kbq-icon]", "kbq-navbar-title"], false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqNavbarToggle, [null, null, null, null, null, null, null, null, null, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqNavbarToggle, [null, null, { optional: true; }]>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/components/popover.api.md
+++ b/tools/public_api_guard/components/popover.api.md
@@ -57,7 +57,6 @@ export const kbqPopoverAnimations: {
 
 // @public (undocumented)
 export class KbqPopoverComponent extends KbqPopUp implements AfterViewInit {
-    constructor();
     // (undocumented)
     checkContentOverflow(contentElement: HTMLElement): void;
     // (undocumented)
@@ -94,7 +93,6 @@ export class KbqPopoverComponent extends KbqPopUp implements AfterViewInit {
 
 // @public (undocumented)
 export class KbqPopoverConfirmComponent extends KbqPopoverComponent {
-    constructor();
     // (undocumented)
     confirmButtonText: string;
     // (undocumented)
@@ -148,7 +146,6 @@ export function kbqPopoverScrollStrategyFactory(overlay: Overlay): () => ScrollS
 
 // @public (undocumented)
 export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> implements AfterContentInit {
-    constructor();
     // (undocumented)
     backdropClass: string;
     get closeOnScroll(): boolean | null;

--- a/tools/public_api_guard/components/popover.api.md
+++ b/tools/public_api_guard/components/popover.api.md
@@ -8,8 +8,6 @@ import { AfterContentInit } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { CdkScrollable } from '@angular/cdk/overlay';
-import { ChangeDetectorRef } from '@angular/core';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
@@ -23,18 +21,15 @@ import { InjectionToken } from '@angular/core';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqPopUp } from '@koobiq/components/core';
 import { KbqPopUpTrigger } from '@koobiq/components/core';
-import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Overlay } from '@angular/cdk/overlay';
 import { OverlayConfig } from '@angular/cdk/overlay';
 import { PopUpPlacements } from '@koobiq/components/core';
 import { PopUpSizes } from '@koobiq/components/core';
-import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { Type } from '@angular/core';
-import { ViewContainerRef } from '@angular/core';
 
 // @public
 export function getKbqPopoverInvalidPositionError(position: string): Error;
@@ -62,7 +57,7 @@ export const kbqPopoverAnimations: {
 
 // @public (undocumented)
 export class KbqPopoverComponent extends KbqPopUp implements AfterViewInit {
-    constructor(changeDetectorRef: ChangeDetectorRef);
+    constructor();
     // (undocumented)
     checkContentOverflow(contentElement: HTMLElement): void;
     // (undocumented)
@@ -99,7 +94,7 @@ export class KbqPopoverComponent extends KbqPopUp implements AfterViewInit {
 
 // @public (undocumented)
 export class KbqPopoverConfirmComponent extends KbqPopoverComponent {
-    constructor(changeDetectorRef: ChangeDetectorRef);
+    constructor();
     // (undocumented)
     confirmButtonText: string;
     // (undocumented)
@@ -114,7 +109,7 @@ export class KbqPopoverConfirmComponent extends KbqPopoverComponent {
 
 // @public (undocumented)
 export class KbqPopoverConfirmTrigger extends KbqPopoverTrigger {
-    constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality, confirmText: string, confirmButtonText: string);
+    constructor(confirmText: string, confirmButtonText: string);
     // (undocumented)
     confirm: EventEmitter<void>;
     // (undocumented)
@@ -132,7 +127,7 @@ export class KbqPopoverConfirmTrigger extends KbqPopoverTrigger {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqPopoverConfirmTrigger, "[kbqPopoverConfirm]", ["kbqPopoverConfirm"], { "confirmText": { "alias": "kbqPopoverConfirmText"; "required": false; }; "confirmButtonText": { "alias": "kbqPopoverConfirmButtonText"; "required": false; }; }, { "confirm": "confirm"; }, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqPopoverConfirmTrigger, [null, null, null, null, null, null, { optional: true; }, { optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqPopoverConfirmTrigger, [{ optional: true; }, { optional: true; }]>;
 }
 
 // @public (undocumented)
@@ -153,7 +148,7 @@ export function kbqPopoverScrollStrategyFactory(overlay: Overlay): () => ScrollS
 
 // @public (undocumented)
 export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> implements AfterContentInit {
-    constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality);
+    constructor();
     // (undocumented)
     backdropClass: string;
     get closeOnScroll(): boolean | null;
@@ -205,6 +200,8 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> impl
     get popoverVisible(): boolean;
     set popoverVisible(value: boolean);
     // (undocumented)
+    protected scrollStrategy: () => ScrollStrategy;
+    // (undocumented)
     get size(): PopUpSizes;
     set size(value: PopUpSizes);
     // (undocumented)
@@ -220,7 +217,7 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> impl
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqPopoverTrigger, "[kbqPopover]", ["kbqPopover"], { "popoverVisible": { "alias": "kbqPopoverVisible"; "required": false; }; "popoverPlacement": { "alias": "kbqPopoverPlacement"; "required": false; }; "popoverPlacementPriority": { "alias": "kbqPopoverPlacementPriority"; "required": false; }; "hasBackdrop": { "alias": "hasBackdrop"; "required": false; }; "header": { "alias": "kbqPopoverHeader"; "required": false; }; "content": { "alias": "kbqPopoverContent"; "required": false; }; "footer": { "alias": "kbqPopoverFooter"; "required": false; }; "disabled": { "alias": "kbqPopoverDisabled"; "required": false; }; "trigger": { "alias": "kbqTrigger"; "required": false; }; "size": { "alias": "kbqPopoverSize"; "required": false; }; "customClass": { "alias": "kbqPopoverClass"; "required": false; }; "hasCloseButton": { "alias": "hasCloseButton"; "required": false; }; "closeOnScroll": { "alias": "closeOnScroll"; "required": false; }; "backdropClass": { "alias": "backdropClass"; "required": false; }; }, { "placementChange": "kbqPopoverPlacementChange"; "visibleChange": "kbqPopoverVisibleChange"; }, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqPopoverTrigger, [null, null, null, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqPopoverTrigger, never>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/tools/public_api_guard/components/select.api.md
+++ b/tools/public_api_guard/components/select.api.md
@@ -21,7 +21,6 @@ import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { ErrorStateMatcher } from '@koobiq/components/core';
 import { EventEmitter } from '@angular/core';
-import { FocusMonitor } from '@angular/cdk/a11y';
 import { FormGroupDirective } from '@angular/forms';
 import { HasTabIndex } from '@koobiq/components/core';
 import { HasTabIndexCtor } from '@koobiq/components/core';
@@ -53,20 +52,17 @@ import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
-import { Overlay } from '@angular/cdk/overlay';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
-import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { SelectionModel } from '@angular/cdk/collections';
 import { SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
-import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
 export class KbqOptionTooltip extends KbqTooltipTrigger implements AfterViewInit, OnDestroy {
-    constructor(option: KbqOption, overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality, focusMonitor: FocusMonitor);
+    constructor(option: KbqOption);
     // (undocumented)
     get isOverflown(): boolean;
     // (undocumented)
@@ -86,7 +82,7 @@ export class KbqOptionTooltip extends KbqTooltipTrigger implements AfterViewInit
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqOptionTooltip, "kbq-option", never, {}, {}, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqOptionTooltip, [null, null, null, null, null, null, null, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqOptionTooltip, never>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "KbqSelectMixinBase" needs to be exported by the entry point index.d.ts

--- a/tools/public_api_guard/components/timezone.api.md
+++ b/tools/public_api_guard/components/timezone.api.md
@@ -6,9 +6,7 @@
 
 import { AfterViewInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
-import { FocusMonitor } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
 import * as i10 from '@koobiq/components/select';
 import * as i11 from '@koobiq/components/icon';
@@ -23,12 +21,8 @@ import { KbqOption } from '@koobiq/components/core';
 import { KbqSelect } from '@koobiq/components/select';
 import { KbqSelectSearch } from '@koobiq/components/core';
 import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
-import { NgZone } from '@angular/core';
 import { OnDestroy } from '@angular/core';
-import { Overlay } from '@angular/cdk/overlay';
 import { PipeTransform } from '@angular/core';
-import { ScrollDispatcher } from '@angular/cdk/overlay';
-import { ViewContainerRef } from '@angular/core';
 
 // @public
 export function filterCitiesBySearchString(cities: string, searchPattern?: string): string;
@@ -83,7 +77,7 @@ export class KbqTimezoneOption extends KbqOption {
 
 // @public (undocumented)
 export class KbqTimezoneOptionTooltip extends KbqTooltipTrigger implements AfterViewInit, OnDestroy {
-    constructor(changeDetectorRef: ChangeDetectorRef, option: KbqTimezoneOption, overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality, focusMonitor: FocusMonitor);
+    constructor(changeDetectorRef: ChangeDetectorRef, option: KbqTimezoneOption);
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
@@ -95,7 +89,7 @@ export class KbqTimezoneOptionTooltip extends KbqTooltipTrigger implements After
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqTimezoneOptionTooltip, "kbq-timezone-option", never, {}, {}, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqTimezoneOptionTooltip, [null, null, null, null, null, null, null, null, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqTimezoneOptionTooltip, never>;
 }
 
 // @public (undocumented)

--- a/tools/public_api_guard/components/tooltip.api.md
+++ b/tools/public_api_guard/components/tooltip.api.md
@@ -46,7 +46,6 @@ export const KBQ_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER: {
 
 // @public (undocumented)
 export class KbqExtendedTooltipTrigger extends KbqTooltipTrigger {
-    constructor();
     // (undocumented)
     get content(): string | TemplateRef<any>;
     set content(content: string | TemplateRef<any>);
@@ -175,7 +174,6 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
 
 // @public (undocumented)
 export class KbqWarningTooltipTrigger extends KbqTooltipTrigger {
-    constructor();
     // (undocumented)
     get content(): string | TemplateRef<any>;
     set content(content: string | TemplateRef<any>);

--- a/tools/public_api_guard/components/tooltip.api.md
+++ b/tools/public_api_guard/components/tooltip.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-import { ChangeDetectorRef } from '@angular/core';
-import { Directionality } from '@angular/cdk/bidi';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
@@ -13,21 +11,17 @@ import * as i0 from '@angular/core';
 import * as i2 from '@angular/common';
 import * as i3 from '@angular/cdk/overlay';
 import { InjectionToken } from '@angular/core';
-import { Injector } from '@angular/core';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqPopUp } from '@koobiq/components/core';
 import { KbqPopUpTrigger } from '@koobiq/components/core';
-import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { Overlay } from '@angular/cdk/overlay';
 import { OverlayConfig } from '@angular/cdk/overlay';
 import { PopUpPlacements } from '@koobiq/components/core';
-import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { TemplateRef } from '@angular/core';
 import { Type } from '@angular/core';
-import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
 export const KBQ_TOOLTIP_OPEN_TIME: InjectionToken<() => ScrollStrategy>;
@@ -52,7 +46,7 @@ export const KBQ_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER: {
 
 // @public (undocumented)
 export class KbqExtendedTooltipTrigger extends KbqTooltipTrigger {
-    constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality, focusMonitor: FocusMonitor);
+    constructor();
     // (undocumented)
     get content(): string | TemplateRef<any>;
     set content(content: string | TemplateRef<any>);
@@ -66,12 +60,12 @@ export class KbqExtendedTooltipTrigger extends KbqTooltipTrigger {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqExtendedTooltipTrigger, "[kbqExtendedTooltip]", ["kbqExtendedTooltip"], { "content": { "alias": "kbqExtendedTooltip"; "required": false; }; "header": { "alias": "kbqTooltipHeader"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqExtendedTooltipTrigger, [null, null, null, null, null, null, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqExtendedTooltipTrigger, never>;
 }
 
 // @public (undocumented)
 export class KbqTooltipComponent extends KbqPopUp {
-    constructor(changeDetectorRef: ChangeDetectorRef, injector: Injector, openTime: any);
+    constructor(openTime: any);
     // (undocumented)
     elementRef: ElementRef;
     // (undocumented)
@@ -105,7 +99,7 @@ export function kbqTooltipScrollStrategyFactory(overlay: Overlay): () => ScrollS
 
 // @public (undocumented)
 export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> implements OnDestroy {
-    constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality, focusMonitor: FocusMonitor);
+    constructor();
     // (undocumented)
     arrow: boolean;
     // (undocumented)
@@ -150,6 +144,8 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
     // (undocumented)
     placementChange: EventEmitter<any>;
     // (undocumented)
+    protected scrollStrategy: () => ScrollStrategy;
+    // (undocumented)
     show(delay?: number): void;
     // (undocumented)
     get tooltipPlacement(): PopUpPlacements;
@@ -174,12 +170,12 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqTooltipTrigger, "[kbqTooltip]", ["kbqTooltip"], { "tooltipVisible": { "alias": "kbqVisible"; "required": false; }; "tooltipPlacement": { "alias": "kbqPlacement"; "required": false; }; "tooltipPlacementPriority": { "alias": "kbqPlacementPriority"; "required": false; }; "content": { "alias": "kbqTooltip"; "required": false; }; "disabled": { "alias": "kbqTooltipDisabled"; "required": false; }; "enterDelay": { "alias": "kbqEnterDelay"; "required": false; }; "leaveDelay": { "alias": "kbqLeaveDelay"; "required": false; }; "trigger": { "alias": "kbqTrigger"; "required": false; }; "customClass": { "alias": "kbqTooltipClass"; "required": false; }; "context": { "alias": "kbqTooltipContext"; "required": false; }; "color": { "alias": "kbqTooltipColor"; "required": false; }; "arrow": { "alias": "kbqTooltipArrow"; "required": false; }; "offset": { "alias": "kbqTooltipOffset"; "required": false; }; }, { "placementChange": "kbqPlacementChange"; "visibleChange": "kbqVisibleChange"; }, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqTooltipTrigger, [null, null, null, null, null, null, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqTooltipTrigger, never>;
 }
 
 // @public (undocumented)
 export class KbqWarningTooltipTrigger extends KbqTooltipTrigger {
-    constructor(overlay: Overlay, elementRef: ElementRef, ngZone: NgZone, scrollDispatcher: ScrollDispatcher, hostView: ViewContainerRef, scrollStrategy: any, direction: Directionality, focusMonitor: FocusMonitor);
+    constructor();
     // (undocumented)
     get content(): string | TemplateRef<any>;
     set content(content: string | TemplateRef<any>);
@@ -188,7 +184,7 @@ export class KbqWarningTooltipTrigger extends KbqTooltipTrigger {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqWarningTooltipTrigger, "[kbqWarningTooltip]", ["kbqWarningTooltip"], { "content": { "alias": "kbqWarningTooltip"; "required": false; }; }, {}, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqWarningTooltipTrigger, [null, null, null, null, null, null, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqWarningTooltipTrigger, never>;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
В KbqPopUp и KbqPopUpTrigger можно использовать inject для параметров, которые сейчас передаются в конструкторе (overlay, elementRef, ngZone, scrollDispatcher, hostView, scrollStrategy, direction).

Это позволит избежать передачу большого количества параметров при наследовании в:

KbqPasswordToggle
KbqPopoverConfirmTrigger
KbqPopoverTrigger
KbqOptionTooltip
KbqTooltipTrigger
KbqWarningTooltipTrigger
KbqExtendedTooltipTrigger
KbqTitleDirective
KbqEllipsisCenterDirective
KbqNavbarItem
KbqNavbarToggle
KbqTimezoneOptionTooltip

Так же из applyPopupMargins убрал inject(Renderer2), теперь он передается аргументом.