### PR TITLE
feat(icon): migrated to standalone

### DIFF
--- a/packages/components/icon/icon-button.component.ts
+++ b/packages/components/icon/icon-button.component.ts
@@ -16,6 +16,7 @@ import { CanColor, KBQ_FORM_FIELD_REF, KbqFormFieldRef } from '@koobiq/component
 import { KbqIcon } from './icon.component';
 
 @Component({
+    standalone: true,
     selector: `[kbq-icon-button]`,
     template: '<ng-content />',
     styleUrls: ['icon-button.scss', 'icon-button-tokens.scss'],

--- a/packages/components/icon/icon-item.component.ts
+++ b/packages/components/icon/icon-item.component.ts
@@ -13,6 +13,7 @@ import { CanColor, KBQ_FORM_FIELD_REF, KbqFormFieldRef } from '@koobiq/component
 import { KbqIcon } from './icon.component';
 
 @Component({
+    standalone: true,
     selector: `[kbq-icon-item]`,
     template: '<ng-content />',
     styleUrls: ['icon-item.scss', 'icon-item-tokens.scss'],

--- a/packages/components/icon/icon.component.ts
+++ b/packages/components/icon/icon.component.ts
@@ -31,6 +31,7 @@ export const KbqIconMixinBase: CanColorCtor & typeof KbqIconBase = mixinColor(
 );
 
 @Component({
+    standalone: true,
     selector: '[kbq-icon]',
     template: '<ng-content />',
     styleUrls: ['icon.scss', 'icon-tokens.scss'],

--- a/packages/components/icon/icon.module.ts
+++ b/packages/components/icon/icon.module.ts
@@ -1,24 +1,15 @@
-import { A11yModule } from '@angular/cdk/a11y';
-import { PlatformModule } from '@angular/cdk/platform';
 import { NgModule } from '@angular/core';
 import { KbqIconButton } from './icon-button.component';
 import { KbqIconItem } from './icon-item.component';
 import { KbqIcon } from './icon.component';
 
+const COMPONENTS = [
+    KbqIcon,
+    KbqIconButton,
+    KbqIconItem
+];
 @NgModule({
-    imports: [
-        A11yModule,
-        PlatformModule
-    ],
-    exports: [
-        KbqIcon,
-        KbqIconButton,
-        KbqIconItem
-    ],
-    declarations: [
-        KbqIcon,
-        KbqIconButton,
-        KbqIconItem
-    ]
+    imports: COMPONENTS,
+    exports: COMPONENTS
 })
 export class KbqIconModule {}

--- a/tools/public_api_guard/components/icon.api.md
+++ b/tools/public_api_guard/components/icon.api.md
@@ -11,8 +11,6 @@ import { ChangeDetectorRef } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import * as i0 from '@angular/core';
-import * as i4 from '@angular/cdk/a11y';
-import * as i5 from '@angular/cdk/platform';
 import { KbqFormFieldRef } from '@koobiq/components/core';
 import { OnDestroy } from '@angular/core';
 
@@ -40,7 +38,7 @@ export class KbqIcon extends KbqIconMixinBase implements CanColor, AfterContentI
     // (undocumented)
     updateMaxHeight(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqIcon, "[kbq-icon]", never, { "color": { "alias": "color"; "required": false; }; "small": { "alias": "small"; "required": false; }; "autoColor": { "alias": "autoColor"; "required": false; }; }, {}, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqIcon, "[kbq-icon]", never, { "color": { "alias": "color"; "required": false; }; "small": { "alias": "small"; "required": false; }; "autoColor": { "alias": "autoColor"; "required": false; }; }, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqIcon, [null, { attribute: "kbq-icon"; }, { optional: true; }, null]>;
 }
@@ -71,7 +69,7 @@ export class KbqIconButton extends KbqIcon implements OnDestroy, CanColor {
     get tabindex(): any;
     set tabindex(value: any);
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqIconButton, "[kbq-icon-button]", never, { "color": { "alias": "color"; "required": false; }; "small": { "alias": "small"; "required": false; }; "tabindex": { "alias": "tabindex"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, {}, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqIconButton, "[kbq-icon-button]", never, { "color": { "alias": "color"; "required": false; }; "small": { "alias": "small"; "required": false; }; "tabindex": { "alias": "tabindex"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; }, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqIconButton, [null, { attribute: "kbq-icon-button"; }, { optional: true; }, null, null]>;
 }
@@ -88,7 +86,7 @@ export class KbqIconItem extends KbqIcon implements CanColor {
     // (undocumented)
     name: string;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqIconItem, "[kbq-icon-item]", never, { "color": { "alias": "color"; "required": false; }; "fade": { "alias": "fade"; "required": false; }; "big": { "alias": "big"; "required": false; }; }, {}, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqIconItem, "[kbq-icon-item]", never, { "color": { "alias": "color"; "required": false; }; "fade": { "alias": "fade"; "required": false; }; "big": { "alias": "big"; "required": false; }; }, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqIconItem, [null, { attribute: "kbq-icon-item"; }, { optional: true; }, null]>;
 }
@@ -107,7 +105,7 @@ export class KbqIconModule {
     // Warning: (ae-forgotten-export) The symbol "i3" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<KbqIconModule, [typeof i1.KbqIcon, typeof i2.KbqIconButton, typeof i3.KbqIconItem], [typeof i4.A11yModule, typeof i5.PlatformModule], [typeof i1.KbqIcon, typeof i2.KbqIconButton, typeof i3.KbqIconItem]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<KbqIconModule, never, [typeof i1.KbqIcon, typeof i2.KbqIconButton, typeof i3.KbqIconItem], [typeof i1.KbqIcon, typeof i2.KbqIconButton, typeof i3.KbqIconItem]>;
 }
 
 // (No @packageDocumentation comment for this package)


### PR DESCRIPTION
хочется иметь возможность использовать `icon` в [hostDirectives](https://angular.dev/guide/directives/directive-composition-api)