### PR TITLE
feat(visual): added css-vars for font-family tokens and added default value for global tokens (#DS-2956)

### DIFF
--- a/packages/components/alert/alert-tokens.scss
+++ b/packages/components/alert/alert-tokens.scss
@@ -43,26 +43,32 @@
     --kbq-alert-font-title-line-height: 26px;
     --kbq-alert-font-title-letter-spacing: normal;
     --kbq-alert-font-title-font-weight: 600;
-    --kbq-alert-font-title-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-alert-font-title-text-transform: null;
     --kbq-alert-font-title-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-alert-font-title-compact-font-size: 16px;
     --kbq-alert-font-title-compact-line-height: 24px;
     --kbq-alert-font-title-compact-letter-spacing: -0.011em;
     --kbq-alert-font-title-compact-font-weight: 600;
-    --kbq-alert-font-title-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-alert-font-title-compact-text-transform: null;
     --kbq-alert-font-title-compact-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-alert-font-text-font-size: 14px;
     --kbq-alert-font-text-line-height: 20px;
     --kbq-alert-font-text-letter-spacing: -0.006em;
     --kbq-alert-font-text-font-weight: normal;
-    --kbq-alert-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-alert-font-text-text-transform: null;
     --kbq-alert-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-alert-font-title-font-family: var(--kbq-typography-subheading-font-family);
+    --kbq-alert-font-title-compact-font-family: var(--kbq-typography-text-big-strong-font-family);
+    --kbq-alert-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-subheading-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-big-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/badge/badge-tokens.scss
+++ b/packages/components/badge/badge-tokens.scss
@@ -26,34 +26,41 @@
     --kbq-badge-font-normal-default-line-height: 20px;
     --kbq-badge-font-normal-default-letter-spacing: -0.006em;
     --kbq-badge-font-normal-default-font-weight: 500;
-    --kbq-badge-font-normal-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-badge-font-normal-default-text-transform: null;
     --kbq-badge-font-normal-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-badge-font-normal-caption-font-size: 14px;
     --kbq-badge-font-normal-caption-line-height: 20px;
     --kbq-badge-font-normal-caption-letter-spacing: -0.006em;
     --kbq-badge-font-normal-caption-font-weight: normal;
-    --kbq-badge-font-normal-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-badge-font-normal-caption-text-transform: null;
     --kbq-badge-font-normal-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-badge-font-compact-default-font-size: 12px;
     --kbq-badge-font-compact-default-line-height: 16px;
     --kbq-badge-font-compact-default-letter-spacing: normal;
     --kbq-badge-font-compact-default-font-weight: 500;
-    --kbq-badge-font-compact-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-badge-font-compact-default-text-transform: null;
     --kbq-badge-font-compact-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-badge-font-compact-caption-font-size: 12px;
     --kbq-badge-font-compact-caption-line-height: 16px;
     --kbq-badge-font-compact-caption-letter-spacing: normal;
     --kbq-badge-font-compact-caption-font-weight: normal;
-    --kbq-badge-font-compact-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-badge-font-compact-caption-text-transform: null;
     --kbq-badge-font-compact-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-badge-font-normal-default-font-family: var(--kbq-typography-text-normal-medium-font-family);
+    --kbq-badge-font-normal-caption-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-badge-font-compact-default-font-family: var(--kbq-typography-text-compact-medium-font-family);
+    --kbq-badge-font-compact-caption-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-medium-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-medium-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/button-toggle/button-toggle-tokens.scss
+++ b/packages/components/button-toggle/button-toggle-tokens.scss
@@ -13,10 +13,14 @@
     --kbq-button-toggle-font-item-line-height: 20px;
     --kbq-button-toggle-font-item-letter-spacing: -0.006em;
     --kbq-button-toggle-font-item-font-weight: 500;
-    --kbq-button-toggle-font-item-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-button-toggle-font-item-text-transform: null;
     --kbq-button-toggle-font-item-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-button-toggle-font-item-font-family: var(--kbq-typography-text-normal-medium-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-medium-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/button/button-tokens.scss
+++ b/packages/components/button/button-tokens.scss
@@ -8,10 +8,14 @@
     --kbq-button-font-default-line-height: 20px;
     --kbq-button-font-default-letter-spacing: -0.006em;
     --kbq-button-font-default-font-weight: 500;
-    --kbq-button-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-button-font-default-text-transform: null;
     --kbq-button-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-button-font-default-font-family: var(--kbq-typography-text-normal-medium-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-medium-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/checkbox/checkbox-tokens.scss
+++ b/packages/components/checkbox/checkbox-tokens.scss
@@ -15,34 +15,39 @@
     --kbq-checkbox-font-normal-label-line-height: 20px;
     --kbq-checkbox-font-normal-label-letter-spacing: -0.006em;
     --kbq-checkbox-font-normal-label-font-weight: normal;
-    --kbq-checkbox-font-normal-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-checkbox-font-normal-label-text-transform: null;
     --kbq-checkbox-font-normal-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-checkbox-font-normal-caption-font-size: 12px;
     --kbq-checkbox-font-normal-caption-line-height: 16px;
     --kbq-checkbox-font-normal-caption-letter-spacing: normal;
     --kbq-checkbox-font-normal-caption-font-weight: normal;
-    --kbq-checkbox-font-normal-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-checkbox-font-normal-caption-text-transform: null;
     --kbq-checkbox-font-normal-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-checkbox-font-big-label-font-size: 16px;
     --kbq-checkbox-font-big-label-line-height: 24px;
     --kbq-checkbox-font-big-label-letter-spacing: -0.011em;
     --kbq-checkbox-font-big-label-font-weight: normal;
-    --kbq-checkbox-font-big-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-checkbox-font-big-label-text-transform: null;
     --kbq-checkbox-font-big-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-checkbox-font-big-caption-font-size: 14px;
     --kbq-checkbox-font-big-caption-line-height: 20px;
     --kbq-checkbox-font-big-caption-letter-spacing: -0.006em;
     --kbq-checkbox-font-big-caption-font-weight: normal;
-    --kbq-checkbox-font-big-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-checkbox-font-big-caption-text-transform: null;
     --kbq-checkbox-font-big-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-checkbox-font-normal-label-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-checkbox-font-normal-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-checkbox-font-big-label-font-family: var(--kbq-typography-text-big-font-family);
+    --kbq-checkbox-font-big-caption-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/code-block/code-block-tokens.scss
+++ b/packages/components/code-block/code-block-tokens.scss
@@ -24,7 +24,6 @@
     --kbq-code-block-font-default-line-height: 20px;
     --kbq-code-block-font-default-letter-spacing: normal;
     --kbq-code-block-font-default-font-weight: normal;
-    --kbq-code-block-font-default-font-family: 'JetBrains Mono', 'Roboto Mono', 'Consolas', 'Menlo', 'Monaco', monospace;
     --kbq-code-block-font-default-text-transform: null;
     --kbq-code-block-font-default-font-feature-settings: initial;
     --kbq-code-block-font-hljs-addition-font-style: null;
@@ -129,6 +128,12 @@
     --kbq-code-block-font-hljs-variable-constant-font-weight: null;
     --kbq-code-block-font-hljs-variable-language-font-style: null;
     --kbq-code-block-font-hljs-variable-language-font-weight: null;
+    --kbq-code-block-font-default-font-family: var(--kbq-typography-mono-codeblock-font-family);
+}
+
+:root {
+    --kbq-typography-mono-codeblock-font-family: 'JetBrains Mono', 'Roboto Mono', 'Consolas', 'Menlo', 'Monaco',
+        monospace;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/core/forms/forms-tokens.scss
+++ b/packages/components/core/forms/forms-tokens.scss
@@ -14,18 +14,23 @@
     --kbq-forms-font-label-line-height: 20px;
     --kbq-forms-font-label-letter-spacing: -0.006em;
     --kbq-forms-font-label-font-weight: normal;
-    --kbq-forms-font-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-forms-font-label-text-transform: null;
     --kbq-forms-font-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-forms-font-legend-font-size: 18px;
     --kbq-forms-font-legend-line-height: 26px;
     --kbq-forms-font-legend-letter-spacing: normal;
     --kbq-forms-font-legend-font-weight: 600;
-    --kbq-forms-font-legend-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-forms-font-legend-text-transform: null;
     --kbq-forms-font-legend-font-feature-settings: 'calt', 'kern', 'liga';
+    --kbq-forms-font-label-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-forms-font-legend-font-family: var(--kbq-typography-subheading-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-subheading-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/core/option/optgroup-tokens.scss
+++ b/packages/components/core/option/optgroup-tokens.scss
@@ -5,10 +5,14 @@
     --kbq-optgroup-font-default-line-height: 26px;
     --kbq-optgroup-font-default-letter-spacing: normal;
     --kbq-optgroup-font-default-font-weight: 600;
-    --kbq-optgroup-font-default-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-optgroup-font-default-text-transform: null;
     --kbq-optgroup-font-default-font-feature-settings: 'calt', 'kern', 'liga';
+    --kbq-optgroup-font-default-font-family: var(--kbq-typography-subheading-font-family);
+}
+
+:root {
+    --kbq-typography-subheading-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/core/option/option-tokens.scss
+++ b/packages/components/core/option/option-tokens.scss
@@ -21,32 +21,24 @@
     --kbq-list-font-text-line-height: 20px;
     --kbq-list-font-text-letter-spacing: -0.006em;
     --kbq-list-font-text-font-weight: normal;
-    --kbq-list-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-text-text-transform: null;
     --kbq-list-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-caption-font-size: 12px;
     --kbq-list-font-caption-line-height: 16px;
     --kbq-list-font-caption-letter-spacing: normal;
     --kbq-list-font-caption-font-weight: normal;
-    --kbq-list-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-caption-text-transform: null;
     --kbq-list-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-header-font-size: 16px;
     --kbq-list-font-header-line-height: 24px;
     --kbq-list-font-header-letter-spacing: -0.011em;
     --kbq-list-font-header-font-weight: 600;
-    --kbq-list-font-header-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-header-text-transform: null;
     --kbq-list-font-header-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-subheading-font-size: 12px;
     --kbq-list-font-subheading-line-height: 16px;
     --kbq-list-font-subheading-letter-spacing: 1px;
     --kbq-list-font-subheading-font-weight: 500;
-    --kbq-list-font-subheading-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-list-font-subheading-text-transform: uppercase;
     --kbq-list-font-subheading-font-feature-settings: 'calt', 'case', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-option-size-horizontal-padding: 12px;
@@ -56,10 +48,26 @@
     --kbq-option-font-default-line-height: 24px;
     --kbq-option-font-default-letter-spacing: -0.011em;
     --kbq-option-font-default-font-weight: normal;
-    --kbq-option-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-option-font-default-text-transform: null;
     --kbq-option-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-list-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-list-font-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-list-font-header-font-family: var(--kbq-typography-text-big-strong-font-family);
+    --kbq-list-font-subheading-font-family: var(--kbq-typography-caps-compact-strong-font-family);
+    --kbq-option-font-default-font-family: var(--kbq-typography-text-big-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-caps-compact-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-big-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/core/selection/pseudo-checkbox/pseudo-checkbox-tokens.scss
+++ b/packages/components/core/selection/pseudo-checkbox/pseudo-checkbox-tokens.scss
@@ -15,34 +15,39 @@
     --kbq-checkbox-font-normal-label-line-height: 20px;
     --kbq-checkbox-font-normal-label-letter-spacing: -0.006em;
     --kbq-checkbox-font-normal-label-font-weight: normal;
-    --kbq-checkbox-font-normal-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-checkbox-font-normal-label-text-transform: null;
     --kbq-checkbox-font-normal-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-checkbox-font-normal-caption-font-size: 12px;
     --kbq-checkbox-font-normal-caption-line-height: 16px;
     --kbq-checkbox-font-normal-caption-letter-spacing: normal;
     --kbq-checkbox-font-normal-caption-font-weight: normal;
-    --kbq-checkbox-font-normal-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-checkbox-font-normal-caption-text-transform: null;
     --kbq-checkbox-font-normal-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-checkbox-font-big-label-font-size: 16px;
     --kbq-checkbox-font-big-label-line-height: 24px;
     --kbq-checkbox-font-big-label-letter-spacing: -0.011em;
     --kbq-checkbox-font-big-label-font-weight: normal;
-    --kbq-checkbox-font-big-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-checkbox-font-big-label-text-transform: null;
     --kbq-checkbox-font-big-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-checkbox-font-big-caption-font-size: 14px;
     --kbq-checkbox-font-big-caption-line-height: 20px;
     --kbq-checkbox-font-big-caption-letter-spacing: -0.006em;
     --kbq-checkbox-font-big-caption-font-weight: normal;
-    --kbq-checkbox-font-big-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-checkbox-font-big-caption-text-transform: null;
     --kbq-checkbox-font-big-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-checkbox-font-normal-label-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-checkbox-font-normal-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-checkbox-font-big-label-font-family: var(--kbq-typography-text-big-font-family);
+    --kbq-checkbox-font-big-caption-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/datepicker/datepicker-tokens.scss
+++ b/packages/components/datepicker/datepicker-tokens.scss
@@ -13,10 +13,14 @@
     --kbq-datepicker-font-text-line-height: 20px;
     --kbq-datepicker-font-text-letter-spacing: -0.006em;
     --kbq-datepicker-font-text-font-weight: normal;
-    --kbq-datepicker-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-datepicker-font-text-text-transform: null;
     --kbq-datepicker-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-datepicker-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/dl/dl-tokens.scss
+++ b/packages/components/dl/dl-tokens.scss
@@ -7,18 +7,21 @@
     --kbq-description-list-font-term-line-height: 20px;
     --kbq-description-list-font-term-letter-spacing: -0.006em;
     --kbq-description-list-font-term-font-weight: normal;
-    --kbq-description-list-font-term-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-description-list-font-term-text-transform: null;
     --kbq-description-list-font-term-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-description-list-font-description-font-size: 14px;
     --kbq-description-list-font-description-line-height: 20px;
     --kbq-description-list-font-description-letter-spacing: -0.006em;
     --kbq-description-list-font-description-font-weight: normal;
-    --kbq-description-list-font-description-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-description-list-font-description-text-transform: null;
     --kbq-description-list-font-description-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-description-list-font-term-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-description-list-font-description-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/dropdown/dropdown-tokens.scss
+++ b/packages/components/dropdown/dropdown-tokens.scss
@@ -20,34 +20,41 @@
     --kbq-list-font-text-line-height: 20px;
     --kbq-list-font-text-letter-spacing: -0.006em;
     --kbq-list-font-text-font-weight: normal;
-    --kbq-list-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-text-text-transform: null;
     --kbq-list-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-caption-font-size: 12px;
     --kbq-list-font-caption-line-height: 16px;
     --kbq-list-font-caption-letter-spacing: normal;
     --kbq-list-font-caption-font-weight: normal;
-    --kbq-list-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-caption-text-transform: null;
     --kbq-list-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-header-font-size: 16px;
     --kbq-list-font-header-line-height: 24px;
     --kbq-list-font-header-letter-spacing: -0.011em;
     --kbq-list-font-header-font-weight: 600;
-    --kbq-list-font-header-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-header-text-transform: null;
     --kbq-list-font-header-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-subheading-font-size: 12px;
     --kbq-list-font-subheading-line-height: 16px;
     --kbq-list-font-subheading-letter-spacing: 1px;
     --kbq-list-font-subheading-font-weight: 500;
-    --kbq-list-font-subheading-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-list-font-subheading-text-transform: uppercase;
     --kbq-list-font-subheading-font-feature-settings: 'calt', 'case', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-list-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-list-font-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-list-font-header-font-family: var(--kbq-typography-text-big-strong-font-family);
+    --kbq-list-font-subheading-font-family: var(--kbq-typography-caps-compact-strong-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-caps-compact-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/empty-state/empty-state-tokens.scss
+++ b/packages/components/empty-state/empty-state-tokens.scss
@@ -19,34 +19,39 @@
     --kbq-empty-state-font-big-title-line-height: 32px;
     --kbq-empty-state-font-big-title-letter-spacing: normal;
     --kbq-empty-state-font-big-title-font-weight: 700;
-    --kbq-empty-state-font-big-title-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-empty-state-font-big-title-text-transform: null;
     --kbq-empty-state-font-big-title-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-empty-state-font-big-text-font-size: 14px;
     --kbq-empty-state-font-big-text-line-height: 20px;
     --kbq-empty-state-font-big-text-letter-spacing: -0.006em;
     --kbq-empty-state-font-big-text-font-weight: normal;
-    --kbq-empty-state-font-big-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-empty-state-font-big-text-text-transform: null;
     --kbq-empty-state-font-big-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-empty-state-font-normal-title-font-size: 16px;
     --kbq-empty-state-font-normal-title-line-height: 24px;
     --kbq-empty-state-font-normal-title-letter-spacing: -0.011em;
     --kbq-empty-state-font-normal-title-font-weight: 600;
-    --kbq-empty-state-font-normal-title-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-empty-state-font-normal-title-text-transform: null;
     --kbq-empty-state-font-normal-title-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-empty-state-font-normal-text-font-size: 14px;
     --kbq-empty-state-font-normal-text-line-height: 20px;
     --kbq-empty-state-font-normal-text-letter-spacing: -0.006em;
     --kbq-empty-state-font-normal-text-font-weight: normal;
-    --kbq-empty-state-font-normal-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-empty-state-font-normal-text-text-transform: null;
     --kbq-empty-state-font-normal-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-empty-state-font-big-title-font-family: var(--kbq-typography-headline-font-family);
+    --kbq-empty-state-font-big-text-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-empty-state-font-normal-title-font-family: var(--kbq-typography-text-big-strong-font-family);
+    --kbq-empty-state-font-normal-text-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-headline-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -22,42 +22,46 @@
     --kbq-file-upload-font-single-text-block-line-height: 20px;
     --kbq-file-upload-font-single-text-block-letter-spacing: -0.006em;
     --kbq-file-upload-font-single-text-block-font-weight: normal;
-    --kbq-file-upload-font-single-text-block-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-file-upload-font-single-text-block-text-transform: null;
     --kbq-file-upload-font-single-text-block-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-file-upload-font-multiple-title-font-size: 18px;
     --kbq-file-upload-font-multiple-title-line-height: 26px;
     --kbq-file-upload-font-multiple-title-letter-spacing: normal;
     --kbq-file-upload-font-multiple-title-font-weight: 600;
-    --kbq-file-upload-font-multiple-title-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont,
-        'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
     --kbq-file-upload-font-multiple-title-text-transform: null;
     --kbq-file-upload-font-multiple-title-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-file-upload-font-multiple-text-block-font-size: 14px;
     --kbq-file-upload-font-multiple-text-block-line-height: 20px;
     --kbq-file-upload-font-multiple-text-block-letter-spacing: -0.006em;
     --kbq-file-upload-font-multiple-text-block-font-weight: normal;
-    --kbq-file-upload-font-multiple-text-block-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-file-upload-font-multiple-text-block-text-transform: null;
     --kbq-file-upload-font-multiple-text-block-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-file-upload-font-multiple-grid-font-size: 14px;
     --kbq-file-upload-font-multiple-grid-line-height: 20px;
     --kbq-file-upload-font-multiple-grid-letter-spacing: -0.006em;
     --kbq-file-upload-font-multiple-grid-font-weight: normal;
-    --kbq-file-upload-font-multiple-grid-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-file-upload-font-multiple-grid-text-transform: null;
     --kbq-file-upload-font-multiple-grid-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-form-field-hint-font-text-font-size: 12px;
     --kbq-form-field-hint-font-text-line-height: 16px;
     --kbq-form-field-hint-font-text-letter-spacing: normal;
     --kbq-form-field-hint-font-text-font-weight: normal;
-    --kbq-form-field-hint-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-form-field-hint-font-text-text-transform: null;
     --kbq-form-field-hint-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-file-upload-font-single-text-block-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-file-upload-font-multiple-title-font-family: var(--kbq-typography-subheading-font-family);
+    --kbq-file-upload-font-multiple-text-block-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-file-upload-font-multiple-grid-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-form-field-hint-font-text-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-subheading-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/form-field/form-field-tokens.scss
+++ b/packages/components/form-field/form-field-tokens.scss
@@ -12,8 +12,6 @@
     --kbq-form-field-font-text-line-height: 20px;
     --kbq-form-field-font-text-letter-spacing: -0.006em;
     --kbq-form-field-font-text-font-weight: normal;
-    --kbq-form-field-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-form-field-font-text-text-transform: null;
     --kbq-form-field-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-form-field-hint-size-margin-top: 4px;
@@ -22,10 +20,17 @@
     --kbq-form-field-hint-font-text-line-height: 16px;
     --kbq-form-field-hint-font-text-letter-spacing: normal;
     --kbq-form-field-hint-font-text-font-weight: normal;
-    --kbq-form-field-hint-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-form-field-hint-font-text-text-transform: null;
     --kbq-form-field-hint-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-form-field-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-form-field-hint-font-text-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/form-field/hint-tokens.scss
+++ b/packages/components/form-field/hint-tokens.scss
@@ -7,18 +7,23 @@
     --kbq-hint-font-normal-text-line-height: 20px;
     --kbq-hint-font-normal-text-letter-spacing: -0.006em;
     --kbq-hint-font-normal-text-font-weight: 500;
-    --kbq-hint-font-normal-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-hint-font-normal-text-text-transform: null;
     --kbq-hint-font-normal-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-hint-font-compact-text-font-size: 12px;
     --kbq-hint-font-compact-text-line-height: 16px;
     --kbq-hint-font-compact-text-letter-spacing: normal;
     --kbq-hint-font-compact-text-font-weight: normal;
-    --kbq-hint-font-compact-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-hint-font-compact-text-text-transform: null;
     --kbq-hint-font-compact-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-hint-font-normal-text-font-family: var(--kbq-typography-text-normal-medium-font-family);
+    --kbq-hint-font-compact-text-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-medium-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/input/input-tokens.scss
+++ b/packages/components/input/input-tokens.scss
@@ -5,8 +5,12 @@
     --kbq-input-font-text-line-height: 20px;
     --kbq-input-font-text-letter-spacing: -0.006em;
     --kbq-input-font-text-font-weight: normal;
-    --kbq-input-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-input-font-text-text-transform: null;
     --kbq-input-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-input-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }

--- a/packages/components/link/link-tokens.scss
+++ b/packages/components/link/link-tokens.scss
@@ -8,26 +8,32 @@
     --kbq-link-font-compact-line-height: 16px;
     --kbq-link-font-compact-letter-spacing: normal;
     --kbq-link-font-compact-font-weight: normal;
-    --kbq-link-font-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-link-font-compact-text-transform: null;
     --kbq-link-font-compact-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-link-font-normal-font-size: 14px;
     --kbq-link-font-normal-line-height: 20px;
     --kbq-link-font-normal-letter-spacing: -0.006em;
     --kbq-link-font-normal-font-weight: normal;
-    --kbq-link-font-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-link-font-normal-text-transform: null;
     --kbq-link-font-normal-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-link-font-big-font-size: 16px;
     --kbq-link-font-big-line-height: 24px;
     --kbq-link-font-big-letter-spacing: -0.011em;
     --kbq-link-font-big-font-weight: normal;
-    --kbq-link-font-big-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-link-font-big-text-transform: null;
     --kbq-link-font-big-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-link-font-compact-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-link-font-normal-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-link-font-big-font-family: var(--kbq-typography-text-big-font-family);
+}
+
+:root {
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/list/list-tokens.scss
+++ b/packages/components/list/list-tokens.scss
@@ -17,34 +17,41 @@
     --kbq-list-font-text-line-height: 20px;
     --kbq-list-font-text-letter-spacing: -0.006em;
     --kbq-list-font-text-font-weight: normal;
-    --kbq-list-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-text-text-transform: null;
     --kbq-list-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-caption-font-size: 12px;
     --kbq-list-font-caption-line-height: 16px;
     --kbq-list-font-caption-letter-spacing: normal;
     --kbq-list-font-caption-font-weight: normal;
-    --kbq-list-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-caption-text-transform: null;
     --kbq-list-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-header-font-size: 16px;
     --kbq-list-font-header-line-height: 24px;
     --kbq-list-font-header-letter-spacing: -0.011em;
     --kbq-list-font-header-font-weight: 600;
-    --kbq-list-font-header-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-list-font-header-text-transform: null;
     --kbq-list-font-header-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-list-font-subheading-font-size: 12px;
     --kbq-list-font-subheading-line-height: 16px;
     --kbq-list-font-subheading-letter-spacing: 1px;
     --kbq-list-font-subheading-font-weight: 500;
-    --kbq-list-font-subheading-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-list-font-subheading-text-transform: uppercase;
     --kbq-list-font-subheading-font-feature-settings: 'calt', 'case', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-list-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-list-font-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-list-font-header-font-family: var(--kbq-typography-text-big-strong-font-family);
+    --kbq-list-font-subheading-font-family: var(--kbq-typography-caps-compact-strong-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-caps-compact-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/loader-overlay/loader-overlay-tokens.scss
+++ b/packages/components/loader-overlay/loader-overlay-tokens.scss
@@ -9,34 +9,39 @@
     --kbq-loader-overlay-font-big-text-line-height: 26px;
     --kbq-loader-overlay-font-big-text-letter-spacing: normal;
     --kbq-loader-overlay-font-big-text-font-weight: 600;
-    --kbq-loader-overlay-font-big-text-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-loader-overlay-font-big-text-text-transform: null;
     --kbq-loader-overlay-font-big-text-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-loader-overlay-font-big-caption-font-size: 14px;
     --kbq-loader-overlay-font-big-caption-line-height: 20px;
     --kbq-loader-overlay-font-big-caption-letter-spacing: -0.006em;
     --kbq-loader-overlay-font-big-caption-font-weight: normal;
-    --kbq-loader-overlay-font-big-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-loader-overlay-font-big-caption-text-transform: null;
     --kbq-loader-overlay-font-big-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-loader-overlay-font-compact-text-font-size: 14px;
     --kbq-loader-overlay-font-compact-text-line-height: 20px;
     --kbq-loader-overlay-font-compact-text-letter-spacing: -0.006em;
     --kbq-loader-overlay-font-compact-text-font-weight: normal;
-    --kbq-loader-overlay-font-compact-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-loader-overlay-font-compact-text-text-transform: null;
     --kbq-loader-overlay-font-compact-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-loader-overlay-font-compact-caption-font-size: 12px;
     --kbq-loader-overlay-font-compact-caption-line-height: 16px;
     --kbq-loader-overlay-font-compact-caption-letter-spacing: normal;
     --kbq-loader-overlay-font-compact-caption-font-weight: normal;
-    --kbq-loader-overlay-font-compact-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-loader-overlay-font-compact-caption-text-transform: null;
     --kbq-loader-overlay-font-compact-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-loader-overlay-font-big-text-font-family: var(--kbq-typography-subheading-font-family);
+    --kbq-loader-overlay-font-big-caption-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-loader-overlay-font-compact-text-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-loader-overlay-font-compact-caption-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-subheading-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/markdown/markdown-tokens.scss
+++ b/packages/components/markdown/markdown-tokens.scss
@@ -6,8 +6,6 @@
     --kbq-markdown-h1-font-default-line-height: 44px;
     --kbq-markdown-h1-font-default-letter-spacing: normal;
     --kbq-markdown-h1-font-default-font-weight: 400;
-    --kbq-markdown-h1-font-default-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-markdown-h1-font-default-text-transform: null;
     --kbq-markdown-h1-font-default-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-markdown-h2-size-max-width: 650px;
@@ -17,8 +15,6 @@
     --kbq-markdown-h2-font-default-line-height: 32px;
     --kbq-markdown-h2-font-default-letter-spacing: normal;
     --kbq-markdown-h2-font-default-font-weight: 700;
-    --kbq-markdown-h2-font-default-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-markdown-h2-font-default-text-transform: null;
     --kbq-markdown-h2-font-default-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-markdown-h3-size-max-width: 650px;
@@ -28,8 +24,6 @@
     --kbq-markdown-h3-font-default-line-height: 28px;
     --kbq-markdown-h3-font-default-letter-spacing: normal;
     --kbq-markdown-h3-font-default-font-weight: 700;
-    --kbq-markdown-h3-font-default-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-markdown-h3-font-default-text-transform: null;
     --kbq-markdown-h3-font-default-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-markdown-h4-size-max-width: 650px;
@@ -39,8 +33,6 @@
     --kbq-markdown-h4-font-default-line-height: 26px;
     --kbq-markdown-h4-font-default-letter-spacing: normal;
     --kbq-markdown-h4-font-default-font-weight: 700;
-    --kbq-markdown-h4-font-default-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-markdown-h4-font-default-text-transform: null;
     --kbq-markdown-h4-font-default-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-markdown-h5-size-max-width: 650px;
@@ -50,8 +42,6 @@
     --kbq-markdown-h5-font-default-line-height: 24px;
     --kbq-markdown-h5-font-default-letter-spacing: -0.011em;
     --kbq-markdown-h5-font-default-font-weight: 700;
-    --kbq-markdown-h5-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-h5-font-default-text-transform: null;
     --kbq-markdown-h5-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-markdown-h6-size-max-width: 650px;
@@ -61,8 +51,6 @@
     --kbq-markdown-h6-font-default-line-height: 20px;
     --kbq-markdown-h6-font-default-letter-spacing: 0.08em;
     --kbq-markdown-h6-font-default-font-weight: 500;
-    --kbq-markdown-h6-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-h6-font-default-text-transform: uppercase;
     --kbq-markdown-h6-font-default-font-feature-settings: 'calt', 'case', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-markdown-p-size-max-width: 650px;
@@ -72,8 +60,6 @@
     --kbq-markdown-p-font-default-line-height: 24px;
     --kbq-markdown-p-font-default-letter-spacing: -0.011em;
     --kbq-markdown-p-font-default-font-weight: normal;
-    --kbq-markdown-p-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-p-font-default-text-transform: null;
     --kbq-markdown-p-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-markdown-list-size-max-width: 650px;
@@ -87,8 +73,6 @@
     --kbq-markdown-list-font-default-line-height: 24px;
     --kbq-markdown-list-font-default-letter-spacing: -0.011em;
     --kbq-markdown-list-font-default-font-weight: normal;
-    --kbq-markdown-list-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-list-font-default-text-transform: null;
     --kbq-markdown-list-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-markdown-blockquote-size-max-width: 650px;
@@ -102,8 +86,6 @@
     --kbq-markdown-blockquote-font-default-line-height: 24px;
     --kbq-markdown-blockquote-font-default-letter-spacing: -0.011em;
     --kbq-markdown-blockquote-font-default-font-weight: normal;
-    --kbq-markdown-blockquote-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-markdown-blockquote-font-default-text-transform: null;
     --kbq-markdown-blockquote-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-markdown-code-size-max-width: 650px;
@@ -117,8 +99,6 @@
     --kbq-markdown-code-font-default-line-height: 24px;
     --kbq-markdown-code-font-default-letter-spacing: normal;
     --kbq-markdown-code-font-default-font-weight: normal;
-    --kbq-markdown-code-font-default-font-family: 'JetBrains Mono', 'Roboto Mono', 'Consolas', 'Menlo', 'Monaco',
-        monospace;
     --kbq-markdown-code-font-default-text-transform: null;
     --kbq-markdown-code-font-default-font-feature-settings: initial;
     --kbq-markdown-link-size-icon-margin: 2px;
@@ -128,8 +108,6 @@
     --kbq-markdown-link-font-default-line-height: 24px;
     --kbq-markdown-link-font-default-letter-spacing: -0.011em;
     --kbq-markdown-link-font-default-font-weight: normal;
-    --kbq-markdown-link-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-link-font-default-text-transform: null;
     --kbq-markdown-link-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-markdown-image-size-max-width: 650px;
@@ -141,8 +119,6 @@
     --kbq-markdown-image-font-caption-line-height: 20px;
     --kbq-markdown-image-font-caption-letter-spacing: -0.006em;
     --kbq-markdown-image-font-caption-font-weight: normal;
-    --kbq-markdown-image-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-markdown-image-font-caption-text-transform: null;
     --kbq-markdown-image-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-markdown-hr-size-width: 1px;
@@ -154,16 +130,12 @@
     --kbq-markdown-table-font-header-line-height: 20px;
     --kbq-markdown-table-font-header-letter-spacing: -0.006em;
     --kbq-markdown-table-font-header-font-weight: normal;
-    --kbq-markdown-table-font-header-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-table-font-header-text-transform: null;
     --kbq-markdown-table-font-header-font-feature-settings: 'calt', 'ss01', 'ss04', 'tnum';
     --kbq-markdown-table-font-body-font-size: 16px;
     --kbq-markdown-table-font-body-line-height: 24px;
     --kbq-markdown-table-font-body-letter-spacing: normal;
     --kbq-markdown-table-font-body-font-weight: normal;
-    --kbq-markdown-table-font-body-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-table-font-body-text-transform: null;
     --kbq-markdown-table-font-body-font-feature-settings: 'calt', 'ss01', 'ss04', 'tnum';
     --kbq-markdown-size-max-width: 650px;
@@ -171,10 +143,48 @@
     --kbq-markdown-font-default-line-height: 24px;
     --kbq-markdown-font-default-letter-spacing: -0.011em;
     --kbq-markdown-font-default-font-weight: normal;
-    --kbq-markdown-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-markdown-font-default-text-transform: null;
     --kbq-markdown-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-markdown-h1-font-default-font-family: var(--kbq-md-typography-md-h1-font-family);
+    --kbq-markdown-h2-font-default-font-family: var(--kbq-md-typography-md-h2-font-family);
+    --kbq-markdown-h3-font-default-font-family: var(--kbq-md-typography-md-h3-font-family);
+    --kbq-markdown-h4-font-default-font-family: var(--kbq-md-typography-md-h4-font-family);
+    --kbq-markdown-h5-font-default-font-family: var(--kbq-md-typography-md-h5-font-family);
+    --kbq-markdown-h6-font-default-font-family: var(--kbq-md-typography-md-h6-font-family);
+    --kbq-markdown-p-font-default-font-family: var(--kbq-md-typography-md-body-font-family);
+    --kbq-markdown-list-font-default-font-family: var(--kbq-md-typography-md-body-font-family);
+    --kbq-markdown-blockquote-font-default-font-family: var(--kbq-md-typography-md-body-font-family);
+    --kbq-markdown-code-font-default-font-family: var(--kbq-md-typography-md-body-mono-font-family);
+    --kbq-markdown-link-font-default-font-family: var(--kbq-md-typography-md-body-font-family);
+    --kbq-markdown-image-font-caption-font-family: var(--kbq-md-typography-md-caption-font-family);
+    --kbq-markdown-table-font-header-font-family: var(--kbq-md-typography-md-table-header-font-family);
+    --kbq-markdown-table-font-body-font-family: var(--kbq-md-typography-md-table-cell-font-family);
+    --kbq-markdown-font-default-font-family: var(--kbq-md-typography-md-body-font-family);
+}
+
+:root {
+    --kbq-md-typography-md-h1-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-md-typography-md-h2-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-md-typography-md-h3-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-md-typography-md-h4-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-md-typography-md-h5-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
+    --kbq-md-typography-md-h6-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
+    --kbq-md-typography-md-body-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-md-typography-md-body-mono-font-family: 'JetBrains Mono', 'Roboto Mono', 'Consolas', 'Menlo', 'Monaco',
+        monospace;
+    --kbq-md-typography-md-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-md-typography-md-table-header-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-md-typography-md-table-cell-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/modal/modal-tokens.scss
+++ b/packages/components/modal/modal-tokens.scss
@@ -19,18 +19,23 @@
     --kbq-modal-font-header-line-height: 28px;
     --kbq-modal-font-header-letter-spacing: normal;
     --kbq-modal-font-header-font-weight: 700;
-    --kbq-modal-font-header-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-modal-font-header-text-transform: null;
     --kbq-modal-font-header-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-modal-font-content-font-size: 14px;
     --kbq-modal-font-content-line-height: 20px;
     --kbq-modal-font-content-letter-spacing: -0.006em;
     --kbq-modal-font-content-font-weight: normal;
-    --kbq-modal-font-content-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-modal-font-content-text-transform: null;
     --kbq-modal-font-content-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-modal-font-header-font-family: var(--kbq-typography-title-font-family);
+    --kbq-modal-font-content-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-title-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/navbar/navbar-tokens.scss
+++ b/packages/components/navbar/navbar-tokens.scss
@@ -21,11 +21,15 @@
     --kbq-navbar-font-title-line-height: 28px;
     --kbq-navbar-font-title-letter-spacing: normal;
     --kbq-navbar-font-title-font-weight: 700;
-    --kbq-navbar-font-title-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-navbar-font-title-text-transform: null;
     --kbq-navbar-font-title-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-navbar-item-size-content-border-radius: 8px;
+    --kbq-navbar-font-title-font-family: var(--kbq-typography-navbar-title-font-family);
+}
+
+:root {
+    --kbq-typography-navbar-title-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/popover/popover-tokens.scss
+++ b/packages/components/popover/popover-tokens.scss
@@ -24,18 +24,23 @@
     --kbq-popover-font-header-line-height: 26px;
     --kbq-popover-font-header-letter-spacing: normal;
     --kbq-popover-font-header-font-weight: 600;
-    --kbq-popover-font-header-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-popover-font-header-text-transform: null;
     --kbq-popover-font-header-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-popover-font-content-font-size: 14px;
     --kbq-popover-font-content-line-height: 20px;
     --kbq-popover-font-content-letter-spacing: -0.006em;
     --kbq-popover-font-content-font-weight: normal;
-    --kbq-popover-font-content-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-popover-font-content-text-transform: null;
     --kbq-popover-font-content-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-popover-font-header-font-family: var(--kbq-typography-subheading-font-family);
+    --kbq-popover-font-content-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-subheading-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/progress-bar/progress-bar-tokens.scss
+++ b/packages/components/progress-bar/progress-bar-tokens.scss
@@ -7,18 +7,23 @@
     --kbq-progress-bar-font-label-line-height: 20px;
     --kbq-progress-bar-font-label-letter-spacing: -0.006em;
     --kbq-progress-bar-font-label-font-weight: normal;
-    --kbq-progress-bar-font-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-progress-bar-font-label-text-transform: null;
     --kbq-progress-bar-font-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-progress-bar-font-caption-font-size: 12px;
     --kbq-progress-bar-font-caption-line-height: 16px;
     --kbq-progress-bar-font-caption-letter-spacing: normal;
     --kbq-progress-bar-font-caption-font-weight: normal;
-    --kbq-progress-bar-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-progress-bar-font-caption-text-transform: null;
     --kbq-progress-bar-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-progress-bar-font-label-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-progress-bar-font-caption-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/progress-spinner/progress-spinner-tokens.scss
+++ b/packages/components/progress-spinner/progress-spinner-tokens.scss
@@ -11,18 +11,23 @@
     --kbq-progress-spinner-font-label-line-height: 20px;
     --kbq-progress-spinner-font-label-letter-spacing: -0.006em;
     --kbq-progress-spinner-font-label-font-weight: normal;
-    --kbq-progress-spinner-font-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-progress-spinner-font-label-text-transform: null;
     --kbq-progress-spinner-font-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-progress-spinner-font-caption-font-size: 12px;
     --kbq-progress-spinner-font-caption-line-height: 16px;
     --kbq-progress-spinner-font-caption-letter-spacing: normal;
     --kbq-progress-spinner-font-caption-font-weight: normal;
-    --kbq-progress-spinner-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-progress-spinner-font-caption-text-transform: null;
     --kbq-progress-spinner-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-progress-spinner-font-label-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-progress-spinner-font-caption-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/radio/radio-tokens.scss
+++ b/packages/components/radio/radio-tokens.scss
@@ -15,34 +15,39 @@
     --kbq-radio-font-normal-label-line-height: 20px;
     --kbq-radio-font-normal-label-letter-spacing: -0.006em;
     --kbq-radio-font-normal-label-font-weight: normal;
-    --kbq-radio-font-normal-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-radio-font-normal-label-text-transform: null;
     --kbq-radio-font-normal-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-radio-font-normal-caption-font-size: 12px;
     --kbq-radio-font-normal-caption-line-height: 16px;
     --kbq-radio-font-normal-caption-letter-spacing: normal;
     --kbq-radio-font-normal-caption-font-weight: normal;
-    --kbq-radio-font-normal-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-radio-font-normal-caption-text-transform: null;
     --kbq-radio-font-normal-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-radio-font-big-label-font-size: 16px;
     --kbq-radio-font-big-label-line-height: 24px;
     --kbq-radio-font-big-label-letter-spacing: -0.011em;
     --kbq-radio-font-big-label-font-weight: normal;
-    --kbq-radio-font-big-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-radio-font-big-label-text-transform: null;
     --kbq-radio-font-big-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-radio-font-big-caption-font-size: 14px;
     --kbq-radio-font-big-caption-line-height: 20px;
     --kbq-radio-font-big-caption-letter-spacing: -0.006em;
     --kbq-radio-font-big-caption-font-weight: normal;
-    --kbq-radio-font-big-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-radio-font-big-caption-text-transform: null;
     --kbq-radio-font-big-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-radio-font-normal-label-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-radio-font-normal-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-radio-font-big-label-font-family: var(--kbq-typography-text-big-font-family);
+    --kbq-radio-font-big-caption-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/risk-level/risk-level-tokens.scss
+++ b/packages/components/risk-level/risk-level-tokens.scss
@@ -7,10 +7,14 @@
     --kbq-risk-level-font-text-line-height: 26px;
     --kbq-risk-level-font-text-letter-spacing: normal;
     --kbq-risk-level-font-text-font-weight: 600;
-    --kbq-risk-level-font-text-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-risk-level-font-text-text-transform: null;
     --kbq-risk-level-font-text-font-feature-settings: 'calt', 'kern', 'liga';
+    --kbq-risk-level-font-text-font-family: var(--kbq-typography-subheading-font-family);
+}
+
+:root {
+    --kbq-typography-subheading-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/select/select-tokens.scss
+++ b/packages/components/select/select-tokens.scss
@@ -17,8 +17,6 @@
     --kbq-select-font-default-line-height: 20px;
     --kbq-select-font-default-letter-spacing: -0.006em;
     --kbq-select-font-default-font-weight: normal;
-    --kbq-select-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-select-font-default-text-transform: null;
     --kbq-select-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-select-panel-size-border-radius: 8px;
@@ -27,10 +25,15 @@
     --kbq-select-panel-font-default-line-height: 20px;
     --kbq-select-panel-font-default-letter-spacing: -0.006em;
     --kbq-select-panel-font-default-font-weight: normal;
-    --kbq-select-panel-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-select-panel-font-default-text-transform: null;
     --kbq-select-panel-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-select-font-default-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-select-panel-font-default-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/sidepanel/sidepanel-tokens.scss
+++ b/packages/components/sidepanel/sidepanel-tokens.scss
@@ -16,18 +16,23 @@
     --kbq-sidepanel-font-header-line-height: 28px;
     --kbq-sidepanel-font-header-letter-spacing: normal;
     --kbq-sidepanel-font-header-font-weight: 700;
-    --kbq-sidepanel-font-header-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-sidepanel-font-header-text-transform: null;
     --kbq-sidepanel-font-header-font-feature-settings: 'calt', 'kern', 'liga';
     --kbq-sidepanel-font-content-font-size: 14px;
     --kbq-sidepanel-font-content-line-height: 20px;
     --kbq-sidepanel-font-content-letter-spacing: -0.006em;
     --kbq-sidepanel-font-content-font-weight: normal;
-    --kbq-sidepanel-font-content-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-sidepanel-font-content-text-transform: null;
     --kbq-sidepanel-font-content-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-sidepanel-font-header-font-family: var(--kbq-typography-title-font-family);
+    --kbq-sidepanel-font-content-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-title-font-family: 'TT-Positive', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/table/table-tokens.scss
+++ b/packages/components/table/table-tokens.scss
@@ -6,18 +6,23 @@
     --kbq-table-font-header-line-height: 20px;
     --kbq-table-font-header-letter-spacing: -0.006em;
     --kbq-table-font-header-font-weight: normal;
-    --kbq-table-font-header-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-table-font-header-text-transform: null;
     --kbq-table-font-header-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-table-font-body-font-size: 14px;
     --kbq-table-font-body-line-height: 20px;
     --kbq-table-font-body-letter-spacing: -0.006em;
     --kbq-table-font-body-font-weight: normal;
-    --kbq-table-font-body-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-table-font-body-text-transform: null;
     --kbq-table-font-body-font-feature-settings: 'calt', 'ss01', 'ss04', 'tnum';
+    --kbq-table-font-header-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-table-font-body-font-family: var(--kbq-typography-tabular-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-tabular-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/tabs/tabs-tokens.scss
+++ b/packages/components/tabs/tabs-tokens.scss
@@ -11,10 +11,14 @@
     --kbq-tabs-font-text-line-height: 20px;
     --kbq-tabs-font-text-letter-spacing: -0.006em;
     --kbq-tabs-font-text-font-weight: 500;
-    --kbq-tabs-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-tabs-font-text-text-transform: null;
     --kbq-tabs-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-tabs-font-text-font-family: var(--kbq-typography-text-normal-medium-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-medium-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/tags/tag-input-tokens.scss
+++ b/packages/components/tags/tag-input-tokens.scss
@@ -7,8 +7,12 @@
     --kbq-tag-input-font-default-line-height: 20px;
     --kbq-tag-input-font-default-letter-spacing: -0.006em;
     --kbq-tag-input-font-default-font-weight: normal;
-    --kbq-tag-input-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-tag-input-font-default-text-transform: null;
     --kbq-tag-input-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-tag-input-font-default-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }

--- a/packages/components/tags/tag-tokens.scss
+++ b/packages/components/tags/tag-tokens.scss
@@ -5,8 +5,6 @@
     --kbq-tag-input-font-default-line-height: 20px;
     --kbq-tag-input-font-default-letter-spacing: -0.006em;
     --kbq-tag-input-font-default-font-weight: normal;
-    --kbq-tag-input-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-tag-input-font-default-text-transform: null;
     --kbq-tag-input-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-tag-list-size-content-gap: 4px;
@@ -19,10 +17,17 @@
     --kbq-tag-font-default-line-height: 20px;
     --kbq-tag-font-default-letter-spacing: -0.006em;
     --kbq-tag-font-default-font-weight: 500;
-    --kbq-tag-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-tag-font-default-text-transform: null;
     --kbq-tag-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-tag-input-font-default-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-tag-font-default-font-family: var(--kbq-typography-text-normal-medium-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-normal-medium-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/textarea/textarea-tokens.scss
+++ b/packages/components/textarea/textarea-tokens.scss
@@ -7,8 +7,12 @@
     --kbq-textarea-font-default-line-height: 20px;
     --kbq-textarea-font-default-letter-spacing: -0.006em;
     --kbq-textarea-font-default-font-weight: normal;
-    --kbq-textarea-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-textarea-font-default-text-transform: null;
     --kbq-textarea-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-textarea-font-default-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }

--- a/packages/components/timezone/timezone-option-tokens.scss
+++ b/packages/components/timezone/timezone-option-tokens.scss
@@ -8,34 +8,39 @@
     --kbq-timezone-option-font-text-line-height: 20px;
     --kbq-timezone-option-font-text-letter-spacing: -0.006em;
     --kbq-timezone-option-font-text-font-weight: normal;
-    --kbq-timezone-option-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-timezone-option-font-text-text-transform: null;
     --kbq-timezone-option-font-text-font-feature-settings: 'calt', 'ss01', 'ss04', 'tnum';
     --kbq-timezone-option-font-offset-text-font-size: 14px;
     --kbq-timezone-option-font-offset-text-line-height: 20px;
     --kbq-timezone-option-font-offset-text-letter-spacing: -0.006em;
     --kbq-timezone-option-font-offset-text-font-weight: normal;
-    --kbq-timezone-option-font-offset-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-timezone-option-font-offset-text-text-transform: null;
     --kbq-timezone-option-font-offset-text-font-feature-settings: 'calt', 'ss01', 'ss04', 'tnum';
     --kbq-timezone-option-font-caption-font-size: 12px;
     --kbq-timezone-option-font-caption-line-height: 16px;
     --kbq-timezone-option-font-caption-letter-spacing: normal;
     --kbq-timezone-option-font-caption-font-weight: normal;
-    --kbq-timezone-option-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-timezone-option-font-caption-text-transform: null;
     --kbq-timezone-option-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-timezone-option-font-optgroup-label-font-size: 12px;
     --kbq-timezone-option-font-optgroup-label-line-height: 16px;
     --kbq-timezone-option-font-optgroup-label-letter-spacing: 1px;
     --kbq-timezone-option-font-optgroup-label-font-weight: 500;
-    --kbq-timezone-option-font-optgroup-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        'Helvetica Neue', Arial, sans-serif;
     --kbq-timezone-option-font-optgroup-label-text-transform: uppercase;
     --kbq-timezone-option-font-optgroup-label-font-feature-settings: 'calt', 'case', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-timezone-option-font-text-font-family: var(--kbq-typography-tabular-normal-font-family);
+    --kbq-timezone-option-font-offset-text-font-family: var(--kbq-typography-tabular-normal-font-family);
+    --kbq-timezone-option-font-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-timezone-option-font-optgroup-label-font-family: var(--kbq-typography-caps-compact-strong-font-family);
+}
+
+:root {
+    --kbq-typography-tabular-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-caps-compact-strong-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+        'Helvetica Neue', Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/toast/toast-tokens.scss
+++ b/packages/components/toast/toast-tokens.scss
@@ -18,18 +18,21 @@
     --kbq-toast-font-title-line-height: 20px;
     --kbq-toast-font-title-letter-spacing: -0.006em;
     --kbq-toast-font-title-font-weight: normal;
-    --kbq-toast-font-title-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-toast-font-title-text-transform: null;
     --kbq-toast-font-title-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-toast-font-text-font-size: 14px;
     --kbq-toast-font-text-line-height: 20px;
     --kbq-toast-font-text-letter-spacing: -0.006em;
     --kbq-toast-font-text-font-weight: normal;
-    --kbq-toast-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-toast-font-text-text-transform: null;
     --kbq-toast-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-toast-font-title-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-toast-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/toggle/toggle-tokens.scss
+++ b/packages/components/toggle/toggle-tokens.scss
@@ -11,34 +11,39 @@
     --kbq-toggle-font-normal-label-line-height: 20px;
     --kbq-toggle-font-normal-label-letter-spacing: -0.006em;
     --kbq-toggle-font-normal-label-font-weight: normal;
-    --kbq-toggle-font-normal-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-toggle-font-normal-label-text-transform: null;
     --kbq-toggle-font-normal-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-toggle-font-normal-caption-font-size: 12px;
     --kbq-toggle-font-normal-caption-line-height: 16px;
     --kbq-toggle-font-normal-caption-letter-spacing: normal;
     --kbq-toggle-font-normal-caption-font-weight: normal;
-    --kbq-toggle-font-normal-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-toggle-font-normal-caption-text-transform: null;
     --kbq-toggle-font-normal-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-toggle-font-big-label-font-size: 16px;
     --kbq-toggle-font-big-label-line-height: 24px;
     --kbq-toggle-font-big-label-letter-spacing: -0.011em;
     --kbq-toggle-font-big-label-font-weight: normal;
-    --kbq-toggle-font-big-label-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-toggle-font-big-label-text-transform: null;
     --kbq-toggle-font-big-label-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-toggle-font-big-caption-font-size: 14px;
     --kbq-toggle-font-big-caption-line-height: 20px;
     --kbq-toggle-font-big-caption-letter-spacing: -0.006em;
     --kbq-toggle-font-big-caption-font-weight: normal;
-    --kbq-toggle-font-big-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-toggle-font-big-caption-text-transform: null;
     --kbq-toggle-font-big-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-toggle-font-normal-label-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-toggle-font-normal-caption-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-toggle-font-big-label-font-family: var(--kbq-typography-text-big-font-family);
+    --kbq-toggle-font-big-caption-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-big-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
+        sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/tooltip/tooltip-tokens.scss
+++ b/packages/components/tooltip/tooltip-tokens.scss
@@ -8,18 +8,21 @@
     --kbq-tooltip-font-default-line-height: 16px;
     --kbq-tooltip-font-default-letter-spacing: normal;
     --kbq-tooltip-font-default-font-weight: normal;
-    --kbq-tooltip-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-tooltip-font-default-text-transform: null;
     --kbq-tooltip-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-tooltip-font-title-font-size: 12px;
     --kbq-tooltip-font-title-line-height: 16px;
     --kbq-tooltip-font-title-letter-spacing: normal;
     --kbq-tooltip-font-title-font-weight: normal;
-    --kbq-tooltip-font-title-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-tooltip-font-title-text-transform: null;
     --kbq-tooltip-font-title-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-tooltip-font-default-font-family: var(--kbq-typography-text-compact-font-family);
+    --kbq-tooltip-font-title-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/tree-select/tree-select-tokens.scss
+++ b/packages/components/tree-select/tree-select-tokens.scss
@@ -5,10 +5,14 @@
     --kbq-select-panel-font-default-line-height: 20px;
     --kbq-select-panel-font-default-letter-spacing: -0.006em;
     --kbq-select-panel-font-default-font-weight: normal;
-    --kbq-select-panel-font-default-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
-        Arial, sans-serif;
     --kbq-select-panel-font-default-text-transform: null;
     --kbq-select-panel-font-default-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-select-panel-font-default-font-family: var(--kbq-typography-text-normal-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/packages/components/tree/tree-tokens.scss
+++ b/packages/components/tree/tree-tokens.scss
@@ -11,18 +11,23 @@
     --kbq-tree-font-text-line-height: 20px;
     --kbq-tree-font-text-letter-spacing: -0.006em;
     --kbq-tree-font-text-font-weight: normal;
-    --kbq-tree-font-text-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-tree-font-text-text-transform: null;
     --kbq-tree-font-text-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
     --kbq-tree-font-caption-font-size: 12px;
     --kbq-tree-font-caption-line-height: 16px;
     --kbq-tree-font-caption-letter-spacing: normal;
     --kbq-tree-font-caption-font-weight: normal;
-    --kbq-tree-font-caption-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial,
-        sans-serif;
     --kbq-tree-font-caption-text-transform: null;
     --kbq-tree-font-caption-font-feature-settings: 'calt', 'kern', 'liga', 'ss01', 'ss04';
+    --kbq-tree-font-text-font-family: var(--kbq-typography-text-normal-font-family);
+    --kbq-tree-font-caption-font-family: var(--kbq-typography-text-compact-font-family);
+}
+
+:root {
+    --kbq-typography-text-normal-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
+    --kbq-typography-text-compact-font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
+        Arial, sans-serif;
 }
 
 :where(.kbq-light, .theme-light, .kbq-theme-light) {

--- a/tools/tokens/utils.js
+++ b/tools/tokens/utils.js
@@ -159,6 +159,7 @@ const additionalFilter = (token, componentName) => {
 
 const dictionaryMapper = (dictionary, outputReferences) => {
     const formatProperty = formatHelpers.createPropertyFormatter({ outputReferences, dictionary, format: 'css' });
+    if (!dictionary.allTokens.length) return '';
     return '  ' + dictionary.allTokens.map(formatProperty).join('\n  ');
 };
 


### PR DESCRIPTION
## Summary

Упростили кастомизацию шрифтов, используемых в компонентах.

Добавил подключение css-vars для токенов шрифтов и добавил дефолтные значения для глобальных переменных на которые они ссылаются.

Глобальные токены, на которые ссылается компонентный токен, автоматически подтягиваются в псевдоселектор `:root` и устанавливают дефолтное значение.

Это позволяет проще кастомизировать шрифт, но при этом сохранять дефолтное поведение.