### PR TITLE
fix(docs): corrected system-dependent theme selection on startup (#DS-2952)

### DIFF
--- a/apps/docs/src/index.html
+++ b/apps/docs/src/index.html
@@ -67,7 +67,7 @@
         />
     </head>
 
-    <body class="docs-app-background kbq-theme-light docs koobiq">
+    <body class="docs-app-background docs koobiq">
         <!-- Yandex.Metrika counter -->
         <script type="text/javascript">
             (function (m, e, t, r, i, k, a) {


### PR DESCRIPTION
## Summary

Removed theme selector on start, so themeService will resolve current theme on its own.

