### PR TITLE
fix(layout): removed map.get from properties used in styles (#DS-2972)

### DIFF
--- a/packages/components-dev/markdown/template.html
+++ b/packages/components-dev/markdown/template.html
@@ -76,14 +76,14 @@
 ```css
 
 .kbq-markdown__img &#123;
-  max-width: kbq-css-variable(markdown-image-size-max-width);
-  margin-top: kbq-css-variable(markdown-image-size-margin-top);
-  margin-bottom: kbq-css-variable(markdown-image-size-margin-bottom);
+  max-width: var(--kbq-markdown-image-size-max-width);
+  margin-top: var(--kbq-markdown-image-size-margin-top);
+  margin-bottom: var(--kbq-markdown-image-size-margin-bottom);
 
   + em &#123;
       display: block;
-      margin-top: kbq-css-variable(markdown-image-size-caption-margin-top);
-      margin-bottom: kbq-css-variable(markdown-image-size-caption-margin-bottom);
+      margin-top: var(--kbq-markdown-image-size-caption-margin-top);
+      margin-bottom: var(--kbq-markdown-image-size-caption-margin-bottom);
     &#125;
 &#125;
 

--- a/packages/components/accordion/_accordion-theme.scss
+++ b/packages/components/accordion/_accordion-theme.scss
@@ -7,16 +7,16 @@
 @mixin kbq-accordion-theme() {
     .kbq-accordion.cdk-keyboard-focused {
         & .kbq-accordion-item:focus-within {
-            border-color: kbq-css-variable(accordion-item-states-focus-border-color);
+            border-color: var(--kbq-accordion-item-states-focus-border-color);
         }
     }
 
     .kbq-accordion-item {
-        background: kbq-css-variable(accordion-item-default-background);
-        color: kbq-css-variable(accordion-item-default-text-color);
+        background: var(--kbq-accordion-item-default-background);
+        color: var(--kbq-accordion-item-default-text-color);
 
         & .kbq-accordion-trigger__icon {
-            color: kbq-css-variable(accordion-item-default-icon-color);
+            color: var(--kbq-accordion-item-default-icon-color);
         }
     }
 
@@ -26,21 +26,21 @@
         border: none;
         outline: none;
 
-        color: kbq-css-variable(accordion-item-default-text-color);
+        color: var(--kbq-accordion-item-default-text-color);
 
         &:hover:not([data-disabled='true']) {
             cursor: pointer;
 
             & .kbq-accordion-trigger__icon {
-                color: kbq-css-variable(accordion-item-states-hover-icon-color);
+                color: var(--kbq-accordion-item-states-hover-icon-color);
             }
         }
 
         &[data-disabled='true'] {
-            color: kbq-css-variable(accordion-item-states-disabled-text-color);
+            color: var(--kbq-accordion-item-states-disabled-text-color);
 
             & .kbq-accordion-trigger__icon {
-                color: kbq-css-variable(accordion-item-states-disabled-icon-color) !important;
+                color: var(--kbq-accordion-item-states-disabled-icon-color) !important;
             }
         }
     }

--- a/packages/components/accordion/accordion-trigger.component.scss
+++ b/packages/components/accordion/accordion-trigger.component.scss
@@ -13,7 +13,7 @@
     outline: none;
 
     & .kbq-accordion-trigger__icon {
-        padding: kbq-css-variable(size-xxs);
+        padding: var(--kbq-size-xxs);
 
         transition: transform 300ms ease-out;
     }
@@ -22,12 +22,12 @@
         cursor: pointer;
 
         & .kbq-accordion-trigger__icon {
-            color: kbq-css-variable(accordion-item-states-hover-icon-color);
+            color: var(--kbq-accordion-item-states-hover-icon-color);
         }
     }
 
     &.kbq-accordion-trigger_fill {
-        padding: kbq-css-variable(accordion-size-item-header-variant-fill-padding);
+        padding: var(--kbq-accordion-size-item-header-variant-fill-padding);
 
         &[data-state='open'] > .kbq-accordion-trigger__icon {
             transform: rotate(90deg);
@@ -38,7 +38,7 @@
         flex-direction: row-reverse;
         justify-content: flex-end;
 
-        padding: kbq-css-variable(accordion-size-item-header-variant-hug-padding);
+        padding: var(--kbq-accordion-size-item-header-variant-hug-padding);
 
         &[data-state='open'] > .kbq-accordion-trigger__icon {
             transform: rotate(90deg);
@@ -49,7 +49,7 @@
         flex-direction: row-reverse;
         justify-content: space-between;
 
-        padding: kbq-css-variable(accordion-size-item-header-variant-hug-padding);
+        padding: var(--kbq-accordion-size-item-header-variant-hug-padding);
 
         & > .kbq-accordion-trigger__icon {
             transform: rotate(90deg);
@@ -62,7 +62,7 @@
 
     &[data-disabled='true'] {
         & .kbq-accordion-trigger__icon {
-            color: kbq-css-variable(accordion-item-states-disabled-icon-color) !important;
+            color: var(--kbq-accordion-item-states-disabled-icon-color) !important;
         }
     }
 }

--- a/packages/components/accordion/accordion.component.scss
+++ b/packages/components/accordion/accordion.component.scss
@@ -45,13 +45,13 @@
 .kbq-accordion-header {
     display: flex;
 
-    height: kbq-css-variable(accordion-size-item-header-height);
+    height: var(--kbq-accordion-size-item-header-height);
 }
 
 .kbq-accordion-content {
     display: block;
     overflow: hidden;
-    padding: kbq-css-variable(accordion-size-item-content-padding);
+    padding: var(--kbq-accordion-size-item-content-padding);
 
     &[data-state='open'] {
         animation: slideDown 300ms ease-out;

--- a/packages/components/alert/_alert-theme.scss
+++ b/packages/components/alert/_alert-theme.scss
@@ -5,14 +5,14 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-alert-style($type, $style-name) {
-    background: kbq-css-variable(alert-#{$type}-#{$style-name}-container-background);
+    background: var(--kbq-alert-#{$type}-#{$style-name}-container-background);
 
     .kbq-alert__title {
-        color: kbq-css-variable(alert-#{$type}-#{$style-name}-container-title);
+        color: var(--kbq-alert-#{$type}-#{$style-name}-container-title);
     }
 
     .kbq-alert__text {
-        color: kbq-css-variable(alert-#{$type}-#{$style-name}-container-text);
+        color: var(--kbq-alert-#{$type}-#{$style-name}-container-text);
     }
 }
 

--- a/packages/components/alert/alert.component.scss
+++ b/packages/components/alert/alert.component.scss
@@ -11,7 +11,7 @@
     box-sizing: border-box;
 
     & .kbq-alert__content_title {
-        margin-bottom: kbq-css-variable(size-xxs);
+        margin-bottom: var(--kbq-size-xxs);
     }
 }
 
@@ -24,22 +24,19 @@
 }
 
 .kbq-alert.kbq-alert_normal {
-    border-radius: kbq-css-variable(alert-size-normal-container-border-radius);
+    border-radius: var(--kbq-alert-size-normal-container-border-radius);
 
-    padding: kbq-css-variable(alert-size-normal-container-padding-top)
-        kbq-css-variable(alert-size-normal-container-padding-right)
-        kbq-css-variable(alert-size-normal-container-padding-bottom)
-        kbq-css-variable(alert-size-normal-container-padding-left);
+    padding: var(--kbq-alert-size-normal-container-padding-top) var(--kbq-alert-size-normal-container-padding-right)
+        var(--kbq-alert-size-normal-container-padding-bottom) var(--kbq-alert-size-normal-container-padding-left);
 
     & .kbq-alert__icon {
-        margin: kbq-css-variable(alert-size-normal-no-title-icon-margin-top)
-            kbq-css-variable(alert-size-normal-icon-margin-right) kbq-css-variable(alert-size-normal-icon-margin-bottom)
-            kbq-css-variable(alert-size-normal-icon-margin-left);
+        margin: var(--kbq-alert-size-normal-no-title-icon-margin-top) var(--kbq-alert-size-normal-icon-margin-right)
+            var(--kbq-alert-size-normal-icon-margin-bottom) var(--kbq-alert-size-normal-icon-margin-left);
 
         &.kbq-alert__icon_title {
-            margin-top: kbq-css-variable(alert-size-normal-icon-margin-top);
+            margin-top: var(--kbq-alert-size-normal-icon-margin-top);
 
-            padding-top: kbq-css-variable(alert-size-normal-no-title-icon-padding-top);
+            padding-top: var(--kbq-alert-size-normal-no-title-icon-padding-top);
         }
 
         display: inline-flex;
@@ -47,19 +44,17 @@
     }
 
     & .kbq-alert__content {
-        padding: kbq-css-variable(alert-size-normal-content-padding-top)
-            kbq-css-variable(alert-size-normal-content-padding-right)
-            kbq-css-variable(alert-size-normal-content-padding-bottom)
-            kbq-css-variable(alert-size-normal-content-padding-left);
+        padding: var(--kbq-alert-size-normal-content-padding-top) var(--kbq-alert-size-normal-content-padding-right)
+            var(--kbq-alert-size-normal-content-padding-bottom) var(--kbq-alert-size-normal-content-padding-left);
     }
 
     & .kbq-alert__title {
-        margin-bottom: kbq-css-variable(alert-size-normal-title-margin-bottom);
+        margin-bottom: var(--kbq-alert-size-normal-title-margin-bottom);
     }
 
     & .kbq-alert__button-stack {
-        padding-top: kbq-css-variable(alert-size-normal-button-stack-padding-top);
-        padding-bottom: kbq-css-variable(alert-size-normal-button-stack-padding-bottom);
+        padding-top: var(--kbq-alert-size-normal-button-stack-padding-top);
+        padding-bottom: var(--kbq-alert-size-normal-button-stack-padding-bottom);
     }
 
     & .kbq-alert__button-stack_has-button {
@@ -67,8 +62,8 @@
     }
 
     & .kbq-alert__close-button {
-        margin-top: kbq-css-variable(alert-size-normal-close-button-margin-top);
-        margin-left: kbq-css-variable(alert-size-normal-close-button-margin-left);
+        margin-top: var(--kbq-alert-size-normal-close-button-margin-top);
+        margin-left: var(--kbq-alert-size-normal-close-button-margin-left);
 
         .kbq-icon-button {
             --kbq-icon-button-size-normal-horizontal-padding: 4px;
@@ -78,23 +73,21 @@
 }
 
 .kbq-alert.kbq-alert_compact {
-    border-radius: kbq-css-variable(alert-size-compact-container-border-radius);
+    border-radius: var(--kbq-alert-size-compact-container-border-radius);
 
-    padding: kbq-css-variable(alert-size-compact-container-padding-top)
-        kbq-css-variable(alert-size-compact-container-padding-right)
-        kbq-css-variable(alert-size-compact-container-padding-bottom)
-        kbq-css-variable(alert-size-compact-container-padding-left);
+    padding: var(--kbq-alert-size-compact-container-padding-top) var(--kbq-alert-size-compact-container-padding-right)
+        var(--kbq-alert-size-compact-container-padding-bottom) var(--kbq-alert-size-compact-container-padding-left);
 
     & .kbq-alert__icon {
-        margin-top: kbq-css-variable(alert-size-compact-no-title-icon-margin-top);
-        margin-right: kbq-css-variable(alert-size-compact-icon-margin-right);
+        margin-top: var(--kbq-alert-size-compact-no-title-icon-margin-top);
+        margin-right: var(--kbq-alert-size-compact-icon-margin-right);
 
-        padding-top: kbq-css-variable(alert-size-compact-no-title-icon-padding-top);
+        padding-top: var(--kbq-alert-size-compact-no-title-icon-padding-top);
 
         &.kbq-alert__icon_title {
-            margin-top: kbq-css-variable(alert-size-compact-icon-margin-top);
+            margin-top: var(--kbq-alert-size-compact-icon-margin-top);
 
-            padding-top: kbq-css-variable(alert-size-compact-icon-padding-top);
+            padding-top: var(--kbq-alert-size-compact-icon-padding-top);
         }
 
         display: inline-flex;
@@ -102,19 +95,17 @@
     }
 
     & .kbq-alert__content {
-        padding: kbq-css-variable(alert-size-compact-content-padding-top)
-            kbq-css-variable(alert-size-compact-content-padding-right)
-            kbq-css-variable(alert-size-compact-content-padding-bottom)
-            kbq-css-variable(alert-size-compact-content-padding-left);
+        padding: var(--kbq-alert-size-compact-content-padding-top) var(--kbq-alert-size-compact-content-padding-right)
+            var(--kbq-alert-size-compact-content-padding-bottom) var(--kbq-alert-size-compact-content-padding-left);
     }
 
     & .kbq-alert__title {
-        margin-bottom: kbq-css-variable(alert-size-compact-title-margin-bottom);
+        margin-bottom: var(--kbq-alert-size-compact-title-margin-bottom);
     }
 
     & .kbq-alert__button-stack {
-        padding-top: kbq-css-variable(alert-size-compact-button-stack-padding-top);
-        padding-bottom: kbq-css-variable(alert-size-compact-button-stack-padding-bottom);
+        padding-top: var(--kbq-alert-size-compact-button-stack-padding-top);
+        padding-bottom: var(--kbq-alert-size-compact-button-stack-padding-bottom);
     }
 
     & .kbq-alert__button-stack_has-button {
@@ -122,8 +113,8 @@
     }
 
     & .kbq-alert__close-button {
-        margin-top: kbq-css-variable(alert-size-compact-close-button-margin-top);
-        margin-left: kbq-css-variable(alert-size-compact-close-button-margin-left);
+        margin-top: var(--kbq-alert-size-compact-close-button-margin-top);
+        margin-left: var(--kbq-alert-size-compact-close-button-margin-left);
 
         .kbq-icon-button {
             --kbq-icon-button-size-normal-horizontal-padding: 4px;

--- a/packages/components/autocomplete/_autocomplete-theme.scss
+++ b/packages/components/autocomplete/_autocomplete-theme.scss
@@ -6,7 +6,7 @@
 
 @mixin kbq-autocomplete-theme {
     .kbq-autocomplete-panel {
-        box-shadow: kbq-css-variable(select-panel-dropdown-shadow);
-        background: kbq-css-variable(select-panel-dropdown-background);
+        box-shadow: var(--kbq-select-panel-dropdown-shadow);
+        background: var(--kbq-select-panel-dropdown-background);
     }
 }

--- a/packages/components/autocomplete/autocomplete.scss
+++ b/packages/components/autocomplete/autocomplete.scss
@@ -19,12 +19,12 @@
     width: 100%;
     max-width: none;
 
-    max-height: kbq-css-variable(autocomplete-size-panel-max-height);
+    max-height: var(--kbq-autocomplete-size-panel-max-height);
 
-    border-bottom-left-radius: kbq-css-variable(autocomplete-size-panel-border-radius);
-    border-bottom-right-radius: kbq-css-variable(autocomplete-size-panel-border-radius);
+    border-bottom-left-radius: var(--kbq-autocomplete-size-panel-border-radius);
+    border-bottom-right-radius: var(--kbq-autocomplete-size-panel-border-radius);
 
-    padding: kbq-css-variable(autocomplete-size-panel-padding);
+    padding: var(--kbq-autocomplete-size-panel-padding);
 
     &.kbq-autocomplete_visible {
         visibility: visible;
@@ -35,8 +35,8 @@
     }
 
     .kbq-autocomplete-panel-above & {
-        border-radius: kbq-css-variable(autocomplete-size-panel-border-radius)
-            kbq-css-variable(autocomplete-size-panel-border-radius) 0 0;
+        border-radius: var(--kbq-autocomplete-size-panel-border-radius) var(--kbq-autocomplete-size-panel-border-radius)
+            0 0;
     }
 
     // We need to offset horizontal dividers by their height, because

--- a/packages/components/badge/_badge-theme.scss
+++ b/packages/components/badge/_badge-theme.scss
@@ -7,21 +7,21 @@
 @mixin kbq-badge-style($type, $sub-type, $style-name) {
     $base-path: badge-#{$type}-#{$sub-type}-#{$style-name};
 
-    color: kbq-css-variable(#{$base-path}-color);
-    background: kbq-css-variable(#{$base-path}-background);
+    color: var(--kbq-#{$base-path}-color);
+    background: var(--kbq-#{$base-path}-background);
 
     & .kbq-badge-caption {
-        color: kbq-css-variable(#{$base-path}-caption);
+        color: var(--kbq-#{$base-path}-caption);
     }
 
     & .kbq-icon {
-        color: kbq-css-variable(#{$base-path}-icon) !important;
+        color: var(--kbq-#{$base-path}-icon) !important;
     }
 
     @if $type == filled {
         border: transparent;
     } @else {
-        border-color: kbq-css-variable(#{$base-path}-border);
+        border-color: var(--kbq-#{$base-path}-border);
     }
 }
 

--- a/packages/components/badge/badge.component.scss
+++ b/packages/components/badge/badge.component.scss
@@ -10,7 +10,7 @@
     flex-direction: row;
     justify-content: flex-start;
     align-items: center;
-    height: kbq-css-variable(badge-size-normal-height);
+    height: var(--kbq-badge-size-normal-height);
     text-align: center;
     white-space: nowrap;
 
@@ -18,47 +18,47 @@
 
     box-sizing: border-box;
 
-    padding-right: kbq-css-variable(badge-size-normal-horizontal-padding);
-    padding-left: kbq-css-variable(badge-size-normal-horizontal-padding);
+    padding-right: var(--kbq-badge-size-normal-horizontal-padding);
+    padding-left: var(--kbq-badge-size-normal-horizontal-padding);
 
     border: {
-        width: kbq-css-variable(badge-size-normal-border-width);
-        radius: kbq-css-variable(badge-size-normal-border-radius);
+        width: var(--kbq-badge-size-normal-border-width);
+        radius: var(--kbq-badge-size-normal-border-radius);
     }
 
     & .kbq-badge-caption {
-        padding-left: kbq-css-variable(badge-size-normal-content-padding);
+        padding-left: var(--kbq-badge-size-normal-content-padding);
     }
 
     & .kbq-icon_left {
-        margin-right: kbq-css-variable(badge-size-normal-icon-left-margin-right);
+        margin-right: var(--kbq-badge-size-normal-icon-left-margin-right);
     }
 
     & .kbq-icon_right {
-        margin-left: kbq-css-variable(badge-size-normal-icon-right-margin-left);
+        margin-left: var(--kbq-badge-size-normal-icon-right-margin-left);
     }
 
     &.kbq-badge_compact {
-        height: kbq-css-variable(badge-size-compact-height);
+        height: var(--kbq-badge-size-compact-height);
 
-        padding-right: kbq-css-variable(badge-size-compact-horizontal-padding);
-        padding-left: kbq-css-variable(badge-size-compact-horizontal-padding);
+        padding-right: var(--kbq-badge-size-compact-horizontal-padding);
+        padding-left: var(--kbq-badge-size-compact-horizontal-padding);
 
         border: {
-            width: kbq-css-variable(badge-size-compact-border-width);
-            radius: kbq-css-variable(badge-size-compact-border-radius);
+            width: var(--kbq-badge-size-compact-border-width);
+            radius: var(--kbq-badge-size-compact-border-radius);
         }
 
         & .kbq-badge-caption {
-            padding-left: kbq-css-variable(badge-size-compact-content-padding);
+            padding-left: var(--kbq-badge-size-compact-content-padding);
         }
 
         & .kbq-icon_left {
-            margin-right: kbq-css-variable(badge-size-compact-icon-left-margin-right);
+            margin-right: var(--kbq-badge-size-compact-icon-left-margin-right);
         }
 
         & .kbq-icon_right {
-            margin-left: kbq-css-variable(badge-size-compact-icon-right-margin-left);
+            margin-left: var(--kbq-badge-size-compact-icon-right-margin-left);
         }
     }
 }

--- a/packages/components/button-toggle/_button-toggle-theme.scss
+++ b/packages/components/button-toggle/_button-toggle-theme.scss
@@ -6,18 +6,18 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-button-toggle-state($state-name) {
-    background: kbq-css-variable(button-toggle-item-#{$state-name}-background);
+    background: var(--kbq-button-toggle-item-#{$state-name}-background);
 
-    color: kbq-css-variable(button-toggle-item-#{$state-name}-text);
+    color: var(--kbq-button-toggle-item-#{$state-name}-text);
 
     & .kbq-icon {
-        color: kbq-css-variable(button-toggle-item-#{$state-name}-icon);
+        color: var(--kbq-button-toggle-item-#{$state-name}-icon);
     }
 }
 
 @mixin kbq-button-toggle-theme() {
     .kbq-button-toggle-group {
-        background: kbq-css-variable(button-toggle-container-background);
+        background: var(--kbq-button-toggle-container-background);
 
         .kbq-button-toggle {
             & > .kbq-button,
@@ -53,7 +53,7 @@
                 }
 
                 &.cdk-keyboard-focused {
-                    border-color: kbq-css-variable(button-toggle-item-states-focused-outline);
+                    border-color: var(--kbq-button-toggle-item-states-focused-outline);
                 }
             }
         }

--- a/packages/components/button-toggle/button-toggle.scss
+++ b/packages/components/button-toggle/button-toggle.scss
@@ -13,12 +13,12 @@
     flex-direction: row;
     align-items: center;
 
-    gap: kbq-css-variable(button-toggle-size-container-content-gap-horizontal);
+    gap: var(--kbq-button-toggle-size-container-content-gap-horizontal);
 
-    border-radius: kbq-css-variable(button-toggle-size-container-border-radius);
+    border-radius: var(--kbq-button-toggle-size-container-border-radius);
 
-    padding: kbq-css-variable(button-toggle-size-container-padding-vertical)
-        kbq-css-variable(button-toggle-size-container-padding-horizontal);
+    padding: var(--kbq-button-toggle-size-container-padding-vertical)
+        var(--kbq-button-toggle-size-container-padding-horizontal);
 
     .kbq-button-toggle {
         display: flex;
@@ -26,16 +26,16 @@
         justify-content: flex-start;
         align-items: center;
 
-        height: kbq-css-variable(button-toggle-size-item-height);
-        min-height: kbq-css-variable(button-toggle-size-item-height);
+        height: var(--kbq-button-toggle-size-item-height);
+        min-height: var(--kbq-button-toggle-size-item-height);
 
-        border-radius: kbq-css-variable(button-toggle-size-item-border-radius);
+        border-radius: var(--kbq-button-toggle-size-item-border-radius);
 
         > .kbq-button,
         > .kbq-button-icon {
             height: inherit;
             min-height: inherit;
-            border-radius: kbq-css-variable(button-toggle-size-item-border-radius);
+            border-radius: var(--kbq-button-toggle-size-item-border-radius);
 
             padding: kbq-difference-series-css-variables(
                     [ button-toggle-size-item-padding-vertical,
@@ -60,7 +60,7 @@
 
                 width: 100%;
 
-                gap: kbq-css-variable(button-toggle-size-item-content-gap-horizontal);
+                gap: var(--kbq-button-toggle-size-item-content-gap-horizontal);
             }
         }
     }
@@ -71,7 +71,7 @@
             > .kbq-button-icon {
                 max-width: 100%;
 
-                height: kbq-css-variable(button-toggle-size-item-height);
+                height: var(--kbq-button-toggle-size-item-height);
             }
         }
     }
@@ -87,7 +87,7 @@
         > .kbq-button-icon {
             width: 100%;
 
-            border-radius: kbq-css-variable(button-toggle-size-item-border-radius);
+            border-radius: var(--kbq-button-toggle-size-item-border-radius);
         }
     }
 }

--- a/packages/components/button/_button-base.scss
+++ b/packages/components/button/_button-base.scss
@@ -18,8 +18,8 @@
 
     margin: 0; /* Safari */
 
-    height: kbq-css-variable(button-size-height);
-    min-height: kbq-css-variable(button-size-height);
+    height: var(--kbq-button-size-height);
+    min-height: var(--kbq-button-size-height);
 
     white-space: nowrap;
 
@@ -28,8 +28,8 @@
 
     vertical-align: baseline;
 
-    border: kbq-css-variable(button-size-border-width) solid transparent;
-    border-radius: kbq-css-variable(button-size-border-radius);
+    border: var(--kbq-button-size-border-width) solid transparent;
+    border-radius: var(--kbq-button-size-border-radius);
 
     &::-moz-focus-inner {
         border: 0;
@@ -53,10 +53,10 @@
     }
 
     & .kbq-icon_left {
-        margin-right: kbq-css-variable(button-size-content-padding);
+        margin-right: var(--kbq-button-size-content-padding);
     }
 
     & .kbq-icon_right {
-        margin-left: kbq-css-variable(button-size-content-padding);
+        margin-left: var(--kbq-button-size-content-padding);
     }
 }

--- a/packages/components/button/_button-theme.scss
+++ b/packages/components/button/_button-theme.scss
@@ -21,29 +21,29 @@
 @mixin kbq-button-type($type, $sub-type) {
     $base-path: button-#{$type}-#{$sub-type};
 
-    border-color: kbq-css-variable(#{$base-path}-border);
-    color: kbq-css-variable(#{$base-path}-foreground);
-    background: kbq-css-variable(#{$base-path}-background);
+    border-color: var(--kbq-#{$base-path}-border);
+    color: var(--kbq-#{$base-path}-foreground);
+    background: var(--kbq-#{$base-path}-background);
 
-    @include _icon(kbq-css-variable(#{$base-path}-left-icon), kbq-css-variable(#{$base-path}-right-icon));
+    @include _icon(var(--kbq-#{$base-path}-left-icon), var(--kbq-#{$base-path}-right-icon));
 
     &:hover:not(.kbq-disabled),
     &.kbq-hover:not(.kbq-disabled) {
-        background: kbq-css-variable(#{$base-path}-states-hover-background);
+        background: var(--kbq-#{$base-path}-states-hover-background);
     }
 
     &:active:not(.kbq-disabled),
     &.kbq-active:not(.kbq-disabled) {
-        background: kbq-css-variable(#{$base-path}-states-active-background);
+        background: var(--kbq-#{$base-path}-states-active-background);
     }
 
     &.kbq-disabled {
-        color: kbq-css-variable(#{$base-path}-states-disabled-foreground);
-        background: kbq-css-variable(#{$base-path}-states-disabled-background);
+        color: var(--kbq-#{$base-path}-states-disabled-foreground);
+        background: var(--kbq-#{$base-path}-states-disabled-background);
 
         @include _icon(
-            kbq-css-variable(#{$base-path}-states-disabled-left-icon),
-            kbq-css-variable(#{$base-path}-states-disabled-right-icon)
+            var(--kbq-#{$base-path}-states-disabled-left-icon),
+            var(--kbq-#{$base-path}-states-disabled-right-icon)
         );
     }
 }
@@ -91,7 +91,7 @@
         &.kbq-button_outline,
         &.kbq-button_transparent {
             &.cdk-keyboard-focused {
-                $focused-color: kbq-css-variable(states-focused-color);
+                $focused-color: var(--kbq-states-focused-color);
                 outline: 1px solid $focused-color;
                 border-color: $focused-color;
             }

--- a/packages/components/button/button.scss
+++ b/packages/components/button/button.scss
@@ -14,11 +14,11 @@
     padding-right: kbq-sum-series-css-variables([button-size-horizontal-padding, 4px]);
 
     &.kbq-button-icon_left {
-        padding-left: kbq-css-variable(button-size-horizontal-padding);
+        padding-left: var(--kbq-button-size-horizontal-padding);
     }
 
     &.kbq-button-icon_right {
-        padding-right: kbq-css-variable(button-size-horizontal-padding);
+        padding-right: var(--kbq-button-size-horizontal-padding);
     }
 }
 
@@ -29,18 +29,18 @@
 .kbq-button-icon {
     @extend %kbq-button-base;
 
-    padding-left: kbq-css-variable(button-icon-size-horizontal-padding);
+    padding-left: var(--kbq-button-icon-size-horizontal-padding);
 
-    padding-right: kbq-css-variable(button-icon-size-horizontal-padding);
+    padding-right: var(--kbq-button-icon-size-horizontal-padding);
 }
 
 .kbq-button-overlay {
     position: absolute;
 
-    top: calc(-1 * #{kbq-css-variable(button-size-border-width)});
-    left: calc(-1 * #{kbq-css-variable(button-size-border-width)});
-    right: calc(-1 * #{kbq-css-variable(button-size-border-width)});
-    bottom: calc(-1 * #{kbq-css-variable(button-size-border-width)});
+    top: calc(-1 * #{var(--kbq-button-size-border-width)});
+    left: calc(-1 * #{var(--kbq-button-size-border-width)});
+    right: calc(-1 * #{var(--kbq-button-size-border-width)});
+    bottom: calc(-1 * #{var(--kbq-button-size-border-width)});
 
     border-radius: inherit;
 }

--- a/packages/components/checkbox/_checkbox-theme.scss
+++ b/packages/components/checkbox/_checkbox-theme.scss
@@ -8,36 +8,36 @@
     $base: checkbox-#{$style-name};
 
     .kbq-checkbox__frame {
-        border-color: kbq-css-variable(#{$base}-default-border);
-        background-color: kbq-css-variable(#{$base}-default-background);
+        border-color: var(--kbq-#{$base}-default-border);
+        background-color: var(--kbq-#{$base}-default-background);
 
         & .kbq-checkbox-checkmark,
         & .kbq-checkbox-mixedmark {
-            color: kbq-css-variable(#{$base}-default-color);
+            color: var(--kbq-#{$base}-default-color);
         }
     }
 
     .kbq-checkbox-label {
-        color: kbq-css-variable(#{$base}-default-text);
+        color: var(--kbq-#{$base}-default-text);
     }
 
     & .kbq-hint .kbq-hint__text {
-        color: kbq-css-variable(#{$base}-default-caption);
+        color: var(--kbq-#{$base}-default-caption);
     }
 
     &:hover,
     &.kbq-hover {
         .kbq-checkbox__frame {
-            border-color: kbq-css-variable(#{$base}-states-hover-border);
-            background-color: kbq-css-variable(#{$base}-states-hover-background);
+            border-color: var(--kbq-#{$base}-states-hover-border);
+            background-color: var(--kbq-#{$base}-states-hover-background);
         }
     }
 
     &.kbq-checked,
     &.kbq-indeterminate {
         .kbq-checkbox__frame {
-            border-color: kbq-css-variable(#{$base}-states-checked-border);
-            background-color: kbq-css-variable(#{$base}-states-checked-background);
+            border-color: var(--kbq-#{$base}-states-checked-border);
+            background-color: var(--kbq-#{$base}-states-checked-background);
         }
     }
 
@@ -46,45 +46,45 @@
         &:hover,
         &.kbq-hover {
             .kbq-checkbox__frame {
-                border-color: kbq-css-variable(#{$base}-states-checked-hover-border);
-                background-color: kbq-css-variable(#{$base}-states-checked-hover-background);
+                border-color: var(--kbq-#{$base}-states-checked-hover-border);
+                background-color: var(--kbq-#{$base}-states-checked-hover-background);
             }
         }
 
         & .kbq-checkbox-input.cdk-keyboard-focused {
             + .kbq-checkbox__frame {
-                border-color: kbq-css-variable(#{$base}-states-checked-focused-border);
-                background-color: kbq-css-variable(#{$base}-states-checked-focused-background);
-                outline: kbq-css-variable(#{$base}-states-checked-focused-outline);
+                border-color: var(--kbq-#{$base}-states-checked-focused-border);
+                background-color: var(--kbq-#{$base}-states-checked-focused-background);
+                outline: var(--kbq-#{$base}-states-checked-focused-outline);
             }
         }
     }
 
     & .kbq-checkbox-input.cdk-keyboard-focused {
         + .kbq-checkbox__frame {
-            border-color: kbq-css-variable(#{$base}-states-focused-border);
-            background-color: kbq-css-variable(#{$base}-states-focused-background);
-            outline: kbq-css-variable(#{$base}-states-focused-outline);
+            border-color: var(--kbq-#{$base}-states-focused-border);
+            background-color: var(--kbq-#{$base}-states-focused-background);
+            outline: var(--kbq-#{$base}-states-focused-outline);
         }
     }
 
     &.kbq-disabled {
         .kbq-checkbox__frame {
-            border-color: kbq-css-variable(#{$base}-states-disabled-border);
-            background-color: kbq-css-variable(#{$base}-states-disabled-background);
+            border-color: var(--kbq-#{$base}-states-disabled-border);
+            background-color: var(--kbq-#{$base}-states-disabled-background);
 
             & .kbq-checkbox-checkmark,
             & .kbq-checkbox-mixedmark {
-                color: kbq-css-variable(#{$base}-states-disabled-color);
+                color: var(--kbq-#{$base}-states-disabled-color);
             }
         }
 
         & .kbq-hint .kbq-hint__text {
-            color: kbq-css-variable(#{$base}-states-disabled-caption);
+            color: var(--kbq-#{$base}-states-disabled-caption);
         }
 
         .kbq-checkbox-label {
-            color: kbq-css-variable(#{$base}-states-disabled-text);
+            color: var(--kbq-#{$base}-states-disabled-text);
         }
     }
 }

--- a/packages/components/checkbox/checkbox.scss
+++ b/packages/components/checkbox/checkbox.scss
@@ -22,15 +22,15 @@
     pointer-events: none;
     background-color: transparent;
 
-    border-radius: kbq-css-variable(checkbox-size-normal-border-radius);
+    border-radius: var(--kbq-checkbox-size-normal-border-radius);
 
     border: {
-        width: kbq-css-variable(checkbox-size-normal-border-width);
+        width: var(--kbq-checkbox-size-normal-border-width);
         style: solid;
     }
 
-    height: kbq-css-variable(checkbox-size-normal-width);
-    width: kbq-css-variable(checkbox-size-normal-width);
+    height: var(--kbq-checkbox-size-normal-width);
+    width: var(--kbq-checkbox-size-normal-width);
 }
 
 .kbq-checkbox__layout {
@@ -42,9 +42,9 @@
     // (e.g. pointer by default, regular when disabled), instead of the browser default.
     cursor: inherit;
 
-    padding-top: kbq-css-variable(checkbox-size-normal-padding-top);
+    padding-top: var(--kbq-checkbox-size-normal-padding-top);
 
-    padding-bottom: kbq-css-variable(checkbox-size-normal-padding-bottom);
+    padding-bottom: var(--kbq-checkbox-size-normal-padding-bottom);
 
     padding-left: kbq-sum-series-css-variables(
         [checkbox-size-normal-width,
@@ -58,11 +58,11 @@
     display: inline-block;
 
     position: absolute;
-    top: kbq-css-variable(checkbox-size-normal-top);
+    top: var(--kbq-checkbox-size-normal-top);
     left: 0;
 
-    height: kbq-css-variable(checkbox-size-normal-width);
-    width: kbq-css-variable(checkbox-size-normal-width);
+    height: var(--kbq-checkbox-size-normal-width);
+    width: var(--kbq-checkbox-size-normal-width);
 }
 
 .kbq-checkbox {
@@ -100,7 +100,7 @@
     }
 
     & .kbq-hint {
-        margin-top: kbq-css-variable(checkbox-size-normal-vertical-content-padding);
+        margin-top: var(--kbq-checkbox-size-normal-vertical-content-padding);
     }
 }
 
@@ -113,22 +113,22 @@
     }
 
     & .kbq-checkbox__inner-container {
-        top: kbq-css-variable(checkbox-size-big-top);
-        height: kbq-css-variable(checkbox-size-big-width);
-        width: kbq-css-variable(checkbox-size-big-width);
+        top: var(--kbq-checkbox-size-big-top);
+        height: var(--kbq-checkbox-size-big-width);
+        width: var(--kbq-checkbox-size-big-width);
     }
 
     & .kbq-checkbox__frame {
-        border-radius: kbq-css-variable(checkbox-size-big-border-radius);
+        border-radius: var(--kbq-checkbox-size-big-border-radius);
 
         border: {
-            width: kbq-css-variable(checkbox-size-big-border-width);
+            width: var(--kbq-checkbox-size-big-border-width);
             style: solid;
         }
     }
 
     & .kbq-hint {
-        margin-top: kbq-css-variable(checkbox-size-big-vertical-content-padding);
+        margin-top: var(--kbq-checkbox-size-big-vertical-content-padding);
     }
 }
 

--- a/packages/components/code-block/_code-block-theme.scss
+++ b/packages/components/code-block/_code-block-theme.scss
@@ -6,21 +6,21 @@
 @use '../core/styles/common/tokens' as *;
 
 @function kbq-code-block-hljs-attr($attr) {
-    @return kbq-css-variable(code-block-hljs-#{$attr});
+    @return var(--kbq-code-block-hljs-#{$attr});
 }
 
 @mixin kbq-code-block-style($style-name) {
     $base: code-block-#{$style-name};
 
-    background: kbq-css-variable(#{$base}-container-background);
+    background: var(--kbq-#{$base}-container-background);
 
     & .kbq-tab-header {
-        background: kbq-css-variable(#{$base}-header-background) !important;
-        border-color: kbq-css-variable(#{$base}-container-border-color);
+        background: var(--kbq-#{$base}-header-background) !important;
+        border-color: var(--kbq-#{$base}-container-border-color);
     }
 
     .kbq-tab-body__wrapper {
-        border-color: kbq-css-variable(#{$base}-container-border-color);
+        border-color: var(--kbq-#{$base}-container-border-color);
     }
 
     &:not(.kbq-code-block_no-header) {
@@ -30,40 +30,40 @@
     }
 
     & .kbq-code-block-actionbar {
-        background: kbq-css-variable(#{$base}-actionbar-background);
+        background: var(--kbq-#{$base}-actionbar-background);
 
         &.kbq-actionbar-block_floating {
             .kbq-actionbar-block__button-stack {
-                background: kbq-css-variable(#{$base}-actionbar-background);
+                background: var(--kbq-#{$base}-actionbar-background);
             }
         }
     }
 
     &.kbq-code-block_header-with-shadow {
         & .kbq-tab-header {
-            box-shadow: kbq-css-variable(#{$base}-header-shadow);
+            box-shadow: var(--kbq-#{$base}-header-shadow);
         }
     }
 
     &.kbq-code-block_no-header {
         & .kbq-code-block__fade-gradient {
-            background: kbq-css-variable(#{$base}-actionbar-fade-gradient);
+            background: var(--kbq-#{$base}-actionbar-fade-gradient);
         }
     }
 
     .kbq-code-block__show-more {
         .bg-wrapper {
-            background: kbq-css-variable(#{$base}-collapse-button-expand-background);
+            background: var(--kbq-#{$base}-collapse-button-expand-background);
             opacity: 90%;
         }
     }
 
     & .kbq-code-block__show-more_expanded {
-        background: kbq-css-variable(#{$base}-collapse-expanded-background);
+        background: var(--kbq-#{$base}-collapse-expanded-background);
     }
 
     & .kbq-code-block__show-more_collapsed {
-        background: kbq-css-variable(#{$base}-collapse-collapsed-background);
+        background: var(--kbq-#{$base}-collapse-collapsed-background);
     }
 }
 
@@ -351,12 +351,12 @@
         .kbq-tab-group.kbq-focused {
             // paint focus border from the top since because of border constraints
             .kbq-tab-header {
-                box-shadow: 0 2px 0 -1px kbq-css-variable(states-focused-color);
+                box-shadow: 0 2px 0 -1px var(--kbq-states-focused-color);
             }
 
             .kbq-tab-body__wrapper {
-                border-color: kbq-css-variable(states-focused-color);
-                box-shadow: inset 0 0 0.1 1px kbq-css-variable(states-focused-color);
+                border-color: var(--kbq-states-focused-color);
+                box-shadow: inset 0 0 0.1 1px var(--kbq-states-focused-color);
             }
         }
     }

--- a/packages/components/code-block/actionbar.component.scss
+++ b/packages/components/code-block/actionbar.component.scss
@@ -4,8 +4,8 @@
 @use '../core/styles/common/tokens' as *;
 
 $tokens: meta.module-variables(tokens) !default;
-$actionbar-indents: kbq-css-variable(code-block-size-actionbar-padding-vertical)
-    kbq-css-variable(code-block-size-actionbar-padding-horizontal);
+$actionbar-indents: var(--kbq-code-block-size-actionbar-padding-vertical)
+    var(--kbq-code-block-size-actionbar-padding-horizontal);
 
 .kbq-code-block-actionbar {
     display: flex;
@@ -21,13 +21,13 @@ $actionbar-indents: kbq-css-variable(code-block-size-actionbar-padding-vertical)
     margin: $actionbar-indents;
 
     .kbq-actionbar-block__button-stack {
-        gap: kbq-css-variable(code-block-size-actionbar-content-gap-horizontal);
+        gap: var(--kbq-code-block-size-actionbar-content-gap-horizontal);
     }
 
     .kbq-code-block__fade-gradient {
         display: none;
 
-        width: kbq-css-variable(code-block-size-actionbar-fade-gradient-width);
+        width: var(--kbq-code-block-size-actionbar-fade-gradient-width);
     }
 
     &.kbq-actionbar-block_floating {

--- a/packages/components/code-block/code-block.scss
+++ b/packages/components/code-block/code-block.scss
@@ -4,8 +4,8 @@
 
 @use './code-block-theme' as *;
 
-$border-radius: kbq-css-variable(code-block-size-container-border-radius);
-$border-width: kbq-css-variable(code-block-size-container-border-width);
+$border-radius: var(--kbq-code-block-size-container-border-radius);
+$border-width: var(--kbq-code-block-size-container-border-width);
 
 .kbq-code-block {
     display: block;
@@ -26,10 +26,9 @@ $border-width: kbq-css-variable(code-block-size-container-border-width);
         // 4 buttons + margin
         $buttons-margin: calc(32 * 4) + 24px;
 
-        padding: calc(kbq-css-variable(code-block-size-header-padding-vertical) - $border-width)
+        padding: calc(var(--kbq-code-block-size-header-padding-vertical) - $border-width)
             kbq-sum-series-css-variables([code-block-size-header-padding-right, $buttons-margin])
-            kbq-css-variable(code-block-size-header-padding-vertical)
-            kbq-css-variable(code-block-size-header-padding-left);
+            var(--kbq-code-block-size-header-padding-vertical) var(--kbq-code-block-size-header-padding-left);
 
         border-width: $border-width $border-width 0 $border-width;
         border-style: solid;
@@ -39,7 +38,7 @@ $border-width: kbq-css-variable(code-block-size-container-border-width);
     &:has(.kbq-code-block__show-more) {
         .kbq-code-block__code {
             & > code {
-                padding-bottom: kbq-css-variable(size-3xl) !important;
+                padding-bottom: var(--kbq-size-3xl) !important;
                 overflow-x: scroll;
             }
         }
@@ -55,10 +54,10 @@ $border-width: kbq-css-variable(code-block-size-container-border-width);
 
     .kbq-code-block__code {
         > code {
-            padding: kbq-css-variable(code-block-size-with-header-content-padding-top)
-                kbq-css-variable(code-block-size-with-header-content-padding-horizontal)
-                kbq-css-variable(code-block-size-with-header-content-padding-bottom)
-                kbq-css-variable(code-block-size-with-header-content-padding-horizontal);
+            padding: var(--kbq-code-block-size-with-header-content-padding-top)
+                var(--kbq-code-block-size-with-header-content-padding-horizontal)
+                var(--kbq-code-block-size-with-header-content-padding-bottom)
+                var(--kbq-code-block-size-with-header-content-padding-horizontal);
 
             border-radius: $border-radius;
 
@@ -68,7 +67,7 @@ $border-width: kbq-css-variable(code-block-size-container-border-width);
         }
 
         .hljs-ln-numbers {
-            padding-right: kbq-css-variable(code-block-size-with-header-content-content-gap-horizontal);
+            padding-right: var(--kbq-code-block-size-with-header-content-content-gap-horizontal);
         }
     }
 
@@ -110,12 +109,12 @@ $border-width: kbq-css-variable(code-block-size-container-border-width);
             position: relative;
 
             & > code {
-                padding: kbq-css-variable(code-block-size-no-header-content-padding-vertical)
-                    kbq-css-variable(code-block-size-no-header-content-padding-horizontal);
+                padding: var(--kbq-code-block-size-no-header-content-padding-vertical)
+                    var(--kbq-code-block-size-no-header-content-padding-horizontal);
             }
 
             .hljs-ln-numbers {
-                padding-right: kbq-css-variable(code-block-size-no-header-content-content-gap-horizontal);
+                padding-right: var(--kbq-code-block-size-no-header-content-content-gap-horizontal);
             }
         }
     }
@@ -183,19 +182,19 @@ $border-width: kbq-css-variable(code-block-size-container-border-width);
     border-radius: $border-radius;
 
     &.kbq-code-block__show-more_collapsed {
-        padding-top: kbq-css-variable(code-block-size-collapse-collapsed-padding-top);
+        padding-top: var(--kbq-code-block-size-collapse-collapsed-padding-top);
 
-        padding-bottom: kbq-css-variable(code-block-size-collapse-collapsed-padding-bottom);
+        padding-bottom: var(--kbq-code-block-size-collapse-collapsed-padding-bottom);
     }
 
     &.kbq-code-block__show-more_expanded {
-        padding-top: kbq-css-variable(code-block-size-collapse-expanded-padding-top);
+        padding-top: var(--kbq-code-block-size-collapse-expanded-padding-top);
 
-        margin-bottom: kbq-css-variable(code-block-size-collapse-expanded-padding-bottom);
+        margin-bottom: var(--kbq-code-block-size-collapse-expanded-padding-bottom);
     }
 
     .bg-wrapper {
-        border-radius: kbq-css-variable(button-size-border-radius);
+        border-radius: var(--kbq-button-size-border-radius);
     }
 }
 

--- a/packages/components/core/forms/_forms-theme.scss
+++ b/packages/components/core/forms/_forms-theme.scss
@@ -7,11 +7,11 @@
     @include kbq-form-geometry();
 
     .kbq-form__label {
-        color: kbq-css-variable(forms-label);
+        color: var(--kbq-forms-label);
     }
 
     .kbq-form__legend {
-        color: kbq-css-variable(forms-legend);
+        color: var(--kbq-forms-legend);
     }
 }
 

--- a/packages/components/core/forms/_forms.scss
+++ b/packages/components/core/forms/_forms.scss
@@ -12,11 +12,11 @@
     }
 
     .kbq-form-horizontal {
-        $line-height: kbq-css-variable(forms-font-label-line-height);
-        $form-field-size-height: kbq-css-variable(form-field-size-height);
+        $line-height: var(--kbq-forms-font-label-line-height);
+        $form-field-size-height: var(--kbq-form-field-size-height);
 
         & .kbq-form-row_margin {
-            margin-bottom: kbq-css-variable(forms-size-horizontal-row-margin-bottom);
+            margin-bottom: var(--kbq-forms-size-horizontal-row-margin-bottom);
         }
 
         & .kbq-form__label {
@@ -26,12 +26,12 @@
         }
 
         & .kbq-form__control {
-            padding-left: kbq-css-variable(forms-size-horizontal-control-padding-left);
+            padding-left: var(--kbq-forms-size-horizontal-control-padding-left);
         }
 
         & .kbq-form__legend {
-            margin-top: kbq-css-variable(forms-size-horizontal-legend-margin-top);
-            margin-bottom: kbq-css-variable(forms-size-horizontal-legend-margin-bottom);
+            margin-top: var(--kbq-forms-size-horizontal-legend-margin-top);
+            margin-bottom: var(--kbq-forms-size-horizontal-legend-margin-bottom);
         }
     }
 
@@ -41,12 +41,12 @@
         }
 
         & .kbq-form-row_margin {
-            margin-bottom: kbq-css-variable(forms-size-vertical-row-margin-bottom);
+            margin-bottom: var(--kbq-forms-size-vertical-row-margin-bottom);
         }
 
         & .kbq-form__label {
-            padding-top: kbq-css-variable(forms-size-vertical-label-padding-top);
-            padding-bottom: kbq-css-variable(forms-size-vertical-label-padding-bottom);
+            padding-top: var(--kbq-forms-size-vertical-label-padding-top);
+            padding-bottom: var(--kbq-forms-size-vertical-label-padding-bottom);
 
             text-align: start;
         }
@@ -56,8 +56,8 @@
         }
 
         & .kbq-form__legend {
-            margin-top: kbq-css-variable(forms-size-vertical-legend-margin-top);
-            margin-bottom: kbq-css-variable(forms-size-vertical-legend-margin-bottom);
+            margin-top: var(--kbq-forms-size-vertical-legend-margin-top);
+            margin-bottom: var(--kbq-forms-size-vertical-legend-margin-bottom);
         }
     }
 
@@ -70,7 +70,7 @@
         flex-direction: row;
 
         & .kbq-form__row:not(:first-child) {
-            padding-left: kbq-css-variable(forms-size-vertical-control-padding-left);
+            padding-left: var(--kbq-forms-size-vertical-control-padding-left);
         }
     }
 }

--- a/packages/components/core/option/_optgroup-theme.scss
+++ b/packages/components/core/option/_optgroup-theme.scss
@@ -2,11 +2,11 @@
 
 @mixin kbq-optgroup-theme() {
     .kbq-optgroup-label {
-        color: kbq-css-variable(foreground-contrast);
+        color: var(--kbq-foreground-contrast);
     }
 
     .kbq-disabled .kbq-optgroup-label {
-        color: kbq-css-variable(foreground-text-disabled);
+        color: var(--kbq-foreground-text-disabled);
     }
 }
 

--- a/packages/components/core/option/_option-action-theme.scss
+++ b/packages/components/core/option/_option-action-theme.scss
@@ -3,28 +3,28 @@
 @mixin kbq-option-action-theme() {
     .kbq-option-action {
         &.cdk-keyboard-focused {
-            border-color: kbq-css-variable(states-focused-color);
+            border-color: var(--kbq-states-focused-color);
         }
 
         &:active,
         &.kbq-pressed {
             & .kbq-icon {
-                color: kbq-css-variable(states-icon-contrast-fade-active);
+                color: var(--kbq-states-icon-contrast-fade-active);
             }
 
-            background-color: kbq-css-variable(background-transparent);
+            background-color: var(--kbq-background-transparent);
         }
 
         &:hover .kbq-icon {
-            color: kbq-css-variable(states-icon-contrast-fade-hover);
+            color: var(--kbq-states-icon-contrast-fade-hover);
         }
 
         &.kbq-disabled {
             & .kbq-icon {
-                color: kbq-css-variable(states-icon-disabled);
+                color: var(--kbq-states-icon-disabled);
             }
 
-            background-color: kbq-css-variable(background-transparent);
+            background-color: var(--kbq-background-transparent);
         }
     }
 }

--- a/packages/components/core/option/_option-theme.scss
+++ b/packages/components/core/option/_option-theme.scss
@@ -1,18 +1,18 @@
 @use '../styles/common/tokens' as *;
 
 @mixin kbq-option($style-name) {
-    background: kbq-css-variable(list-#{$style-name}-container-background);
+    background: var(--kbq-list-#{$style-name}-container-background);
 
     .kbq-option-text {
-        color: kbq-css-variable(list-#{$style-name}-text-color);
+        color: var(--kbq-list-#{$style-name}-text-color);
     }
 
     .kbq-option-action .kbq-icon {
-        color: kbq-css-variable(list-#{$style-name}-icon-button-color);
+        color: var(--kbq-list-#{$style-name}-icon-button-color);
     }
 
     .kbq-option-caption {
-        color: kbq-css-variable(list-#{$style-name}-caption-color);
+        color: var(--kbq-list-#{$style-name}-caption-color);
     }
 }
 
@@ -26,7 +26,7 @@
 
         &.kbq-focused,
         &.kbq-active {
-            border-color: kbq-css-variable(list-states-focused-focus-outline-color);
+            border-color: var(--kbq-list-states-focused-focus-outline-color);
         }
 
         &.kbq-selected {

--- a/packages/components/core/option/action.scss
+++ b/packages/components/core/option/action.scss
@@ -14,8 +14,8 @@
 
     margin-right: -2px;
 
-    width: kbq-css-variable(list-font-text-line-height);
-    height: kbq-css-variable(list-font-text-line-height);
+    width: var(--kbq-list-font-text-line-height);
+    height: var(--kbq-list-font-text-line-height);
 
     cursor: pointer;
 

--- a/packages/components/core/option/optgroup.scss
+++ b/packages/components/core/option/optgroup.scss
@@ -4,7 +4,7 @@
 @use './optgroup-theme' as *;
 
 .kbq-optgroup-label {
-    padding-left: kbq-css-variable(size-m);
+    padding-left: var(--kbq-size-m);
 
     @include vendor-prefixes.user-select(none);
     cursor: default;

--- a/packages/components/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
+++ b/packages/components/core/selection/pseudo-checkbox/_pseudo-checkbox-theme.scss
@@ -5,28 +5,28 @@
 @mixin kbq-pseudo-checkbox-color($style-name) {
     $base: checkbox-#{$style-name};
 
-    border-color: kbq-css-variable(#{$base}-default-border);
-    background: kbq-css-variable(#{$base}-default-background);
+    border-color: var(--kbq-#{$base}-default-border);
+    background: var(--kbq-#{$base}-default-background);
 
     & .kbq-checkbox-checkmark,
     & .kbq-checkbox-mixedmark {
-        color: kbq-css-variable(#{$base}-default-color);
+        color: var(--kbq-#{$base}-default-color);
     }
 
     &.kbq-checked,
     &.kbq-indeterminate {
-        border-color: kbq-css-variable(#{$base}-states-checked-border);
-        background: kbq-css-variable(#{$base}-states-checked-background);
+        border-color: var(--kbq-#{$base}-states-checked-border);
+        background: var(--kbq-#{$base}-states-checked-background);
     }
 
     &.kbq-disabled {
         & .kbq-checkbox-checkmark,
         & .kbq-checkbox-mixedmark {
-            color: kbq-css-variable(#{$base}-states-disabled-color);
+            color: var(--kbq-#{$base}-states-disabled-color);
         }
 
-        border-color: kbq-css-variable(#{$base}-states-disabled-border);
-        background: kbq-css-variable(#{$base}-states-disabled-background);
+        border-color: var(--kbq-#{$base}-states-disabled-border);
+        background: var(--kbq-#{$base}-states-disabled-background);
     }
 }
 

--- a/packages/components/core/selection/pseudo-checkbox/pseudo-checkbox.scss
+++ b/packages/components/core/selection/pseudo-checkbox/pseudo-checkbox.scss
@@ -13,12 +13,12 @@
     align-items: center;
     justify-content: center;
 
-    width: kbq-css-variable(checkbox-size-normal-width);
-    height: kbq-css-variable(checkbox-size-normal-width);
+    width: var(--kbq-checkbox-size-normal-width);
+    height: var(--kbq-checkbox-size-normal-width);
 
     border: {
-        radius: kbq-css-variable(checkbox-size-normal-border-radius);
-        width: kbq-css-variable(checkbox-size-normal-border-width);
+        radius: var(--kbq-checkbox-size-normal-border-radius);
+        width: var(--kbq-checkbox-size-normal-border-width);
         style: solid;
     }
 
@@ -55,12 +55,12 @@
 }
 
 .kbq-pseudo-checkbox.kbq-pseudo-checkbox_big {
-    width: kbq-css-variable(checkbox-size-big-width);
-    height: kbq-css-variable(checkbox-size-big-width);
+    width: var(--kbq-checkbox-size-big-width);
+    height: var(--kbq-checkbox-size-big-width);
 
     border: {
-        radius: kbq-css-variable(checkbox-size-big-border-radius);
-        width: kbq-css-variable(checkbox-size-big-border-width);
+        radius: var(--kbq-checkbox-size-big-border-radius);
+        width: var(--kbq-checkbox-size-big-border-width);
     }
 }
 

--- a/packages/components/core/styles/common/_groups.scss
+++ b/packages/components/core/styles/common/_groups.scss
@@ -45,7 +45,7 @@ $tokens: meta.module-variables(tokens) !default;
     }
 
     .kbq-group-item + .kbq-group-item {
-        margin-left: calc(-1 * #{kbq-css-variable(button-size-border-width)});
+        margin-left: calc(-1 * #{var(--kbq-button-size-border-width)});
     }
 
     & > .kbq-group-item:first-child:not(:last-child) {
@@ -81,7 +81,7 @@ $tokens: meta.module-variables(tokens) !default;
         &:first-child:not(:last-child) {
             @include border-bottom-radius(0);
 
-            border-top-right-radius: kbq-css-variable(button-size-border-radius);
+            border-top-right-radius: var(--kbq-button-size-border-radius);
 
             > .kbq-form-field__container {
                 @include border-bottom-radius(0);
@@ -91,7 +91,7 @@ $tokens: meta.module-variables(tokens) !default;
         &:last-child:not(:first-child) {
             @include border-top-radius(0);
 
-            border-bottom-left-radius: kbq-css-variable(button-size-border-radius);
+            border-bottom-left-radius: var(--kbq-button-size-border-radius);
 
             > .kbq-form-field__container {
                 @include border-top-radius(0);
@@ -108,6 +108,6 @@ $tokens: meta.module-variables(tokens) !default;
     }
 
     .kbq-group-item + .kbq-group-item {
-        margin-top: calc(-1 * #{kbq-css-variable(button-size-border-width)});
+        margin-top: calc(-1 * #{var(--kbq-button-size-border-width)});
     }
 }

--- a/packages/components/core/styles/common/_list.scss
+++ b/packages/components/core/styles/common/_list.scss
@@ -64,21 +64,21 @@
     outline: none;
     -webkit-tap-highlight-color: transparent;
     min-height: 32px;
-    gap: kbq-css-variable(size-s);
+    gap: var(--kbq-size-s);
 
-    border: kbq-css-variable(size-3xs) solid transparent;
+    border: var(--kbq-size-3xs) solid transparent;
 
-    padding-top: kbq-css-variable(size-xxs);
-    padding-left: kbq-css-variable(size-m);
-    padding-right: kbq-css-variable(size-m);
-    padding-bottom: kbq-css-variable(size-xxs);
+    padding-top: var(--kbq-size-xxs);
+    padding-left: var(--kbq-size-m);
+    padding-right: var(--kbq-size-m);
+    padding-bottom: var(--kbq-size-xxs);
 
     .kbq-list-text {
         @include kbq-list-text();
     }
 
     .kbq-list-option-caption {
-        padding-top: kbq-css-variable(size-3xs);
+        padding-top: var(--kbq-size-3xs);
     }
 }
 
@@ -89,13 +89,13 @@
     box-sizing: border-box;
     min-height: 32px;
 
-    border-left: kbq-css-variable(size-3xs) solid transparent;
-    border-right: kbq-css-variable(size-3xs) solid transparent;
+    border-left: var(--kbq-size-3xs) solid transparent;
+    border-right: var(--kbq-size-3xs) solid transparent;
 
-    padding-top: kbq-css-variable(size-xs);
-    padding-left: kbq-css-variable(size-m);
-    padding-right: kbq-css-variable(size-m);
-    padding-bottom: kbq-css-variable(size-3xs);
+    padding-top: var(--kbq-size-xs);
+    padding-left: var(--kbq-size-m);
+    padding-right: var(--kbq-size-m);
+    padding-bottom: var(--kbq-size-3xs);
 
     .kbq-list-text {
         @include kbq-list-text();
@@ -109,13 +109,13 @@
     box-sizing: border-box;
     min-height: 32px;
 
-    border-left: kbq-css-variable(size-3xs) solid transparent;
-    border-right: kbq-css-variable(size-3xs) solid transparent;
+    border-left: var(--kbq-size-3xs) solid transparent;
+    border-right: var(--kbq-size-3xs) solid transparent;
 
-    padding-top: kbq-css-variable(size-m);
-    padding-left: kbq-css-variable(size-m);
-    padding-right: kbq-css-variable(size-m);
-    padding-bottom: kbq-css-variable(size-xxs);
+    padding-top: var(--kbq-size-m);
+    padding-left: var(--kbq-size-m);
+    padding-right: var(--kbq-size-m);
+    padding-bottom: var(--kbq-size-xxs);
 
     .kbq-list-text {
         @include kbq-list-text();

--- a/packages/components/core/styles/common/_popup.scss
+++ b/packages/components/core/styles/common/_popup.scss
@@ -4,8 +4,8 @@
 @mixin popup-params($theme) {
     $popup: map.get($theme, components, popup);
 
-    box-shadow: kbq-css-variable(popup-shadow, map.get($popup, shadow));
-    border-color: kbq-css-variable(popup-border, map.get($popup, border));
+    box-shadow: var(--kbq-popup-shadow, map.get($popup, shadow));
+    border-color: var(--kbq-popup-border, map.get($popup, border));
 
-    background-color: kbq-css-variable(popup-background, map.get($popup, background));
+    background-color: var(--kbq-popup-background, map.get($popup, background));
 }

--- a/packages/components/core/styles/common/_select.scss
+++ b/packages/components/core/styles/common/_select.scss
@@ -42,7 +42,7 @@ $tokens: meta.module-variables(tokens) !default;
 
         height: kbq-difference-series-css-variables(
             [form-field-size-height,
-            calc(kbq-css-variable(form-field-size-border-width) * 2)]
+            calc(var(--kbq-form-field-size-border-width) * 2)]
         );
     }
 
@@ -83,17 +83,17 @@ $tokens: meta.module-variables(tokens) !default;
 
                 height: kbq-difference-series-css-variables(
                     [form-field-size-height,
-                    calc(kbq-css-variable(select-size-multiple-padding-vertical) * 2)]
+                    calc(var(--kbq-select-size-multiple-padding-vertical) * 2)]
                 );
 
                 max-height: kbq-difference-series-css-variables(
                     [form-field-size-height,
-                    calc(kbq-css-variable(select-size-multiple-padding-vertical) * 2)]
+                    calc(var(--kbq-select-size-multiple-padding-vertical) * 2)]
                 );
 
-                gap: kbq-css-variable(select-size-multiple-content-gap);
+                gap: var(--kbq-select-size-multiple-content-gap);
 
-                margin-right: kbq-css-variable(select-size-multiple-content-gap);
+                margin-right: var(--kbq-select-size-multiple-content-gap);
             }
         }
     }
@@ -108,7 +108,7 @@ $tokens: meta.module-variables(tokens) !default;
             flex: 0 0 70px;
             align-self: center;
             padding-left: 4px;
-            padding-right: kbq-css-variable(select-size-multiple-content-gap);
+            padding-right: var(--kbq-select-size-multiple-content-gap);
 
             text-align: right;
         }
@@ -146,7 +146,7 @@ $tokens: meta.module-variables(tokens) !default;
 
     overflow: hidden;
 
-    border-radius: kbq-css-variable(select-panel-size-border-radius);
+    border-radius: var(--kbq-select-panel-size-border-radius);
 
     // Override optgroup and option to scale based on font-size of the trigger.
     .kbq-optgroup-label,
@@ -163,15 +163,15 @@ $tokens: meta.module-variables(tokens) !default;
         position: relative;
 
         max-width: 100%;
-        height: kbq-css-variable(option-size-height);
+        height: var(--kbq-option-size-height);
 
         cursor: default;
         outline: none;
 
-        padding-left: kbq-css-variable(option-size-horizontal-padding);
-        padding-right: kbq-css-variable(option-size-horizontal-padding);
+        padding-left: var(--kbq-option-size-horizontal-padding);
+        padding-right: var(--kbq-option-size-horizontal-padding);
 
-        border: kbq-css-variable(option-size-border-width) solid transparent;
+        border: var(--kbq-option-size-border-width) solid transparent;
     }
 
     .kbq-select__search-container {
@@ -183,7 +183,7 @@ $tokens: meta.module-variables(tokens) !default;
 }
 
 %kbq-select-content {
-    max-height: kbq-css-variable(select-panel-size-max-height);
+    max-height: var(--kbq-select-panel-size-max-height);
     padding: 4px 0;
     overflow: hidden auto;
 }
@@ -198,5 +198,5 @@ $tokens: meta.module-variables(tokens) !default;
     border-top-width: 1px;
     border-top-style: solid;
 
-    padding: kbq-css-variable(size-xxs) kbq-css-variable(size-m);
+    padding: var(--kbq-size-xxs) var(--kbq-size-m);
 }

--- a/packages/components/core/styles/common/_tokens.scss
+++ b/packages/components/core/styles/common/_tokens.scss
@@ -20,10 +20,7 @@ $tokens: meta.module-variables(tokens) !default;
 }
 
 @mixin kbq-css-font-variable($component, $component-property, $font-property, $font) {
-    #{$font-property}: var(
-        --kbq-#{$component}-#{$font}#{$component-property}-#{$font-property},
-        map.get($tokens, #{$component}-#{$font}#{$component-property}-#{$font-property})
-    );
+    #{$font-property}: var(--kbq-#{$component}-#{$font}#{$component-property}-#{$font-property});
 }
 
 @mixin kbq-typography-css-variables($component, $property) {
@@ -53,13 +50,13 @@ $tokens: meta.module-variables(tokens) !default;
             @if (meta.type-of($variable) == number or meta.type-of($variable) == calculation) {
                 $sum: $variable;
             } @else {
-                $sum: kbq-css-variable($variable);
+                $sum: var(--kbq-#{$variable});
             }
         } @else {
             @if (meta.type-of($variable) == number or meta.type-of($variable) == calculation) {
                 $sum: calc($sum + $variable);
             } @else {
-                $sum: calc($sum + kbq-css-variable($variable));
+                $sum: calc($sum + var(--kbq-#{$variable}));
             }
         }
     }
@@ -73,13 +70,13 @@ $tokens: meta.module-variables(tokens) !default;
             @if (meta.type-of($variable) == number or meta.type-of($variable) == calculation) {
                 $difference: $variable;
             } @else {
-                $difference: kbq-css-variable($variable);
+                $difference: var(--kbq-#{$variable});
             }
         } @else {
             @if (meta.type-of($variable) == number or meta.type-of($variable) == calculation) {
                 $difference: calc($difference - $variable);
             } @else {
-                $difference: calc($difference - kbq-css-variable($variable));
+                $difference: calc($difference - var(--kbq-#{$variable}));
             }
         }
     }
@@ -89,11 +86,11 @@ $tokens: meta.module-variables(tokens) !default;
 @function kbq-css-half-difference($outer, $inner, $border: null) {
     @if $border {
         @if (meta.type-of($border) == number or meta.type-of($border) == calculation) {
-            @return calc((kbq-css-variable($outer) - kbq-css-variable($inner) - $border * 2) / 2);
+            @return calc((var(--kbq-#{$outer}) - var(--kbq-#{$inner}) - $border * 2) / 2);
         } @else {
-            @return calc((kbq-css-variable($outer) - kbq-css-variable($inner) - kbq-css-variable($border * 2)) / 2);
+            @return calc((var(--kbq-#{$outer}) - var(--kbq-#{$inner}) - var(--kbq-#{$border} * 2)) / 2);
         }
     } @else {
-        @return calc((kbq-css-variable($outer) - kbq-css-variable($inner)) / 2);
+        @return calc((var(--kbq-#{$outer}) - var(--kbq-#{$inner})) / 2);
     }
 }

--- a/packages/components/core/styles/common/_tokens.scss
+++ b/packages/components/core/styles/common/_tokens.scss
@@ -7,14 +7,6 @@
 
 $tokens: meta.module-variables(tokens) !default;
 
-@function kbq-css-variable($name, $value: null) {
-    @if $value {
-        @return var(--kbq-#{$name}, $value);
-    } @else {
-        @return var(--kbq-#{$name}, map.get($tokens, $name));
-    }
-}
-
 @function getToken($name) {
     @return map.get($tokens, $name);
 }

--- a/packages/components/core/styles/theming/_scrollbar-theme.scss
+++ b/packages/components/core/styles/theming/_scrollbar-theme.scss
@@ -20,29 +20,29 @@
         cursor: default;
 
         &:vertical {
-            width: kbq-css-variable(scrollbar-size-track-dimension);
+            width: var(--kbq-scrollbar-size-track-dimension);
         }
 
         &:horizontal {
-            height: kbq-css-variable(scrollbar-size-track-dimension);
+            height: var(--kbq-scrollbar-size-track-dimension);
         }
     }
 
     &::-webkit-scrollbar-thumb,
     ::-webkit-scrollbar-thumb {
-        width: kbq-css-variable(scrollbar-size-thumb-width);
+        width: var(--kbq-scrollbar-size-thumb-width);
         border-style: solid;
         border-width: kbq-css-half-difference(scrollbar-size-track-dimension, scrollbar-size-thumb-width);
 
-        border-radius: kbq-css-variable(scrollbar-size-thumb-border-radius);
+        border-radius: var(--kbq-scrollbar-size-thumb-border-radius);
 
         // these props are used to set the user-friendly thumb for long content.
         &:vertical {
-            min-height: kbq-css-variable(scrollbar-size-thumb-min-size);
+            min-height: var(--kbq-scrollbar-size-thumb-min-size);
         }
 
         &:horizontal {
-            min-width: kbq-css-variable(scrollbar-size-thumb-min-size);
+            min-width: var(--kbq-scrollbar-size-thumb-min-size);
         }
     }
 
@@ -58,7 +58,7 @@
 
         // firefox
         @supports not selector(::-webkit-scrollbar) {
-            scrollbar-color: kbq-css-variable(scrollbar-thumb-default-background) transparent;
+            scrollbar-color: var(--kbq-scrollbar-thumb-default-background) transparent;
         }
 
         // webkit
@@ -72,18 +72,18 @@
             border-color: transparent;
 
             background-clip: content-box;
-            background-color: kbq-css-variable(scrollbar-thumb-default-background);
+            background-color: var(--kbq-scrollbar-thumb-default-background);
 
             &:hover {
-                background-color: kbq-css-variable(scrollbar-thumb-hover-background);
+                background-color: var(--kbq-scrollbar-thumb-hover-background);
             }
 
             &:disabled {
-                background-color: kbq-css-variable(scrollbar-thumb-disabled-background);
+                background-color: var(--kbq-scrollbar-thumb-disabled-background);
             }
 
             &:active {
-                background-color: kbq-css-variable(scrollbar-thumb-active-background);
+                background-color: var(--kbq-scrollbar-thumb-active-background);
             }
         }
     }

--- a/packages/components/core/styles/visual/_layout.scss
+++ b/packages/components/core/styles/visual/_layout.scss
@@ -463,19 +463,19 @@
 
 @mixin layout-indents() {
     $sizes: (
-        '3xs': kbq-css-variable(size-3xs),
-        'xxs': kbq-css-variable(size-xxs),
-        'xs': kbq-css-variable(size-xs),
-        's': kbq-css-variable(size-s),
-        'm': kbq-css-variable(size-m),
-        'l': kbq-css-variable(size-l),
-        'xl': kbq-css-variable(size-xl),
-        'xxl': kbq-css-variable(size-xxl),
-        '3xl': kbq-css-variable(size-3xl),
-        '4xl': kbq-css-variable(size-4xl),
-        '5xl': kbq-css-variable(size-5xl),
-        '6xl': kbq-css-variable(size-6xl),
-        '7xl': kbq-css-variable(size-7xl)
+        '3xs': var(--kbq-size-3xs),
+        'xxs': var(--kbq-size-xxs),
+        'xs': var(--kbq-size-xs),
+        's': var(--kbq-size-s),
+        'm': var(--kbq-size-m),
+        'l': var(--kbq-size-l),
+        'xl': var(--kbq-size-xl),
+        'xxl': var(--kbq-size-xxl),
+        '3xl': var(--kbq-size-3xl),
+        '4xl': var(--kbq-size-4xl),
+        '5xl': var(--kbq-size-5xl),
+        '6xl': var(--kbq-size-6xl),
+        '7xl': var(--kbq-size-7xl)
     );
 
     $indents: 'padding', 'margin';

--- a/packages/components/datepicker/_datepicker-theme.scss
+++ b/packages/components/datepicker/_datepicker-theme.scss
@@ -7,47 +7,47 @@
 
 @mixin kbq-datepicker-theme() {
     .kbq-datepicker__content {
-        background: kbq-css-variable(datepicker-container-background);
-        box-shadow: kbq-css-variable(datepicker-container-box-shadow);
+        background: var(--kbq-datepicker-container-background);
+        box-shadow: var(--kbq-datepicker-container-box-shadow);
     }
 
     .kbq-calendar__table-header {
-        color: kbq-css-variable(datepicker-header-text);
+        color: var(--kbq-datepicker-header-text);
     }
 
     .kbq-calendar__table-header-divider::after {
-        background: kbq-css-variable(datepicker-header-divider);
+        background: var(--kbq-datepicker-header-divider);
     }
 
     .kbq-calendar__body-cell-content {
-        background: kbq-css-variable(datepicker-grid-cell-default-background);
-        color: kbq-css-variable(datepicker-grid-cell-default-text);
+        background: var(--kbq-datepicker-grid-cell-default-background);
+        color: var(--kbq-datepicker-grid-cell-default-text);
 
         &.kbq-calendar__body-today {
-            background: kbq-css-variable(datepicker-grid-cell-today-background);
-            color: kbq-css-variable(datepicker-grid-cell-today-text);
+            background: var(--kbq-datepicker-grid-cell-today-background);
+            color: var(--kbq-datepicker-grid-cell-today-text);
         }
 
         &:hover:not(.kbq-disabled) {
-            background: kbq-css-variable(datepicker-grid-cell-states-hover-background);
+            background: var(--kbq-datepicker-grid-cell-states-hover-background);
         }
 
         &:active:not(.kbq-disabled) {
-            background: kbq-css-variable(datepicker-grid-cell-states-active-background);
+            background: var(--kbq-datepicker-grid-cell-states-active-background);
         }
 
         &.kbq-selected:not(.kbq-disabled) {
-            background: kbq-css-variable(datepicker-grid-cell-states-selected-background);
-            color: kbq-css-variable(datepicker-grid-cell-states-selected-text);
+            background: var(--kbq-datepicker-grid-cell-states-selected-background);
+            color: var(--kbq-datepicker-grid-cell-states-selected-text);
 
             &:hover {
-                background: kbq-css-variable(datepicker-grid-cell-states-selected-hover-background);
+                background: var(--kbq-datepicker-grid-cell-states-selected-hover-background);
             }
         }
 
         &.kbq-disabled {
-            color: kbq-css-variable(states-foreground-disabled);
-            background: kbq-css-variable(datepicker-grid-cell-states-disabled-background);
+            color: var(--kbq-states-foreground-disabled);
+            background: var(--kbq-datepicker-grid-cell-states-disabled-background);
         }
     }
 }

--- a/packages/components/datepicker/calendar-body.scss
+++ b/packages/components/datepicker/calendar-body.scss
@@ -32,7 +32,7 @@ $tokens: meta.module-variables(tokens) !default;
     // Prevents text being off-center on Android.
     line-height: 1;
 
-    border-radius: kbq-css-variable(datepicker-size-grid-cell-border-radius);
+    border-radius: var(--kbq-datepicker-size-grid-cell-border-radius);
 
-    margin-bottom: kbq-css-variable(datepicker-size-grid-content-gap-vertical);
+    margin-bottom: var(--kbq-datepicker-size-grid-content-gap-vertical);
 }

--- a/packages/components/datepicker/calendar-header.scss
+++ b/packages/components/datepicker/calendar-header.scss
@@ -11,11 +11,11 @@ $tokens: meta.module-variables(tokens) !default;
     flex-direction: row;
     justify-content: space-between;
 
-    padding-right: kbq-css-variable(datepicker-size-header-padding-horizontal);
+    padding-right: var(--kbq-datepicker-size-header-padding-horizontal);
 
-    padding-left: kbq-css-variable(datepicker-size-header-padding-horizontal);
+    padding-left: var(--kbq-datepicker-size-header-padding-horizontal);
 
-    margin-bottom: kbq-css-variable(datepicker-size-header-margin-bottom);
+    margin-bottom: var(--kbq-datepicker-size-header-margin-bottom);
 }
 
 .kbq-calendar-header__select {

--- a/packages/components/datepicker/calendar.scss
+++ b/packages/components/datepicker/calendar.scss
@@ -8,9 +8,9 @@
 }
 
 .kbq-calendar__content {
-    padding-right: kbq-css-variable(datepicker-size-grid-padding-horizontal);
+    padding-right: var(--kbq-datepicker-size-grid-padding-horizontal);
 
-    padding-left: kbq-css-variable(datepicker-size-grid-padding-horizontal);
+    padding-left: var(--kbq-datepicker-size-grid-padding-horizontal);
 
     outline: none;
 }
@@ -29,7 +29,7 @@
         position: relative;
 
         box-sizing: border-box;
-        height: kbq-css-variable(datepicker-size-grid-content-gap-vertical);
+        height: var(--kbq-datepicker-size-grid-content-gap-vertical);
 
         // We use an absolutely positioned pseudo-element as the divider line for the table header so we
         // can extend it all the way to the edge of the calendar.
@@ -38,10 +38,10 @@
 
             position: absolute;
             top: 0;
-            left: calc(-1 * #{kbq-css-variable(datepicker-size-grid-padding-horizontal)});
-            right: calc(-1 * #{kbq-css-variable(datepicker-size-grid-padding-horizontal)});
+            left: calc(-1 * #{var(--kbq-datepicker-size-grid-padding-horizontal)});
+            right: calc(-1 * #{var(--kbq-datepicker-size-grid-padding-horizontal)});
 
-            height: kbq-css-variable(datepicker-size-grid-divider-height);
+            height: var(--kbq-datepicker-size-grid-divider-height);
         }
     }
 }

--- a/packages/components/datepicker/datepicker-content.scss
+++ b/packages/components/datepicker/datepicker-content.scss
@@ -6,7 +6,7 @@
 @use './datepicker-theme' as *;
 
 $kbq-datepicker-non-touch-calendar-cell-size: 40px;
-$kbq-datepicker-size-grid-padding-horizontal: kbq-css-variable(datepicker-size-grid-padding-horizontal);
+$kbq-datepicker-size-grid-padding-horizontal: var(--kbq-datepicker-size-grid-padding-horizontal);
 
 $kbq-datepicker-non-touch-calendar-width: calc(
     $kbq-datepicker-non-touch-calendar-cell-size * 7 + $kbq-datepicker-size-grid-padding-horizontal * 2
@@ -18,15 +18,15 @@ $kbq-datepicker-non-touch-calendar-height: 270px;
 .kbq-datepicker__content {
     display: block;
 
-    border-radius: kbq-css-variable(datepicker-size-container-border-radius);
+    border-radius: var(--kbq-datepicker-size-container-border-radius);
 
     .kbq-calendar {
         width: $kbq-datepicker-non-touch-calendar-width;
         height: $kbq-datepicker-non-touch-calendar-height;
 
-        padding-top: kbq-css-variable(datepicker-size-container-padding-vertical);
+        padding-top: var(--kbq-datepicker-size-container-padding-vertical);
 
-        padding-bottom: kbq-css-variable(datepicker-size-container-padding-vertical);
+        padding-bottom: var(--kbq-datepicker-size-container-padding-vertical);
     }
 }
 

--- a/packages/components/datepicker/datepicker-toggle.scss
+++ b/packages/components/datepicker/datepicker-toggle.scss
@@ -12,8 +12,8 @@ $tokens: meta.module-variables(tokens) !default;
 
 .kbq-datepicker-toggle__button.kbq-button-icon {
     // FIXME: no such tokens in design-tokens, component needs to be reviewed
-    width: kbq-css-variable(datepicker-toggle-size-width);
-    height: kbq-css-variable(datepicker-toggle-size-height);
+    width: var(--kbq-datepicker-toggle-size-width);
+    height: var(--kbq-datepicker-toggle-size-height);
     margin-left: 2px;
 }
 

--- a/packages/components/divider/_divider-theme.scss
+++ b/packages/components/divider/_divider-theme.scss
@@ -4,6 +4,6 @@
 
 @mixin kbq-divider-theme() {
     .kbq-divider {
-        background: kbq-css-variable(divider-color);
+        background: var(--kbq-divider-color);
     }
 }

--- a/packages/components/divider/divider.scss
+++ b/packages/components/divider/divider.scss
@@ -10,23 +10,23 @@
     margin: 0;
 
     &.kbq-divider_horizontal {
-        height: kbq-css-variable(divider-size-horizontal-width);
+        height: var(--kbq-divider-size-horizontal-width);
 
         &.kbq-divider_paddings {
-            margin-top: kbq-css-variable(divider-size-horizontal-margin-vertical);
+            margin-top: var(--kbq-divider-size-horizontal-margin-vertical);
 
-            margin-bottom: kbq-css-variable(divider-size-horizontal-margin-vertical);
+            margin-bottom: var(--kbq-divider-size-horizontal-margin-vertical);
         }
     }
 
     &.kbq-divider_vertical {
-        width: kbq-css-variable(divider-size-vertical-width);
+        width: var(--kbq-divider-size-vertical-width);
         height: 100%;
 
         &.kbq-divider_paddings {
-            margin-left: kbq-css-variable(divider-size-vertical-margin-horizontal);
+            margin-left: var(--kbq-divider-size-vertical-margin-horizontal);
 
-            margin-right: kbq-css-variable(divider-size-vertical-margin-horizontal);
+            margin-right: var(--kbq-divider-size-vertical-margin-horizontal);
         }
     }
 }

--- a/packages/components/dl/_dl-theme.scss
+++ b/packages/components/dl/_dl-theme.scss
@@ -6,11 +6,11 @@
 
 @mixin kbq-dl-theme() {
     .kbq-dt {
-        color: kbq-css-variable(description-list-term-color);
+        color: var(--kbq-description-list-term-color);
     }
 
     .kbq-dd {
-        color: kbq-css-variable(description-list-description-color);
+        color: var(--kbq-description-list-description-color);
     }
 }
 

--- a/packages/components/dl/dl.scss
+++ b/packages/components/dl/dl.scss
@@ -7,8 +7,8 @@
 
 .kbq-dl {
     display: grid;
-    column-gap: kbq-css-variable(description-list-size-horizontal-content-gap-horizontal);
-    row-gap: kbq-css-variable(description-list-size-horizontal-gap-vertical);
+    column-gap: var(--kbq-description-list-size-horizontal-content-gap-horizontal);
+    row-gap: var(--kbq-description-list-size-horizontal-gap-vertical);
 
     grid-template-columns: repeat(4, 1fr);
 
@@ -35,7 +35,7 @@
     &.kbq-dl_vertical {
         grid-template-columns: repeat(1, 1fr);
 
-        row-gap: kbq-css-variable(description-list-size-vertical-content-gap-vertical);
+        row-gap: var(--kbq-description-list-size-vertical-content-gap-vertical);
 
         .kbq-dt,
         .kbq-dd {
@@ -43,7 +43,7 @@
         }
 
         .kbq-dd {
-            margin-bottom: kbq-css-variable(description-list-size-vertical-gap-vertical);
+            margin-bottom: var(--kbq-description-list-size-vertical-gap-vertical);
         }
     }
 }

--- a/packages/components/dropdown/_dropdown-theme.scss
+++ b/packages/components/dropdown/_dropdown-theme.scss
@@ -6,18 +6,18 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-dropdown-item-state($style-name) {
-    background: kbq-css-variable(list-#{$style-name}-container-background);
-    color: kbq-css-variable(list-#{$style-name}-text-color);
+    background: var(--kbq-list-#{$style-name}-container-background);
+    color: var(--kbq-list-#{$style-name}-text-color);
 
     .kbq-dropdown-item__caption {
-        color: kbq-css-variable(list-#{$style-name}-caption-color);
+        color: var(--kbq-list-#{$style-name}-caption-color);
     }
 }
 
 @mixin kbq-dropdown-theme() {
     .kbq-dropdown__panel {
-        box-shadow: kbq-css-variable(dropdown-container-box-shadow);
-        background: kbq-css-variable(dropdown-container-background);
+        box-shadow: var(--kbq-dropdown-container-box-shadow);
+        background: var(--kbq-dropdown-container-background);
     }
 
     .kbq-dropdown-item {
@@ -29,7 +29,7 @@
         }
 
         &.cdk-keyboard-focused {
-            border-color: kbq-css-variable(list-states-focused-focus-outline-color);
+            border-color: var(--kbq-list-states-focused-focus-outline-color);
         }
 
         &.kbq-selected {
@@ -47,7 +47,7 @@
 
     .kbq-dropdown__group-header {
         &.kbq-dropdown__group-header_small {
-            color: kbq-css-variable(foreground-contrast-secondary);
+            color: var(--kbq-foreground-contrast-secondary);
         }
     }
 

--- a/packages/components/dropdown/dropdown-item.scss
+++ b/packages/components/dropdown/dropdown-item.scss
@@ -21,13 +21,13 @@
     & > .kbq-icon:first-child:before {
         align-self: center;
         display: flex;
-        height: kbq-css-variable(size-xl);
+        height: var(--kbq-size-xl);
         width: 16px;
         align-items: center;
     }
 
     & .kbq-dropdown-item__caption {
-        padding-top: kbq-css-variable(size-3xs);
+        padding-top: var(--kbq-size-3xs);
     }
 }
 

--- a/packages/components/dropdown/dropdown.scss
+++ b/packages/components/dropdown/dropdown.scss
@@ -22,14 +22,14 @@
 .kbq-dropdown__panel {
     margin-top: 2px;
 
-    min-width: kbq-css-variable(dropdown-size-container-width-min);
-    max-width: kbq-css-variable(dropdown-size-container-width-max);
+    min-width: var(--kbq-dropdown-size-container-width-min);
+    max-width: var(--kbq-dropdown-size-container-width-max);
 
-    border-radius: kbq-css-variable(dropdown-size-container-border-radius);
+    border-radius: var(--kbq-dropdown-size-container-border-radius);
 
-    padding-top: kbq-css-variable(dropdown-size-container-padding-vertical);
+    padding-top: var(--kbq-dropdown-size-container-padding-vertical);
 
-    padding-bottom: kbq-css-variable(dropdown-size-container-padding-vertical);
+    padding-bottom: var(--kbq-dropdown-size-container-padding-vertical);
 
     // Prevent users from interacting with the panel while it's animating. Note that
     // people won't be able to click through it, because the overlay pane will catch the click.

--- a/packages/components/empty-state/_empty-state-theme.scss
+++ b/packages/components/empty-state/_empty-state-theme.scss
@@ -6,21 +6,21 @@
 @mixin kbq-empty-state-theme() {
     .kbq-empty-state_normal-color {
         .kbq-empty-state-title {
-            color: kbq-css-variable(empty-state-title);
+            color: var(--kbq-empty-state-title);
         }
 
         .kbq-empty-state-text {
-            color: kbq-css-variable(empty-state-title);
+            color: var(--kbq-empty-state-title);
         }
     }
 
     .kbq-empty-state_error-color {
         .kbq-empty-state-title {
-            color: kbq-css-variable(foreground-error);
+            color: var(--kbq-foreground-error);
         }
 
         .kbq-empty-state-text {
-            color: kbq-css-variable(foreground-error);
+            color: var(--kbq-foreground-error);
         }
     }
 }

--- a/packages/components/empty-state/empty-state.scss
+++ b/packages/components/empty-state/empty-state.scss
@@ -14,62 +14,60 @@
     flex: 1;
 
     &.kbq-empty-state_normal {
-        padding: kbq-css-variable(empty-state-size-normal-padding-top)
-            kbq-css-variable(empty-state-size-normal-padding-horizontal)
-            kbq-css-variable(empty-state-size-normal-padding-bottom);
+        padding: var(--kbq-empty-state-size-normal-padding-top) var(--kbq-empty-state-size-normal-padding-horizontal)
+            var(--kbq-empty-state-size-normal-padding-bottom);
 
         & .kbq-empty-state-icon {
-            margin-bottom: kbq-css-variable(empty-state-size-normal-image-margin-bottom);
+            margin-bottom: var(--kbq-empty-state-size-normal-image-margin-bottom);
         }
 
         & .kbq-empty-state-text {
-            max-width: kbq-css-variable(empty-state-size-normal-max-width);
+            max-width: var(--kbq-empty-state-size-normal-max-width);
         }
 
         & .kbq-empty-state-title {
-            max-width: kbq-css-variable(empty-state-size-normal-max-width);
+            max-width: var(--kbq-empty-state-size-normal-max-width);
 
-            margin-bottom: kbq-css-variable(empty-state-size-normal-title-margin-bottom);
+            margin-bottom: var(--kbq-empty-state-size-normal-title-margin-bottom);
         }
 
         & .kbq-empty-state-actions {
-            max-width: kbq-css-variable(empty-state-size-normal-max-width);
+            max-width: var(--kbq-empty-state-size-normal-max-width);
 
-            margin-top: kbq-css-variable(empty-state-size-normal-actions-margin-top);
+            margin-top: var(--kbq-empty-state-size-normal-actions-margin-top);
         }
 
         &.kbq-empty-state_align-center.kbq-empty-state_has-icon {
-            margin-bottom: kbq-css-variable(empty-state-size-normal-image-addon-height);
+            margin-bottom: var(--kbq-empty-state-size-normal-image-addon-height);
         }
     }
 
     &.kbq-empty-state_big {
-        padding: kbq-css-variable(empty-state-size-big-padding-top)
-            kbq-css-variable(empty-state-size-big-padding-horizontal)
-            kbq-css-variable(empty-state-size-big-padding-bottom);
+        padding: var(--kbq-empty-state-size-big-padding-top) var(--kbq-empty-state-size-big-padding-horizontal)
+            var(--kbq-empty-state-size-big-padding-bottom);
 
         & .kbq-empty-state-icon {
-            margin-bottom: kbq-css-variable(empty-state-size-big-image-margin-bottom);
+            margin-bottom: var(--kbq-empty-state-size-big-image-margin-bottom);
         }
 
         & .kbq-empty-state-text {
-            max-width: kbq-css-variable(empty-state-size-big-max-width);
+            max-width: var(--kbq-empty-state-size-big-max-width);
         }
 
         & .kbq-empty-state-title {
-            max-width: kbq-css-variable(empty-state-size-big-max-width);
+            max-width: var(--kbq-empty-state-size-big-max-width);
 
-            margin-bottom: kbq-css-variable(empty-state-size-big-title-margin-bottom);
+            margin-bottom: var(--kbq-empty-state-size-big-title-margin-bottom);
         }
 
         & .kbq-empty-state-actions {
-            max-width: kbq-css-variable(empty-state-size-big-max-width);
+            max-width: var(--kbq-empty-state-size-big-max-width);
 
-            margin-top: kbq-css-variable(empty-state-size-big-actions-margin-top);
+            margin-top: var(--kbq-empty-state-size-big-actions-margin-top);
         }
 
         &.kbq-empty-state_align-center.kbq-empty-state_has-icon {
-            margin-bottom: kbq-css-variable(empty-state-size-big-image-addon-height);
+            margin-bottom: var(--kbq-empty-state-size-big-image-addon-height);
         }
     }
 

--- a/packages/components/file-upload/_file-upload-theme.scss
+++ b/packages/components/file-upload/_file-upload-theme.scss
@@ -8,41 +8,41 @@
     .kbq-file-upload {
         .kbq-focused,
         .kbq-link.kbq-focused {
-            border: 2px solid kbq-css-variable(file-upload-single-states-focused-focus-outline);
+            border: 2px solid var(--kbq-file-upload-single-states-focused-focus-outline);
         }
     }
 
     .kbq-single-file-upload {
         .kbq-file-upload {
             // FIXME: move to mixin kbq-file-upload-state
-            background-color: kbq-css-variable(file-upload-single-default-container-background);
-            border-color: kbq-css-variable(file-upload-single-default-container-border) !important;
+            background-color: var(--kbq-file-upload-single-default-container-background);
+            border-color: var(--kbq-file-upload-single-default-container-border) !important;
 
             &.dragover {
-                background-color: kbq-css-variable(file-upload-single-states-on-drag-container-background);
-                border-color: kbq-css-variable(file-upload-single-states-on-drag-container-border) !important;
+                background-color: var(--kbq-file-upload-single-states-on-drag-container-background);
+                border-color: var(--kbq-file-upload-single-states-on-drag-container-border) !important;
             }
 
             &.kbq-error:not(.kbq-disabled) {
                 &:not(.dragover) {
-                    background-color: kbq-css-variable(file-upload-single-states-error-container-background);
-                    border-color: kbq-css-variable(file-upload-single-states-error-container-border) !important;
+                    background-color: var(--kbq-file-upload-single-states-error-container-background);
+                    border-color: var(--kbq-file-upload-single-states-error-container-border) !important;
                 }
 
                 *,
                 .kbq-icon {
-                    color: kbq-css-variable(file-upload-single-states-error-text-block-color);
+                    color: var(--kbq-file-upload-single-states-error-text-block-color);
                 }
             }
 
             &.kbq-disabled {
-                background-color: kbq-css-variable(file-upload-single-states-disabled-container-background);
-                border-color: kbq-css-variable(file-upload-single-states-disabled-container-border) !important;
+                background-color: var(--kbq-file-upload-single-states-disabled-container-background);
+                border-color: var(--kbq-file-upload-single-states-disabled-container-border) !important;
 
                 &,
                 .kbq-icon,
                 .kbq-link {
-                    color: kbq-css-variable(file-upload-single-states-disabled-container-border);
+                    color: var(--kbq-file-upload-single-states-disabled-container-border);
                 }
             }
         }
@@ -50,47 +50,45 @@
 
     .kbq-multiple-file-upload {
         .kbq-file-upload {
-            background-color: kbq-css-variable(file-upload-multiple-default-container-background);
-            border-color: kbq-css-variable(file-upload-multiple-default-container-border) !important;
+            background-color: var(--kbq-file-upload-multiple-default-container-background);
+            border-color: var(--kbq-file-upload-multiple-default-container-border) !important;
 
             .btn-upload {
-                border-top-color: kbq-css-variable(file-upload-multiple-default-container-border);
+                border-top-color: var(--kbq-file-upload-multiple-default-container-border);
             }
 
             .kbq-file-multiple-uploaded__header {
-                border-bottom-color: kbq-css-variable(file-upload-multiple-default-grid-divider-color);
+                border-bottom-color: var(--kbq-file-upload-multiple-default-grid-divider-color);
             }
 
             &.dragover {
-                background-color: kbq-css-variable(file-upload-multiple-states-on-drag-container-background);
-                border-color: kbq-css-variable(file-upload-multiple-states-on-drag-container-border) !important;
+                background-color: var(--kbq-file-upload-multiple-states-on-drag-container-background);
+                border-color: var(--kbq-file-upload-multiple-states-on-drag-container-border) !important;
 
                 .kbq-file-multiple-uploaded__header {
-                    border-bottom-color: kbq-css-variable(
-                        file-upload-multiple-states-on-drag-container-background
-                    ) !important;
+                    border-bottom-color: var(--kbq-file-upload-multiple-states-on-drag-container-background) !important;
                 }
 
                 &.selected {
                     .dropzone {
-                        border-top-color: kbq-css-variable(file-upload-multiple-states-on-drag-container-border);
+                        border-top-color: var(--kbq-file-upload-multiple-states-on-drag-container-border);
                     }
                 }
             }
 
             &.kbq-disabled {
-                background-color: kbq-css-variable(file-upload-multiple-states-disabled-container-background);
-                border-color: kbq-css-variable(file-upload-multiple-states-disabled-container-border) !important;
+                background-color: var(--kbq-file-upload-multiple-states-disabled-container-background);
+                border-color: var(--kbq-file-upload-multiple-states-disabled-container-border) !important;
 
                 &,
                 .kbq-icon,
                 .kbq-link {
-                    color: kbq-css-variable(file-upload-multiple-states-disabled-container-border);
+                    color: var(--kbq-file-upload-multiple-states-disabled-container-border);
                 }
 
                 &.selected {
                     .dropzone {
-                        border-top-color: kbq-css-variable(file-upload-multiple-states-disabled-container-border);
+                        border-top-color: var(--kbq-file-upload-multiple-states-disabled-container-border);
                     }
                 }
             }
@@ -99,18 +97,18 @@
                 .kbq-file-upload__row.error {
                     *,
                     .kbq-icon {
-                        color: kbq-css-variable(file-upload-multiple-states-error-text-block-color);
+                        color: var(--kbq-file-upload-multiple-states-error-text-block-color);
                     }
                 }
             }
 
             .multiple__uploaded-item {
                 & .kbq-file-upload__file .kbq-icon {
-                    color: kbq-css-variable(file-upload-multiple-default-left-icon-color);
+                    color: var(--kbq-file-upload-multiple-default-left-icon-color);
                 }
 
                 & .kbq-file-upload__action .kbq-icon {
-                    color: kbq-css-variable(file-upload-multiple-default-icon-button-color);
+                    color: var(--kbq-file-upload-multiple-default-icon-button-color);
                 }
             }
         }
@@ -119,7 +117,7 @@
     .kbq-single-file-upload,
     .kbq-multiple-file-upload {
         .kbq-file-upload__hint:not(.kbq-error) {
-            color: kbq-css-variable(form-field-hint-text);
+            color: var(--kbq-form-field-hint-text);
         }
     }
 }

--- a/packages/components/file-upload/multiple-file-upload.component.scss
+++ b/packages/components/file-upload/multiple-file-upload.component.scss
@@ -2,22 +2,22 @@
 
 // todo нужно рефакторить со стилями тут сложно
 .kbq-multiple-file-upload .kbq-file-upload {
-    border-radius: kbq-css-variable(file-upload-size-multiple-big-container-border-radius);
-    border-width: kbq-css-variable(file-upload-size-multiple-big-container-border-width);
+    border-radius: var(--kbq-file-upload-size-multiple-big-container-border-radius);
+    border-width: var(--kbq-file-upload-size-multiple-big-container-border-width);
     border-style: dashed;
 
     &.default:not(.selected) {
         justify-content: center;
 
-        padding: kbq-css-variable(file-upload-size-multiple-big-container-padding-vertical)
-            kbq-css-variable(file-upload-size-multiple-big-container-padding-vertical);
+        padding: var(--kbq-file-upload-size-multiple-big-container-padding-vertical)
+            var(--kbq-file-upload-size-multiple-big-container-padding-vertical);
 
-        min-height: kbq-css-variable(file-upload-size-multiple-big-container-min-height);
+        min-height: var(--kbq-file-upload-size-multiple-big-container-min-height);
 
-        min-width: kbq-css-variable(file-upload-size-multiple-big-container-min-width);
+        min-width: var(--kbq-file-upload-size-multiple-big-container-min-width);
 
         & .dropzone {
-            gap: kbq-css-variable(file-upload-size-multiple-big-container-content-gap-horizontal);
+            gap: var(--kbq-file-upload-size-multiple-big-container-content-gap-horizontal);
         }
 
         & .dropzone__text {
@@ -27,26 +27,26 @@
 
             & .multiple__caption {
                 display: block;
-                padding-top: kbq-css-variable(file-upload-size-multiple-big-text-block-content-gap-vertical);
+                padding-top: var(--kbq-file-upload-size-multiple-big-text-block-content-gap-vertical);
                 // гап не применяется тк не флекс. в целом гап не нужен, тк по логике дизайна ссылка от текста отделяется пробелом
-                gap: kbq-css-variable(file-upload-size-multiple-big-text-block-content-gap-horizontal);
+                gap: var(--kbq-file-upload-size-multiple-big-text-block-content-gap-horizontal);
             }
         }
     }
 
     &.compact:not(.selected) {
-        padding: kbq-css-variable(file-upload-size-single-container-padding-vertical)
-            kbq-css-variable(file-upload-size-single-container-padding-horizontal);
+        padding: var(--kbq-file-upload-size-single-container-padding-vertical)
+            var(--kbq-file-upload-size-single-container-padding-horizontal);
 
         & .dropzone {
-            gap: kbq-css-variable(file-upload-size-single-container-content-gap-horizontal);
+            gap: var(--kbq-file-upload-size-single-container-content-gap-horizontal);
 
             & .dropzone__text.multiple__caption {
-                padding-top: kbq-css-variable(file-upload-size-single-text-block-padding-vertical);
+                padding-top: var(--kbq-file-upload-size-single-text-block-padding-vertical);
 
-                padding-bottom: kbq-css-variable(file-upload-size-single-text-block-padding-vertical);
+                padding-bottom: var(--kbq-file-upload-size-single-text-block-padding-vertical);
 
-                gap: kbq-css-variable(file-upload-size-single-text-block-content-gap-horizontal);
+                gap: var(--kbq-file-upload-size-single-text-block-content-gap-horizontal);
             }
         }
     }
@@ -83,12 +83,12 @@
             width: 65%;
             max-width: 65%;
 
-            gap: kbq-css-variable(file-upload-size-multiple-big-grid-cell-content-gap-horizontal);
+            gap: var(--kbq-file-upload-size-multiple-big-grid-cell-content-gap-horizontal);
         }
 
         .kbq-file-upload__size {
-            width: kbq-css-variable(size-7xl);
-            min-width: kbq-css-variable(size-7xl);
+            width: var(--kbq-size-7xl);
+            min-width: var(--kbq-size-7xl);
             text-align: left;
             flex-grow: 1;
         }
@@ -132,21 +132,21 @@
                 [ file-upload-size-single-container-padding-horizontal,
                 file-upload-size-single-container-border-width]
             );
-        border-top-left-radius: kbq-css-variable(file-upload-size-single-container-border-radius);
+        border-top-left-radius: var(--kbq-file-upload-size-single-container-border-radius);
 
-        border-top-right-radius: kbq-css-variable(file-upload-size-single-container-border-radius);
-        border-top-width: kbq-css-variable(file-upload-size-single-container-border-width);
+        border-top-right-radius: var(--kbq-file-upload-size-single-container-border-radius);
+        border-top-width: var(--kbq-file-upload-size-single-container-border-width);
         border-top-style: dashed;
 
         & .dropzone {
-            gap: kbq-css-variable(file-upload-size-single-container-content-gap-horizontal);
+            gap: var(--kbq-file-upload-size-single-container-content-gap-horizontal);
 
             & .dropzone__text.multiple__caption {
-                padding-top: kbq-css-variable(file-upload-size-single-text-block-padding-vertical);
+                padding-top: var(--kbq-file-upload-size-single-text-block-padding-vertical);
 
-                padding-bottom: kbq-css-variable(file-upload-size-single-text-block-padding-vertical);
+                padding-bottom: var(--kbq-file-upload-size-single-text-block-padding-vertical);
 
-                gap: kbq-css-variable(file-upload-size-single-text-block-content-gap-horizontal);
+                gap: var(--kbq-file-upload-size-single-text-block-content-gap-horizontal);
             }
         }
     }
@@ -158,5 +158,5 @@
 }
 
 .kbq-file-upload__hint {
-    margin-top: kbq-css-variable(form-field-hint-size-margin-top);
+    margin-top: var(--kbq-form-field-hint-size-margin-top);
 }

--- a/packages/components/file-upload/single-file-upload.component.scss
+++ b/packages/components/file-upload/single-file-upload.component.scss
@@ -18,20 +18,20 @@ $tokens: meta.module-variables(tokens) !default;
             file-upload-size-single-container-border-width]
         );
 
-    border-radius: kbq-css-variable(file-upload-size-single-container-border-radius);
-    border-width: kbq-css-variable(file-upload-size-single-container-border-width);
+    border-radius: var(--kbq-file-upload-size-single-container-border-radius);
+    border-width: var(--kbq-file-upload-size-single-container-border-width);
     border-style: dashed;
 
     & .dropzone__text {
-        padding-top: kbq-css-variable(file-upload-size-single-text-block-padding-vertical);
+        padding-top: var(--kbq-file-upload-size-single-text-block-padding-vertical);
 
-        padding-bottom: kbq-css-variable(file-upload-size-single-text-block-padding-vertical);
+        padding-bottom: var(--kbq-file-upload-size-single-text-block-padding-vertical);
 
-        gap: kbq-css-variable(file-upload-size-single-text-block-content-gap-horizontal);
+        gap: var(--kbq-file-upload-size-single-text-block-content-gap-horizontal);
     }
 
     & .dropzone {
-        gap: kbq-css-variable(file-upload-size-single-container-content-gap-horizontal);
+        gap: var(--kbq-file-upload-size-single-container-content-gap-horizontal);
     }
 
     .file-item {
@@ -42,7 +42,7 @@ $tokens: meta.module-variables(tokens) !default;
             align-items: center;
             width: 100%;
 
-            gap: kbq-css-variable(file-upload-size-single-container-content-gap-horizontal);
+            gap: var(--kbq-file-upload-size-single-container-content-gap-horizontal);
 
             .file-item__text {
                 width: 120px;
@@ -53,5 +53,5 @@ $tokens: meta.module-variables(tokens) !default;
 }
 
 .kbq-file-upload__hint {
-    margin-top: kbq-css-variable(form-field-hint-size-margin-top);
+    margin-top: var(--kbq-form-field-hint-size-margin-top);
 }

--- a/packages/components/form-field/_form-field-theme.scss
+++ b/packages/components/form-field/_form-field-theme.scss
@@ -7,25 +7,25 @@
 
 @mixin kbq-form-field-state($state-name) {
     .kbq-form-field__container {
-        border-color: kbq-css-variable(form-field-#{$state-name}-border-color);
-        background-color: kbq-css-variable(form-field-#{$state-name}-background);
+        border-color: var(--kbq-form-field-#{$state-name}-border-color);
+        background-color: var(--kbq-form-field-#{$state-name}-background);
     }
 
     .kbq-input,
     .kbq-tag-input,
     .kbq-textarea {
-        color: kbq-css-variable(form-field-#{$state-name}-text);
+        color: var(--kbq-form-field-#{$state-name}-text);
 
         &::placeholder {
-            color: kbq-css-variable(form-field-#{$state-name}-placeholder);
+            color: var(--kbq-form-field-#{$state-name}-placeholder);
         }
 
         &::-ms-input-placeholder {
-            color: kbq-css-variable(form-field-#{$state-name}-placeholder);
+            color: var(--kbq-form-field-#{$state-name}-placeholder);
         }
 
         &::-webkit-input-placeholder {
-            color: kbq-css-variable(form-field-#{$state-name}-placeholder);
+            color: var(--kbq-form-field-#{$state-name}-placeholder);
         }
     }
 }
@@ -39,9 +39,9 @@
             &:-webkit-autofill,
             &:-webkit-autofill:hover,
             &:-webkit-autofill:focus {
-                -webkit-box-shadow: inset 0 0 0 40rem kbq-css-variable(form-field-states-autofill-background);
-                -webkit-text-fill-color: kbq-css-variable(form-field-states-autofill-text);
-                caret-color: kbq-css-variable(form-field-states-autofill-text);
+                -webkit-box-shadow: inset 0 0 0 40rem var(--kbq-form-field-states-autofill-background);
+                -webkit-text-fill-color: var(--kbq-form-field-states-autofill-text);
+                caret-color: var(--kbq-form-field-states-autofill-text);
             }
         }
 
@@ -49,7 +49,7 @@
             @include kbq-form-field-state(states-focused);
 
             & .kbq-form-field__container {
-                box-shadow: 0 0 0.1px 1px kbq-css-variable(form-field-states-focused-focus-outline);
+                box-shadow: 0 0 0.1px 1px var(--kbq-form-field-states-focused-focus-outline);
             }
         }
 
@@ -58,7 +58,7 @@
             @include kbq-form-field-state(states-error);
 
             &.cdk-focused .kbq-form-field__container {
-                box-shadow: 0 0 0.1px 1px kbq-css-variable(form-field-states-error-focused-focus-outline);
+                box-shadow: 0 0 0.1px 1px var(--kbq-form-field-states-error-focused-focus-outline);
             }
         }
 
@@ -66,15 +66,15 @@
             @include kbq-form-field-state(states-disabled);
 
             .kbq-icon {
-                color: kbq-css-variable(form-field-states-disabled-text);
-                -webkit-text-fill-color: kbq-css-variable(form-field-states-disabled-text);
+                color: var(--kbq-form-field-states-disabled-text);
+                -webkit-text-fill-color: var(--kbq-form-field-states-disabled-text);
             }
         }
     }
 
     .kbq-form-field__hint {
         & > .kbq-hint:not(.kbq-password-hint, .kbq-contrast-fade, .kbq-success, .kbq-warning, .kbq-error) {
-            color: kbq-css-variable(form-field-hint-text);
+            color: var(--kbq-form-field-hint-text);
         }
     }
 }

--- a/packages/components/form-field/_hint-theme.scss
+++ b/packages/components/form-field/_hint-theme.scss
@@ -6,10 +6,10 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-hint-color($type, $style-name) {
-    color: kbq-css-variable(hint-#{$type}-#{$style-name}-text);
+    color: var(--kbq-hint-#{$type}-#{$style-name}-text);
 
     & .kbq-icon {
-        color: kbq-css-variable(hint-#{$type}-#{$style-name}-icon) !important;
+        color: var(--kbq-hint-#{$type}-#{$style-name}-icon) !important;
     }
 }
 

--- a/packages/components/form-field/cleaner.scss
+++ b/packages/components/form-field/cleaner.scss
@@ -8,8 +8,8 @@
     align-items: center;
     justify-content: center;
 
-    width: kbq-css-variable(form-field-size-icon-button-size);
-    margin-right: kbq-css-variable(form-field-size-icon-button-margin-right);
+    width: var(--kbq-form-field-size-icon-button-size);
+    margin-right: var(--kbq-form-field-size-icon-button-margin-right);
     height: 100%;
 
     cursor: pointer;

--- a/packages/components/form-field/form-field.scss
+++ b/packages/components/form-field/form-field.scss
@@ -19,13 +19,13 @@
     }
 
     .kbq-form-field:not(.kbq-form-field-type-textarea) {
-        height: kbq-css-variable(form-field-size-height);
+        height: var(--kbq-form-field-size-height);
     }
 
     &,
     .kbq-input,
     .kbq-textarea {
-        border-radius: kbq-css-variable(form-field-size-border-radius);
+        border-radius: var(--kbq-form-field-size-border-radius);
     }
 
     &:hover {
@@ -65,17 +65,17 @@
     }
 
     & + .kbq-password-hint {
-        margin-top: kbq-css-variable(size-m);
+        margin-top: var(--kbq-size-m);
     }
 }
 
 .kbq-form-field__container {
     position: relative;
 
-    border-width: kbq-css-variable(form-field-size-border-width);
+    border-width: var(--kbq-form-field-size-border-width);
     border-style: solid;
     border-color: transparent;
-    border-radius: kbq-css-variable(form-field-size-border-radius);
+    border-radius: var(--kbq-form-field-size-border-radius);
 }
 
 .kbq-form-field__prefix,
@@ -115,12 +115,12 @@
     justify-content: center;
     align-items: center;
 
-    width: kbq-css-variable(form-field-size-icon-button-size);
+    width: var(--kbq-form-field-size-icon-button-size);
 
     .kbq-stepper-step-up,
     .kbq-stepper-step-down {
         cursor: pointer;
-        width: kbq-css-variable(form-field-size-icon-button-size);
+        width: var(--kbq-form-field-size-icon-button-size);
         text-align: center;
     }
 
@@ -132,15 +132,15 @@
 .kbq-form-field__hint {
     display: flex;
     flex-direction: column;
-    margin-top: kbq-css-variable(form-field-hint-size-margin-top);
+    margin-top: var(--kbq-form-field-hint-size-margin-top);
 
     & .kbq-password-hint:first-child {
-        margin-top: kbq-css-variable(size-s);
+        margin-top: var(--kbq-size-s);
     }
 }
 
 .kbq-password-hint {
-    margin-top: kbq-css-variable(form-field-hint-size-gap);
+    margin-top: var(--kbq-form-field-hint-size-gap);
 }
 
 @include kbq-form-field-theme();

--- a/packages/components/form-field/hint.scss
+++ b/packages/components/form-field/hint.scss
@@ -9,14 +9,14 @@
     display: flex;
 
     & .kbq-icon {
-        margin-top: kbq-css-variable(hint-size-normal-margin-top);
-        margin-right: kbq-css-variable(hint-size-normal-content-padding);
+        margin-top: var(--kbq-hint-size-normal-margin-top);
+        margin-right: var(--kbq-hint-size-normal-content-padding);
     }
 
     &.kbq-hint_compact {
         & .kbq-icon {
-            margin-top: kbq-css-variable(hint-size-compact-margin-top);
-            margin-right: kbq-css-variable(hint-size-compact-content-padding);
+            margin-top: var(--kbq-hint-size-compact-margin-top);
+            margin-right: var(--kbq-hint-size-compact-content-padding);
         }
     }
 }

--- a/packages/components/form-field/password-toggle.scss
+++ b/packages/components/form-field/password-toggle.scss
@@ -8,8 +8,8 @@
     align-items: center;
     justify-content: center;
 
-    width: kbq-css-variable(form-field-size-icon-button-size);
-    margin-right: kbq-css-variable(form-field-size-icon-button-margin-right);
+    width: var(--kbq-form-field-size-icon-button-size);
+    margin-right: var(--kbq-form-field-size-icon-button-margin-right);
     height: 100%;
 
     &::-moz-focus-inner {

--- a/packages/components/form-field/stepper.scss
+++ b/packages/components/form-field/stepper.scss
@@ -9,14 +9,14 @@
     justify-content: center;
     align-items: center;
 
-    width: kbq-css-variable(form-field-size-icon-button-size);
-    margin-right: kbq-css-variable(form-field-size-icon-button-margin-right);
+    width: var(--kbq-form-field-size-icon-button-size);
+    margin-right: var(--kbq-form-field-size-icon-button-margin-right);
     height: 100%;
 
     .kbq-stepper-step-up,
     .kbq-stepper-step-down {
         cursor: pointer;
-        width: kbq-css-variable(form-field-size-icon-button-size);
+        width: var(--kbq-form-field-size-icon-button-size);
         text-align: center;
     }
 

--- a/packages/components/icon/_icon-button-theme.scss
+++ b/packages/components/icon/_icon-button-theme.scss
@@ -11,111 +11,111 @@
 
         // FIXME: move to unified mixin
         &.kbq-theme {
-            color: kbq-css-variable(icon-button-theme-default);
+            color: var(--kbq-icon-button-theme-default);
 
             &:active,
             &.kbq-active {
-                color: kbq-css-variable(icon-button-theme-states-active);
+                color: var(--kbq-icon-button-theme-states-active);
             }
 
             &:not(.kbq-disabled):hover {
-                color: kbq-css-variable(icon-button-theme-states-hover);
+                color: var(--kbq-icon-button-theme-states-hover);
             }
 
             &.kbq-disabled {
-                color: kbq-css-variable(icon-button-theme-states-disabled);
+                color: var(--kbq-icon-button-theme-states-disabled);
             }
         }
 
         &.kbq-contrast {
-            color: kbq-css-variable(icon-button-contrast-default);
+            color: var(--kbq-icon-button-contrast-default);
 
             &:active,
             &.kbq-active {
-                color: kbq-css-variable(icon-button-contrast-states-active);
+                color: var(--kbq-icon-button-contrast-states-active);
             }
 
             &:not(.kbq-disabled):hover {
-                color: kbq-css-variable(icon-button-contrast-states-hover);
+                color: var(--kbq-icon-button-contrast-states-hover);
             }
 
             &.kbq-disabled {
-                color: kbq-css-variable(icon-button-contrast-states-disabled);
+                color: var(--kbq-icon-button-contrast-states-disabled);
             }
         }
 
         &.kbq-contrast-fade {
-            color: kbq-css-variable(icon-button-fade-contrast-default);
+            color: var(--kbq-icon-button-fade-contrast-default);
 
             &:active,
             &.kbq-active {
-                color: kbq-css-variable(icon-button-fade-contrast-states-active);
+                color: var(--kbq-icon-button-fade-contrast-states-active);
             }
 
             &:not(.kbq-disabled):hover {
-                color: kbq-css-variable(icon-button-fade-contrast-states-hover);
+                color: var(--kbq-icon-button-fade-contrast-states-hover);
             }
 
             &.kbq-disabled {
-                color: kbq-css-variable(icon-button-fade-contrast-states-disabled);
+                color: var(--kbq-icon-button-fade-contrast-states-disabled);
             }
         }
 
         &.kbq-error {
-            color: kbq-css-variable(icon-button-error-default);
+            color: var(--kbq-icon-button-error-default);
 
             &:active,
             &.kbq-active {
-                color: kbq-css-variable(icon-button-error-states-active);
+                color: var(--kbq-icon-button-error-states-active);
             }
 
             &:not(.kbq-disabled):hover {
-                color: kbq-css-variable(icon-button-error-states-hover);
+                color: var(--kbq-icon-button-error-states-hover);
             }
 
             &.kbq-disabled {
-                color: kbq-css-variable(icon-button-error-states-disabled);
+                color: var(--kbq-icon-button-error-states-disabled);
             }
         }
 
         &.kbq-success {
-            color: kbq-css-variable(icon-button-success-default);
+            color: var(--kbq-icon-button-success-default);
 
             &:active,
             &.kbq-active {
-                color: kbq-css-variable(icon-button-success-states-active);
+                color: var(--kbq-icon-button-success-states-active);
             }
 
             &:not(.kbq-disabled):hover {
-                color: kbq-css-variable(icon-button-success-states-hover);
+                color: var(--kbq-icon-button-success-states-hover);
             }
 
             &.kbq-disabled {
-                color: kbq-css-variable(icon-button-success-states-disabled);
+                color: var(--kbq-icon-button-success-states-disabled);
             }
         }
 
         &.kbq-warning {
-            color: kbq-css-variable(icon-button-warning-default);
+            color: var(--kbq-icon-button-warning-default);
 
             &:active,
             &.kbq-active {
-                color: kbq-css-variable(icon-button-warning-states-active);
+                color: var(--kbq-icon-button-warning-states-active);
             }
 
             &:not(.kbq-disabled):hover {
-                color: kbq-css-variable(icon-button-warning-states-hover);
+                color: var(--kbq-icon-button-warning-states-hover);
             }
 
             &.kbq-disabled {
-                color: kbq-css-variable(icon-button-warning-states-disabled);
+                color: var(--kbq-icon-button-warning-states-disabled);
             }
         }
 
         &.cdk-keyboard-focused {
             box-shadow:
-                inset 0 0 0.1px 1px kbq-css-variable(states-focused-color),
-                0 0 0.1px 1px kbq-css-variable(states-focused-color);
+                inset 0 0 0.1px 1px var(--kbq-states-focused-color),
+                0 0 0.1px 1px var(--kbq-states-focused-color);
         }
     }
 }

--- a/packages/components/icon/_icon-item-theme.scss
+++ b/packages/components/icon/_icon-item-theme.scss
@@ -6,8 +6,8 @@
 @mixin kbq-icon-item-style($type, $style-name) {
     $base: icon-item-filled-#{$type}-#{$style-name};
 
-    color: kbq-css-variable(#{$base}-color);
-    background: kbq-css-variable(#{$base}-background);
+    color: var(--kbq-#{$base}-color);
+    background: var(--kbq-#{$base}-background);
 }
 
 @mixin kbq-icon-item-theme() {

--- a/packages/components/icon/_icon-theme.scss
+++ b/packages/components/icon/_icon-theme.scss
@@ -3,27 +3,27 @@
 @mixin kbq-icon-theme() {
     .kbq-icon:not(.kbq-icon-button, .kbq-icon-item) {
         &.kbq-theme {
-            color: kbq-css-variable(icon-theme-color);
+            color: var(--kbq-icon-theme-color);
         }
 
         &.kbq-contrast {
-            color: kbq-css-variable(icon-contrast-color);
+            color: var(--kbq-icon-contrast-color);
         }
 
         &.kbq-contrast-fade {
-            color: kbq-css-variable(icon-fade-contrast-color);
+            color: var(--kbq-icon-fade-contrast-color);
         }
 
         &.kbq-error {
-            color: kbq-css-variable(icon-error-color);
+            color: var(--kbq-icon-error-color);
         }
 
         &.kbq-warning {
-            color: kbq-css-variable(icon-warning-color);
+            color: var(--kbq-icon-warning-color);
         }
 
         &.kbq-success {
-            color: kbq-css-variable(icon-success-color);
+            color: var(--kbq-icon-success-color);
         }
     }
 }

--- a/packages/components/icon/icon-button.scss
+++ b/packages/components/icon/icon-button.scss
@@ -10,12 +10,10 @@
         cursor: pointer;
     }
 
-    padding: kbq-css-variable(icon-button-size-normal-vertical-padding)
-        kbq-css-variable(icon-button-size-normal-horizontal-padding);
+    padding: var(--kbq-icon-button-size-normal-vertical-padding) var(--kbq-icon-button-size-normal-horizontal-padding);
 
     &.kbq-icon-button_small {
-        padding: kbq-css-variable(icon-button-size-small-vertical-padding)
-            kbq-css-variable(icon-button-size-small-horizontal-padding);
+        padding: var(--kbq-icon-button-size-small-vertical-padding) var(--kbq-icon-button-size-small-horizontal-padding);
     }
 }
 

--- a/packages/components/icon/icon-item.scss
+++ b/packages/components/icon/icon-item.scss
@@ -11,13 +11,11 @@
     border-radius: 50%;
 
     &.kbq-icon-item_normal {
-        padding: kbq-css-variable(icon-item-size-normal-vertical-padding)
-            kbq-css-variable(icon-item-size-normal-horizontal-padding);
+        padding: var(--kbq-icon-item-size-normal-vertical-padding) var(--kbq-icon-item-size-normal-horizontal-padding);
     }
 
     &.kbq-icon-item_big {
-        padding: kbq-css-variable(icon-item-size-big-vertical-padding)
-            kbq-css-variable(icon-item-size-big-horizontal-padding);
+        padding: var(--kbq-icon-item-size-big-vertical-padding) var(--kbq-icon-item-size-big-horizontal-padding);
     }
 }
 

--- a/packages/components/input/input.scss
+++ b/packages/components/input/input.scss
@@ -14,11 +14,11 @@
     width: 100%;
     min-height: kbq-difference-series-css-variables(
         [form-field-size-height,
-        calc(kbq-css-variable(form-field-size-border-width) * 2)]
+        calc(var(--kbq-form-field-size-border-width) * 2)]
     );
 
     padding: kbq-difference-series-css-variables([input-size-padding-vertical, form-field-size-border-width])
-        kbq-css-variable(input-size-padding-horizontal);
+        var(--kbq-input-size-padding-horizontal);
 }
 
 input.kbq-input[type='number'] {

--- a/packages/components/karma.conf.js
+++ b/packages/components/karma.conf.js
@@ -4,6 +4,14 @@ module.exports = function (config) {
     const baseConfig = getBaseKarmaConfig();
     return config.set({
         ...baseConfig,
-        files: [{ pattern: '../../dist/components/prebuilt-themes/light-theme.css', included: true, watched: true }]
+        files: [
+            { pattern: '../../dist/components/prebuilt-themes/theme.css', included: true, watched: true },
+            { pattern: '../../node_modules/@koobiq/design-tokens/web/css-tokens.css', included: true, watched: true },
+            {
+                pattern: '../../node_modules/@koobiq/design-tokens/web/css-tokens-light.css',
+                included: true,
+                watched: true
+            }
+        ]
     });
 };

--- a/packages/components/link/_link-theme.scss
+++ b/packages/components/link/_link-theme.scss
@@ -8,7 +8,7 @@
     text-decoration: none;
     cursor: pointer;
 
-    outline-offset: kbq-css-variable(link-size-state-focused-outline-offset);
+    outline-offset: var(--kbq-link-size-state-focused-outline-offset);
 
     &:focus {
         outline: none;
@@ -23,22 +23,22 @@
 
     &.kbq-text-with-icon .kbq-link__text {
         &:not(:first-child) {
-            margin-left: kbq-css-variable(link-size-normal-content-padding);
+            margin-left: var(--kbq-link-size-normal-content-padding);
         }
 
         &:not(:last-child) {
-            margin-right: kbq-css-variable(link-size-normal-content-padding);
+            margin-right: var(--kbq-link-size-normal-content-padding);
         }
     }
 
     &.kbq-link_compact {
         &.kbq-text-with-icon .kbq-link__text {
             &:not(:first-child) {
-                margin-left: kbq-css-variable(link-size-compact-content-padding);
+                margin-left: var(--kbq-link-size-compact-content-padding);
             }
 
             &:not(:last-child) {
-                margin-right: kbq-css-variable(link-size-compact-content-padding);
+                margin-right: var(--kbq-link-size-compact-content-padding);
             }
         }
     }
@@ -46,11 +46,11 @@
     &.kbq-link_big {
         &.kbq-text-with-icon .kbq-link__text {
             &:not(:first-child) {
-                margin-left: kbq-css-variable(link-size-big-content-padding);
+                margin-left: var(--kbq-link-size-big-content-padding);
             }
 
             &:not(:last-child) {
-                margin-right: kbq-css-variable(link-size-big-content-padding);
+                margin-right: var(--kbq-link-size-big-content-padding);
             }
         }
     }
@@ -72,16 +72,16 @@
         $base-path: link-#{$state-name};
     }
 
-    color: kbq-css-variable(#{$base-path}-text);
+    color: var(--kbq-#{$base-path}-text);
 
     &.kbq-text-only,
     &.kbq-text-with-icon .kbq-link__text,
     &.kbq-text-with-dot .kbq-link__text {
-        border-bottom-color: kbq-css-variable(#{$base-path}-border-bottom);
+        border-bottom-color: var(--kbq-#{$base-path}-border-bottom);
     }
 
     & .kbq-icon {
-        color: kbq-css-variable(#{$base-path}-text) !important;
+        color: var(--kbq-#{$base-path}-text) !important;
     }
 }
 
@@ -118,7 +118,7 @@
         }
 
         &.cdk-keyboard-focused {
-            outline: kbq-css-variable(link-state-focused-outline) solid;
+            outline: var(--kbq-link-state-focused-outline) solid;
         }
 
         &.kbq-disabled {

--- a/packages/components/list/_list-theme.scss
+++ b/packages/components/list/_list-theme.scss
@@ -1,22 +1,22 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-list-item($state-name) {
-    background: kbq-css-variable(list-#{$state-name}-container-background);
+    background: var(--kbq-list-#{$state-name}-container-background);
 
     .kbq-list-text {
-        color: kbq-css-variable(list-#{$state-name}-text-color);
+        color: var(--kbq-list-#{$state-name}-text-color);
     }
 
     .kbq-icon {
-        color: kbq-css-variable(list-#{$state-name}-icon-color);
+        color: var(--kbq-list-#{$state-name}-icon-color);
     }
 
     .kbq-option-action .kbq-icon {
-        color: kbq-css-variable(list-#{$state-name}-icon-button-color);
+        color: var(--kbq-list-#{$state-name}-icon-button-color);
     }
 
     .kbq-list-option-caption {
-        color: kbq-css-variable(list-#{$state-name}-caption-color);
+        color: var(--kbq-list-#{$state-name}-caption-color);
     }
 }
 
@@ -29,7 +29,7 @@
         }
 
         &.kbq-focused {
-            border-color: kbq-css-variable(list-states-focused-focus-outline-color);
+            border-color: var(--kbq-list-states-focused-focus-outline-color);
         }
 
         &.kbq-selected {

--- a/packages/components/list/list.scss
+++ b/packages/components/list/list.scss
@@ -24,7 +24,7 @@
 
     & .kbq-option-action {
         display: none;
-        height: kbq-css-variable(size-xl);
+        height: var(--kbq-size-xl);
         align-items: center;
     }
 

--- a/packages/components/loader-overlay/_loader-overlay-theme.scss
+++ b/packages/components/loader-overlay/_loader-overlay-theme.scss
@@ -4,29 +4,29 @@
     // FIXME: move to unified mixin if necessary
     .kbq-loader-overlay_filled {
         &.kbq-loader-overlay {
-            background: kbq-css-variable(loader-overlay-filled-overlay-background);
+            background: var(--kbq-loader-overlay-filled-overlay-background);
         }
 
         & .kbq-loader-overlay-text {
-            color: kbq-css-variable(loader-overlay-filled-text-color);
+            color: var(--kbq-loader-overlay-filled-text-color);
         }
 
         & .kbq-loader-overlay-caption {
-            color: kbq-css-variable(loader-overlay-filled-caption-color);
+            color: var(--kbq-loader-overlay-filled-caption-color);
         }
     }
 
     .kbq-loader-overlay_transparent {
         &.kbq-loader-overlay {
-            background: kbq-css-variable(loader-overlay-transparent-overlay-background);
+            background: var(--kbq-loader-overlay-transparent-overlay-background);
         }
 
         & .kbq-loader-overlay-text {
-            color: kbq-css-variable(loader-overlay-transparent-text-color);
+            color: var(--kbq-loader-overlay-transparent-text-color);
         }
 
         & .kbq-loader-overlay-caption {
-            color: kbq-css-variable(loader-overlay-transparent-caption-color);
+            color: var(--kbq-loader-overlay-transparent-caption-color);
         }
     }
 }

--- a/packages/components/loader-overlay/loader-overlay.scss
+++ b/packages/components/loader-overlay/loader-overlay.scss
@@ -41,30 +41,30 @@
     }
 
     &.kbq-loader-overlay_big {
-        padding-left: kbq-css-variable(loader-overlay-size-big-overlay-padding-horizontal);
+        padding-left: var(--kbq-loader-overlay-size-big-overlay-padding-horizontal);
 
-        padding-right: kbq-css-variable(loader-overlay-size-big-overlay-padding-horizontal);
+        padding-right: var(--kbq-loader-overlay-size-big-overlay-padding-horizontal);
 
         & .kbq-progress-spinner {
-            margin-bottom: kbq-css-variable(loader-overlay-size-big-loader-margin-bottom);
+            margin-bottom: var(--kbq-loader-overlay-size-big-loader-margin-bottom);
         }
 
         & .kbq-loader-overlay-text {
-            margin-bottom: kbq-css-variable(loader-overlay-size-big-content-content-gap-vertical);
+            margin-bottom: var(--kbq-loader-overlay-size-big-content-content-gap-vertical);
         }
     }
 
     &.kbq-loader-overlay_compact {
-        padding-left: kbq-css-variable(loader-overlay-size-compact-overlay-padding-horizontal);
+        padding-left: var(--kbq-loader-overlay-size-compact-overlay-padding-horizontal);
 
-        padding-right: kbq-css-variable(loader-overlay-size-compact-overlay-padding-horizontal);
+        padding-right: var(--kbq-loader-overlay-size-compact-overlay-padding-horizontal);
 
         & .kbq-progress-spinner {
-            margin-bottom: kbq-css-variable(loader-overlay-size-compact-loader-margin-bottom);
+            margin-bottom: var(--kbq-loader-overlay-size-compact-loader-margin-bottom);
         }
 
         & .kbq-loader-overlay-text {
-            margin-bottom: kbq-css-variable(loader-overlay-size-compact-content-content-gap-vertical);
+            margin-bottom: var(--kbq-loader-overlay-size-compact-content-content-gap-vertical);
         }
     }
 }

--- a/packages/components/markdown/_markdown-theme.scss
+++ b/packages/components/markdown/_markdown-theme.scss
@@ -4,81 +4,81 @@
 
 @mixin kbq-markdown-theme() {
     .kbq-markdown {
-        color: kbq-css-variable(foreground-contrast);
-        background: kbq-css-variable(background-bg);
+        color: var(--kbq-foreground-contrast);
+        background: var(--kbq-background-bg);
 
         // h1, h2, h3, h4, h5, h6
         @for $i from 1 through 6 {
             .kbq-markdown__h#{$i} {
-                color: kbq-css-variable(markdown-h#{$i}-color);
+                color: var(--kbq-markdown-h#{$i}-color);
             }
         }
 
         .kbq-markdown__p {
-            color: kbq-css-variable(markdown-p-color);
+            color: var(--kbq-markdown-p-color);
         }
 
         .kbq-markdown__ul,
         .kbq-markdown__ol {
-            color: kbq-css-variable(markdown-list-color);
+            color: var(--kbq-markdown-list-color);
         }
 
         .kbq-markdown__blockquote {
-            color: kbq-css-variable(markdown-blockquote-text);
-            background: kbq-css-variable(markdown-blockquote-background);
-            border-color: kbq-css-variable(markdown-blockquote-border);
-            border-left-color: kbq-css-variable(markdown-blockquote-line);
+            color: var(--kbq-markdown-blockquote-text);
+            background: var(--kbq-markdown-blockquote-background);
+            border-color: var(--kbq-markdown-blockquote-border);
+            border-left-color: var(--kbq-markdown-blockquote-line);
         }
 
         .kbq-markdown__pre,
         .kbq-markdown__p > .kbq-markdown__code {
-            color: kbq-css-variable(markdown-code-text);
-            background-color: kbq-css-variable(markdown-code-background);
-            border-color: kbq-css-variable(markdown-code-border);
+            color: var(--kbq-markdown-code-text);
+            background-color: var(--kbq-markdown-code-background);
+            border-color: var(--kbq-markdown-code-border);
         }
 
         .kbq-markdown__a {
-            color: kbq-css-variable(markdown-link-text);
-            border-bottom-color: kbq-css-variable(markdown-link-border-bottom);
+            color: var(--kbq-markdown-link-text);
+            border-bottom-color: var(--kbq-markdown-link-border-bottom);
 
             &:visited {
-                color: kbq-css-variable(markdown-link-state-visited-text);
-                border-bottom-color: kbq-css-variable(markdown-link-state-visited-border-bottom);
+                color: var(--kbq-markdown-link-state-visited-text);
+                border-bottom-color: var(--kbq-markdown-link-state-visited-border-bottom);
             }
 
             &:hover {
-                color: kbq-css-variable(markdown-link-state-hover-text);
+                color: var(--kbq-markdown-link-state-hover-text);
                 transition: color 0ms;
-                border-bottom-color: kbq-css-variable(markdown-link-state-hover-border-bottom);
+                border-bottom-color: var(--kbq-markdown-link-state-hover-border-bottom);
             }
 
             &:active {
-                color: kbq-css-variable(markdown-link-state-active);
+                color: var(--kbq-markdown-link-state-active);
             }
 
             &:focus {
-                outline: kbq-css-variable(markdown-link-state-focused-outline) solid
-                    kbq-css-variable(markdown-link-size-state-focused-outline-width);
+                outline: var(--kbq-markdown-link-state-focused-outline) solid
+                    var(--kbq-markdown-link-size-state-focused-outline-width);
 
-                outline-offset: kbq-css-variable(markdown-link-size-state-focused-outline-offset);
+                outline-offset: var(--kbq-markdown-link-size-state-focused-outline-offset);
             }
         }
 
         .kbq-markdown__img + em {
-            color: kbq-css-variable(markdown-image-caption-text);
+            color: var(--kbq-markdown-image-caption-text);
         }
 
         .kbq-markdown__hr {
-            border-bottom-color: kbq-css-variable(markdown-hr-color);
+            border-bottom-color: var(--kbq-markdown-hr-color);
         }
 
         .kbq-markdown__table > .kbq-markdown__thead {
-            color: kbq-css-variable(markdown-table-header);
-            border-bottom-color: kbq-css-variable(markdown-table-border);
+            color: var(--kbq-markdown-table-header);
+            border-bottom-color: var(--kbq-markdown-table-border);
         }
 
         .kbq-markdown__table > .kbq-markdown__tbody {
-            color: kbq-css-variable(markdown-table-body);
+            color: var(--kbq-markdown-table-body);
         }
     }
 }

--- a/packages/components/markdown/markdown.scss
+++ b/packages/components/markdown/markdown.scss
@@ -14,8 +14,8 @@
     // h1, h2, h3, h4, h5, h6
     @for $i from 1 through 6 {
         .kbq-markdown__h#{$i} {
-            margin-top: kbq-css-variable(markdown-h#{$i}-size-margin-top);
-            margin-bottom: kbq-css-variable(markdown-h#{$i}-size-margin-bottom);
+            margin-top: var(--kbq-markdown-h#{$i}-size-margin-top);
+            margin-bottom: var(--kbq-markdown-h#{$i}-size-margin-bottom);
 
             @for $i from 1 through 6 {
                 & + .kbq-markdown__h#{$i} {
@@ -37,24 +37,24 @@
     }
 
     .kbq-markdown__p {
-        margin-top: kbq-css-variable(markdown-p-size-margin-top);
-        margin-bottom: kbq-css-variable(markdown-p-size-margin-bottom);
+        margin-top: var(--kbq-markdown-p-size-margin-top);
+        margin-bottom: var(--kbq-markdown-p-size-margin-bottom);
     }
 
     .kbq-markdown__ul,
     .kbq-markdown__ol {
-        margin-top: kbq-css-variable(markdown-list-size-margin-top);
-        margin-bottom: kbq-css-variable(markdown-list-size-margin-bottom);
+        margin-top: var(--kbq-markdown-list-size-margin-top);
+        margin-bottom: var(--kbq-markdown-list-size-margin-bottom);
 
         > li {
-            margin-bottom: kbq-css-variable(markdown-list-size-item-margin-bottom);
+            margin-bottom: var(--kbq-markdown-list-size-item-margin-bottom);
         }
     }
 
     .kbq-markdown__ul {
         position: relative;
         list-style: none;
-        padding: kbq-css-variable(markdown-list-size-ul-padding);
+        padding: var(--kbq-markdown-list-size-ul-padding);
     }
 
     .kbq-markdown__ul > li:before {
@@ -75,7 +75,7 @@
             &:before {
                 content: counter(li) '.';
                 counter-increment: li;
-                padding-right: kbq-css-variable(markdown-list-size-ol-number-padding-right);
+                padding-right: var(--kbq-markdown-list-size-ol-number-padding-right);
             }
 
             > * {
@@ -86,20 +86,20 @@
 
     .kbq-markdown__p + .kbq-markdown__ul,
     .kbq-markdown__p + .kbq-markdown__ol {
-        margin-top: kbq-css-variable(markdown-list-size-margin-top-after-paragraph);
+        margin-top: var(--kbq-markdown-list-size-margin-top-after-paragraph);
     }
 
     .kbq-markdown__blockquote {
-        margin-top: kbq-css-variable(markdown-blockquote-size-margin-top);
+        margin-top: var(--kbq-markdown-blockquote-size-margin-top);
         margin-left: 0;
-        margin-bottom: kbq-css-variable(markdown-blockquote-size-margin-bottom);
+        margin-bottom: var(--kbq-markdown-blockquote-size-margin-bottom);
         margin-right: 0;
 
-        border-left-width: kbq-css-variable(markdown-blockquote-size-line-width);
+        border-left-width: var(--kbq-markdown-blockquote-size-line-width);
 
         border-left-style: solid;
 
-        padding: kbq-css-variable(markdown-blockquote-size-padding);
+        padding: var(--kbq-markdown-blockquote-size-padding);
     }
 
     .kbq-markdown__blockquote > .kbq-markdown__p {
@@ -111,32 +111,32 @@
         position: relative;
         overflow-x: auto;
 
-        margin-top: kbq-css-variable(markdown-code-size-multiline-margin-top);
-        margin-bottom: kbq-css-variable(markdown-code-size-multiline-margin-bottom);
+        margin-top: var(--kbq-markdown-code-size-multiline-margin-top);
+        margin-bottom: var(--kbq-markdown-code-size-multiline-margin-bottom);
 
-        padding: kbq-css-variable(markdown-code-size-multiline-padding);
+        padding: var(--kbq-markdown-code-size-multiline-padding);
     }
 
     .kbq-markdown__pre,
     .kbq-markdown__p > .kbq-markdown__code {
-        border-radius: kbq-css-variable(markdown-code-size-border-radius);
-        border-width: kbq-css-variable(markdown-code-size-border-width);
+        border-radius: var(--kbq-markdown-code-size-border-radius);
+        border-width: var(--kbq-markdown-code-size-border-width);
         border-style: solid;
     }
 
     .kbq-markdown__p > .kbq-markdown__code {
-        padding: kbq-css-variable(markdown-code-size-inline-padding);
+        padding: var(--kbq-markdown-code-size-inline-padding);
     }
 
     .kbq-markdown__img {
         max-width: 100%;
-        margin-top: kbq-css-variable(markdown-image-size-margin-top);
-        margin-bottom: kbq-css-variable(markdown-image-size-margin-bottom);
+        margin-top: var(--kbq-markdown-image-size-margin-top);
+        margin-bottom: var(--kbq-markdown-image-size-margin-bottom);
 
         + em {
             display: block;
-            margin-top: kbq-css-variable(markdown-image-size-caption-margin-top);
-            margin-bottom: kbq-css-variable(markdown-image-size-caption-margin-bottom);
+            margin-top: var(--kbq-markdown-image-size-caption-margin-top);
+            margin-bottom: var(--kbq-markdown-image-size-caption-margin-bottom);
         }
     }
 
@@ -145,8 +145,8 @@
         border-left: none;
         border-right: none;
         border-bottom-style: solid;
-        border-bottom-width: kbq-css-variable(markdown-hr-size-width);
-        margin: kbq-css-variable(markdown-hr-size-margin-vertical) 0;
+        border-bottom-width: var(--kbq-markdown-hr-size-width);
+        margin: var(--kbq-markdown-hr-size-margin-vertical) 0;
     }
 
     .kbq-markdown__table {
@@ -154,7 +154,7 @@
         overflow-x: auto;
         display: table;
         border-collapse: collapse;
-        margin-bottom: kbq-css-variable(markdown-table-size-margin-bottom);
+        margin-bottom: var(--kbq-markdown-table-size-margin-bottom);
 
         td {
             vertical-align: top;
@@ -162,14 +162,14 @@
 
         th,
         td {
-            padding: kbq-css-variable(markdown-table-size-padding);
+            padding: var(--kbq-markdown-table-size-padding);
             font-weight: 400;
         }
     }
 
     .kbq-markdown__table > .kbq-markdown__thead {
         border-bottom-style: solid;
-        border-bottom-width: kbq-css-variable(markdown-table-size-border-width);
+        border-bottom-width: var(--kbq-markdown-table-size-border-width);
 
         text-align: left;
 

--- a/packages/components/modal/_modal-confirm.scss
+++ b/packages/components/modal/_modal-confirm.scss
@@ -8,6 +8,6 @@
     .kbq-confirm-footer {
         display: flex;
 
-        gap: kbq-css-variable(modal-size-footer-content-gap-horizontal);
+        gap: var(--kbq-modal-size-footer-content-gap-horizontal);
     }
 }

--- a/packages/components/modal/_modal-theme.scss
+++ b/packages/components/modal/_modal-theme.scss
@@ -1,26 +1,24 @@
-/* stylelint-disable no-unknown-custom-properties */
-
 @use 'sass:map';
 
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-modal-theme() {
     .kbq-modal {
-        background: kbq-css-variable(modal-container-background);
-        box-shadow: kbq-css-variable(modal-container-box-shadow);
+        background: var(--kbq-modal-container-background);
+        box-shadow: var(--kbq-modal-container-box-shadow);
 
         .kbq-modal-header {
             & .kbq-modal-title {
-                color: kbq-css-variable(modal-header-text-color);
+                color: var(--kbq-modal-header-text-color);
             }
 
             & .kbq-modal-close {
-                color: kbq-css-variable(modal-close-button-color);
+                color: var(--kbq-modal-close-button-color);
             }
         }
 
         .kbq-modal-content {
-            color: kbq-css-variable(modal-content-text-color);
+            color: var(--kbq-modal-content-text-color);
         }
 
         .kbq-modal-header.kbq-modal-body_top-overflow {
@@ -33,7 +31,7 @@
     }
 
     .kbq-modal-mask {
-        background-color: kbq-css-variable(modal-overlay-background);
+        background-color: var(--kbq-modal-overlay-background);
     }
 }
 

--- a/packages/components/modal/modal.scss
+++ b/packages/components/modal/modal.scss
@@ -14,7 +14,7 @@
 
     top: 48px;
 
-    border-radius: kbq-css-variable(modal-size-border-radius);
+    border-radius: var(--kbq-modal-size-border-radius);
 
     width: auto;
 
@@ -31,15 +31,15 @@
     }
 
     &.kbq-modal_small {
-        width: kbq-css-variable(modal-size-small-width);
+        width: var(--kbq-modal-size-small-width);
     }
 
     &.kbq-modal_medium {
-        width: kbq-css-variable(modal-size-medium-width);
+        width: var(--kbq-modal-size-medium-width);
     }
 
     &.kbq-modal_large {
-        width: kbq-css-variable(modal-size-large-width);
+        width: var(--kbq-modal-size-large-width);
     }
 
     // todo реализуем когда будем делать 2.0, пока нет возможности отслеживать наличие/отсутствие футера
@@ -75,7 +75,7 @@
 .kbq-modal-content {
     position: relative;
 
-    border-radius: kbq-css-variable(modal-size-border-radius);
+    border-radius: var(--kbq-modal-size-border-radius);
 
     background-clip: padding-box;
 }
@@ -85,11 +85,11 @@
     align-items: center;
     justify-content: space-between;
 
-    padding: kbq-css-variable(modal-size-header-padding-vertical) kbq-css-variable(modal-size-header-padding-right)
-        kbq-css-variable(modal-size-header-padding-vertical) kbq-css-variable(modal-size-header-padding-left);
+    padding: var(--kbq-modal-size-header-padding-vertical) var(--kbq-modal-size-header-padding-right)
+        var(--kbq-modal-size-header-padding-vertical) var(--kbq-modal-size-header-padding-left);
 
     & + .kbq-modal-body {
-        padding-top: kbq-css-variable(modal-size-content-padding-top);
+        padding-top: var(--kbq-modal-size-content-padding-top);
     }
 }
 
@@ -106,9 +106,8 @@
 
     max-height: calc(100vh - 260px);
 
-    padding: kbq-css-variable(modal-size-content-padding-top-without-header)
-        kbq-css-variable(modal-size-content-padding-horizontal) kbq-css-variable(modal-size-content-padding-bottom)
-        kbq-css-variable(modal-size-content-padding-horizontal);
+    padding: var(--kbq-modal-size-content-padding-top-without-header) var(--kbq-modal-size-content-padding-horizontal)
+        var(--kbq-modal-size-content-padding-bottom) var(--kbq-modal-size-content-padding-horizontal);
 
     word-wrap: break-word;
 
@@ -122,9 +121,9 @@
     display: flex;
     align-items: center;
 
-    padding: kbq-css-variable(modal-size-footer-padding-vertical) kbq-css-variable(modal-size-footer-padding-horizontal);
+    padding: var(--kbq-modal-size-footer-padding-vertical) var(--kbq-modal-size-footer-padding-horizontal);
 
-    gap: kbq-css-variable(modal-size-footer-content-gap-horizontal);
+    gap: var(--kbq-modal-size-footer-content-gap-horizontal);
 }
 
 .kbq-modal-mask {

--- a/packages/components/navbar/_navbar-item_horizontal.scss
+++ b/packages/components/navbar/_navbar-item_horizontal.scss
@@ -15,18 +15,18 @@
     outline: none;
     -webkit-tap-highlight-color: transparent;
 
-    min-height: kbq-css-variable(size-3xl);
-    min-width: kbq-css-variable(size-3xl);
+    min-height: var(--kbq-size-3xl);
+    min-width: var(--kbq-size-3xl);
 
-    margin: kbq-css-variable(size-s);
+    margin: var(--kbq-size-s);
 
     justify-content: center;
 
     &:before {
-        top: calc(-1 * #{kbq-css-variable(size-s)});
-        left: calc(-1 * #{kbq-css-variable(size-s)});
-        right: calc(-1 * #{kbq-css-variable(size-s)});
-        bottom: calc(-1 * #{kbq-css-variable(size-s)});
+        top: calc(-1 * #{var(--kbq-size-s)});
+        left: calc(-1 * #{var(--kbq-size-s)});
+        right: calc(-1 * #{var(--kbq-size-s)});
+        bottom: calc(-1 * #{var(--kbq-size-s)});
     }
 
     &:after {
@@ -37,19 +37,19 @@
     }
 
     & .kbq-navbar-item__title {
-        padding-left: kbq-css-variable(size-xxs);
-        padding-right: kbq-css-variable(size-xxs);
+        padding-left: var(--kbq-size-xxs);
+        padding-right: var(--kbq-size-xxs);
     }
 
     & .kbq-navbar-item__arrow-icon {
-        padding-left: kbq-css-variable(size-xxs);
+        padding-left: var(--kbq-size-xxs);
     }
 
     &.kbq-navbar-item_with-title:not(.kbq-navbar-item_collapsed) {
         margin-left: 0;
         margin-right: 0;
-        padding-right: kbq-css-variable(size-m);
-        padding-left: kbq-css-variable(size-m);
+        padding-right: var(--kbq-size-m);
+        padding-left: var(--kbq-size-m);
 
         &:before {
             left: 0;
@@ -59,24 +59,24 @@
         & > .kbq-icon {
             align-self: center;
 
-            padding-right: kbq-css-variable(size-xxs);
+            padding-right: var(--kbq-size-xxs);
         }
     }
 
     &.kbq-navbar-bento {
         justify-content: center;
 
-        margin-right: kbq-css-variable(size-xxs);
+        margin-right: var(--kbq-size-xxs);
 
         &:before {
-            right: calc(-1 * #{kbq-css-variable(size-xxs)});
+            right: calc(-1 * #{var(--kbq-size-xxs)});
         }
     }
 
     &.kbq-navbar-item_collapsed {
         justify-content: center;
 
-        padding: kbq-css-variable(size-s);
+        padding: var(--kbq-size-s);
 
         & .kbq-navbar-item__container {
             display: none;
@@ -93,12 +93,12 @@
     }
 
     &.kbq-navbar-item_has-nested {
-        margin-left: kbq-css-variable(size-m);
-        margin-right: kbq-css-variable(size-m);
+        margin-left: var(--kbq-size-m);
+        margin-right: var(--kbq-size-m);
 
         &:before {
-            left: calc(-1 * #{kbq-css-variable(size-m)});
-            right: calc(-1 * #{kbq-css-variable(size-m)});
+            left: calc(-1 * #{var(--kbq-size-m)});
+            right: calc(-1 * #{var(--kbq-size-m)});
         }
     }
 }

--- a/packages/components/navbar/_navbar-item_vertical.scss
+++ b/packages/components/navbar/_navbar-item_vertical.scss
@@ -6,24 +6,24 @@
 
 .kbq-navbar-item.kbq-vertical {
     & .kbq-navbar-item__container {
-        gap: kbq-css-variable(size-m);
+        gap: var(--kbq-size-m);
     }
 
     &.kbq-expanded {
-        height: kbq-css-variable(size-5xl);
+        height: var(--kbq-size-5xl);
 
         align-items: center;
 
-        padding-right: kbq-css-variable(size-xl);
-        padding-left: kbq-css-variable(size-xl);
+        padding-right: var(--kbq-size-xl);
+        padding-left: var(--kbq-size-xl);
 
-        gap: kbq-css-variable(size-m);
+        gap: var(--kbq-size-m);
 
         &:after {
-            top: kbq-css-variable(size-xxs);
-            right: kbq-css-variable(size-s);
-            bottom: kbq-css-variable(size-xxs);
-            left: kbq-css-variable(size-s);
+            top: var(--kbq-size-xxs);
+            right: var(--kbq-size-s);
+            bottom: var(--kbq-size-xxs);
+            left: var(--kbq-size-s);
         }
 
         &.kbq-navbar-bento {
@@ -34,44 +34,44 @@
             justify-content: center;
             align-items: center;
 
-            top: kbq-css-variable(size-xxs);
-            right: kbq-css-variable(size-xxs);
+            top: var(--kbq-size-xxs);
+            right: var(--kbq-size-xxs);
 
             z-index: 1;
 
-            padding: kbq-css-variable(size-s);
+            padding: var(--kbq-size-s);
 
-            height: kbq-css-variable(size-5xl);
-            width: kbq-css-variable(size-5xl);
+            height: var(--kbq-size-5xl);
+            width: var(--kbq-size-5xl);
 
             &:after {
-                top: kbq-css-variable(size-s);
-                right: kbq-css-variable(size-s);
-                bottom: kbq-css-variable(size-s);
-                left: kbq-css-variable(size-s);
+                top: var(--kbq-size-s);
+                right: var(--kbq-size-s);
+                bottom: var(--kbq-size-s);
+                left: var(--kbq-size-s);
             }
         }
 
         &.kbq-navbar-item_has-nested {
             align-items: center;
 
-            padding: 0 kbq-css-variable(size-m);
+            padding: 0 var(--kbq-size-m);
         }
     }
 
     &.kbq-collapsed {
-        height: kbq-css-variable(size-5xl);
-        width: kbq-css-variable(size-5xl);
+        height: var(--kbq-size-5xl);
+        width: var(--kbq-size-5xl);
 
-        padding: kbq-css-variable(size-l);
+        padding: var(--kbq-size-l);
 
         justify-content: center;
 
         &:after {
-            top: kbq-css-variable(size-s);
-            right: kbq-css-variable(size-s);
-            bottom: kbq-css-variable(size-s);
-            left: kbq-css-variable(size-s);
+            top: var(--kbq-size-s);
+            right: var(--kbq-size-s);
+            bottom: var(--kbq-size-s);
+            left: var(--kbq-size-s);
         }
 
         & .kbq-badge {
@@ -79,8 +79,8 @@
 
             z-index: 1;
 
-            top: kbq-css-variable(size-xs);
-            right: kbq-css-variable(size-xs);
+            top: var(--kbq-size-xs);
+            right: var(--kbq-size-xs);
         }
 
         & .kbq-navbar-item__container {

--- a/packages/components/navbar/_navbar-theme.scss
+++ b/packages/components/navbar/_navbar-theme.scss
@@ -4,31 +4,31 @@
     &:not(.kbq-navbar-item_has-nested) {
         &:after {
             display: block;
-            background: kbq-css-variable(navbar-item-#{$state-name}-content-background);
+            background: var(--kbq-navbar-item-#{$state-name}-content-background);
         }
     }
 
     .kbq-navbar-title {
-        color: kbq-css-variable(navbar-item-#{$state-name}-content-text);
+        color: var(--kbq-navbar-item-#{$state-name}-content-text);
     }
 
     & > .kbq-icon {
-        color: kbq-css-variable(navbar-item-#{$state-name}-content-icon-left) !important;
+        color: var(--kbq-navbar-item-#{$state-name}-content-icon-left) !important;
     }
 
     .kbq-navbar-item__arrow-icon {
-        color: kbq-css-variable(navbar-item-#{$state-name}-content-icon-right) !important;
+        color: var(--kbq-navbar-item-#{$state-name}-content-icon-right) !important;
     }
 }
 
 @mixin kbq-navbar-theme() {
     .kbq-navbar,
     .kbq-vertical-navbar .kbq-vertical-navbar__container {
-        background-color: kbq-css-variable(navbar-background);
+        background-color: var(--kbq-navbar-background);
     }
 
     .kbq-vertical-navbar .kbq-vertical-navbar__container {
-        border-right: 1px solid kbq-css-variable(navbar-border);
+        border-right: 1px solid var(--kbq-navbar-border);
     }
 
     .kbq-navbar-item,
@@ -47,7 +47,7 @@
 
             &:after {
                 display: block;
-                box-shadow: inset 0 0 0 2px kbq-css-variable(states-line-focus-theme);
+                box-shadow: inset 0 0 0 2px var(--kbq-states-line-focus-theme);
             }
         }
 
@@ -81,7 +81,7 @@
     }
 
     .kbq-navbar-divider {
-        background: kbq-css-variable(line-contrast-less);
+        background: var(--kbq-line-contrast-less);
     }
 }
 

--- a/packages/components/navbar/navbar-brand.scss
+++ b/packages/components/navbar/navbar-brand.scss
@@ -15,7 +15,7 @@ $tokens: meta.module-variables(tokens) !default;
 
     display: flex;
 
-    border-radius: kbq-css-variable(size-s);
+    border-radius: var(--kbq-size-s);
 
     &:after {
         position: absolute;
@@ -23,7 +23,7 @@ $tokens: meta.module-variables(tokens) !default;
 
         display: none;
 
-        border-radius: kbq-css-variable(navbar-item-size-content-border-radius);
+        border-radius: var(--kbq-navbar-item-size-content-border-radius);
     }
 
     & .kbq-navbar-title {
@@ -36,21 +36,21 @@ a.kbq-navbar-brand {
 }
 
 .kbq-navbar-brand.kbq-horizontal {
-    padding: kbq-css-variable(size-s) kbq-css-variable(size-xs) kbq-css-variable(size-s) kbq-css-variable(size-xxs);
+    padding: var(--kbq-size-s) var(--kbq-size-xs) var(--kbq-size-s) var(--kbq-size-xxs);
 
     align-items: center;
 
-    gap: kbq-css-variable(size-s);
+    gap: var(--kbq-size-s);
 
     &:after {
-        top: kbq-css-variable(size-xxs);
-        right: kbq-css-variable(size-xxs);
-        bottom: kbq-css-variable(size-xxs);
+        top: var(--kbq-size-xxs);
+        right: var(--kbq-size-xxs);
+        bottom: var(--kbq-size-xxs);
         left: 0;
     }
 
     & .kbq-navbar-title {
-        padding-right: kbq-css-variable(size-m);
+        padding-right: var(--kbq-size-m);
     }
 }
 
@@ -63,10 +63,10 @@ a.kbq-navbar-brand {
         display: block;
         align-items: center;
 
-        padding-top: kbq-css-variable(size-xxs);
-        padding-bottom: kbq-css-variable(size-xxs);
+        padding-top: var(--kbq-size-xxs);
+        padding-bottom: var(--kbq-size-xxs);
 
-        height: kbq-css-variable(size-3xl);
+        height: var(--kbq-size-3xl);
 
         padding-left: 0;
 
@@ -78,10 +78,10 @@ a.kbq-navbar-brand {
     &.kbq-expanded {
         position: relative;
 
-        height: kbq-css-variable(size-4xl);
-        width: kbq-css-variable(size-4xl);
+        height: var(--kbq-size-4xl);
+        width: var(--kbq-size-4xl);
 
-        margin: kbq-css-variable(size-l) kbq-css-variable(size-l) kbq-css-variable(size-4xl);
+        margin: var(--kbq-size-l) var(--kbq-size-l) var(--kbq-size-4xl);
 
         flex-direction: column;
 
@@ -93,7 +93,7 @@ a.kbq-navbar-brand {
         }
 
         & .kbq-navbar-logo {
-            min-height: kbq-css-variable(size-4xl);
+            min-height: var(--kbq-size-4xl);
 
             justify-content: center;
         }
@@ -101,21 +101,21 @@ a.kbq-navbar-brand {
         & .kbq-navbar-title {
             position: absolute;
 
-            left: kbq-css-variable(size-xxs);
-            top: kbq-css-variable(size-4xl);
+            left: var(--kbq-size-xxs);
+            top: var(--kbq-size-4xl);
             max-width: 200px;
         }
     }
 
     &.kbq-collapsed {
-        height: kbq-css-variable(size-5xl);
-        width: kbq-css-variable(size-5xl);
+        height: var(--kbq-size-5xl);
+        width: var(--kbq-size-5xl);
 
         &:after {
-            top: kbq-css-variable(size-xxs);
-            right: kbq-css-variable(size-xxs);
-            bottom: kbq-css-variable(size-xxs);
-            left: kbq-css-variable(size-xxs);
+            top: var(--kbq-size-xxs);
+            right: var(--kbq-size-xxs);
+            bottom: var(--kbq-size-xxs);
+            left: var(--kbq-size-xxs);
         }
 
         & .kbq-navbar-title {

--- a/packages/components/navbar/navbar-divider.scss
+++ b/packages/components/navbar/navbar-divider.scss
@@ -7,7 +7,7 @@
 .kbq-navbar-divider.kbq-vertical {
     height: 1px;
 
-    margin: kbq-css-variable(size-s) kbq-css-variable(size-l);
+    margin: var(--kbq-size-s) var(--kbq-size-l);
 }
 
 .kbq-navbar-divider.kbq-horizontal {
@@ -15,6 +15,6 @@
 
     height: 12px;
 
-    margin-left: kbq-css-variable(size-m);
-    margin-right: kbq-css-variable(size-m);
+    margin-left: var(--kbq-size-m);
+    margin-right: var(--kbq-size-m);
 }

--- a/packages/components/navbar/navbar-item.scss
+++ b/packages/components/navbar/navbar-item.scss
@@ -13,17 +13,17 @@
     display: flex;
     align-items: center;
 
-    border-radius: kbq-css-variable(navbar-item-size-content-border-radius);
+    border-radius: var(--kbq-navbar-item-size-content-border-radius);
 
     & .kbq-icon {
-        min-width: kbq-css-variable(size-l);
-        min-height: kbq-css-variable(size-l);
+        min-width: var(--kbq-size-l);
+        min-height: var(--kbq-size-l);
     }
 
     & .kbq-button-icon {
         position: absolute;
-        padding-left: kbq-css-variable(size-xs);
-        padding-right: kbq-css-variable(size-xs);
+        padding-left: var(--kbq-size-xs);
+        padding-right: var(--kbq-size-xs);
         top: 50%;
         transform: translateY(-50%);
     }
@@ -39,7 +39,7 @@
 
         display: none;
 
-        border-radius: kbq-css-variable(navbar-item-size-content-border-radius);
+        border-radius: var(--kbq-navbar-item-size-content-border-radius);
     }
 
     &.kbq-horizontal {

--- a/packages/components/navbar/navbar.scss
+++ b/packages/components/navbar/navbar.scss
@@ -23,7 +23,7 @@
 }
 
 .kbq-navbar .kbq-navbar-container + .kbq-navbar-container {
-    margin-left: kbq-css-variable(size-xxl);
+    margin-left: var(--kbq-size-xxl);
 }
 
 @include kbq-navbar-theme();

--- a/packages/components/navbar/vertical-navbar.scss
+++ b/packages/components/navbar/vertical-navbar.scss
@@ -12,7 +12,7 @@
     }
 
     & .kbq-navbar-container + .kbq-navbar-container {
-        padding-top: kbq-css-variable(size-xxl);
+        padding-top: var(--kbq-size-xxl);
     }
 
     & .kbq-vertical-navbar__container {
@@ -22,7 +22,7 @@
         height: 100%;
 
         &.kbq-collapsed {
-            width: kbq-css-variable(size-5xl);
+            width: var(--kbq-size-5xl);
         }
 
         &.kbq-expanded {

--- a/packages/components/popover/_popover-theme.scss
+++ b/packages/components/popover/_popover-theme.scss
@@ -2,28 +2,28 @@
 
 @mixin kbq-popover-theme() {
     .kbq-popover {
-        box-shadow: kbq-css-variable(popover-container-box-shadow);
+        box-shadow: var(--kbq-popover-container-box-shadow);
     }
 
     .kbq-popover__container {
-        background: kbq-css-variable(popover-container-background);
+        background: var(--kbq-popover-container-background);
     }
 
     .kbq-popover__arrow {
-        box-shadow: kbq-css-variable(popover-container-box-shadow);
-        background: kbq-css-variable(popover-container-background);
+        box-shadow: var(--kbq-popover-container-box-shadow);
+        background: var(--kbq-popover-container-background);
     }
 
     .kbq-popover__close {
-        background-color: kbq-css-variable(background-overlay-inverse);
+        background-color: var(--kbq-background-overlay-inverse);
     }
 
     .kbq-popover__header {
-        color: kbq-css-variable(popover-header-text-color);
+        color: var(--kbq-popover-header-text-color);
     }
 
     .kbq-popover__content {
-        color: kbq-css-variable(popover-content-text-color);
+        color: var(--kbq-popover-content-text-color);
     }
 }
 

--- a/packages/components/popover/popover.scss
+++ b/packages/components/popover/popover.scss
@@ -11,7 +11,7 @@ $trigger-margin: 9px;
 .kbq-popover {
     position: relative;
 
-    border-radius: kbq-css-variable(popover-size-container-border-radius);
+    border-radius: var(--kbq-popover-size-container-border-radius);
 
     box-sizing: border-box;
 
@@ -21,15 +21,15 @@ $trigger-margin: 9px;
     z-index: 1;
 
     &.kbq-popover_small {
-        max-width: kbq-css-variable(popover-size-container-width-small);
+        max-width: var(--kbq-popover-size-container-width-small);
     }
 
     &.kbq-popover_medium {
-        max-width: kbq-css-variable(popover-size-container-width-medium);
+        max-width: var(--kbq-popover-size-container-width-medium);
     }
 
     &.kbq-popover_large {
-        max-width: kbq-css-variable(popover-size-container-width-large);
+        max-width: var(--kbq-popover-size-container-width-large);
     }
 
     @include pop-up.popup-margins(kbq-popover, 8px);
@@ -38,8 +38,8 @@ $trigger-margin: 9px;
 .kbq-popover__content {
     overflow-y: auto;
 
-    padding: kbq-css-variable(popover-size-content-padding-top)
-        kbq-css-variable(popover-size-content-padding-horizontal) kbq-css-variable(popover-size-content-padding-bottom);
+    padding: var(--kbq-popover-size-content-padding-top) var(--kbq-popover-size-content-padding-horizontal)
+        var(--kbq-popover-size-content-padding-bottom);
 }
 
 .kbq-popover__container {
@@ -48,19 +48,19 @@ $trigger-margin: 9px;
     display: flex;
     flex-direction: column;
 
-    max-height: kbq-css-variable(popover-size-container-max-height);
+    max-height: var(--kbq-popover-size-container-max-height);
 
-    border-radius: kbq-css-variable(popover-size-container-border-radius);
+    border-radius: var(--kbq-popover-size-container-border-radius);
 
     &.kbq-popover__container_with-header {
         .kbq-popover__content {
-            padding-top: kbq-css-variable(size-s);
+            padding-top: var(--kbq-size-s);
         }
     }
 
     &.kbq-popover__container_with-footer {
         .kbq-popover__content {
-            padding-bottom: kbq-css-variable(size-s);
+            padding-bottom: var(--kbq-size-s);
         }
     }
 }
@@ -83,8 +83,8 @@ $trigger-margin: 9px;
 
     overflow: hidden;
 
-    padding: kbq-css-variable(popover-size-header-padding-top) kbq-css-variable(popover-size-header-padding-horizontal)
-        kbq-css-variable(popover-size-header-padding-bottom) kbq-css-variable(popover-size-header-padding-horizontal);
+    padding: var(--kbq-popover-size-header-padding-top) var(--kbq-popover-size-header-padding-horizontal)
+        var(--kbq-popover-size-header-padding-bottom) var(--kbq-popover-size-header-padding-horizontal);
 
     & .kbq-popover__header-text {
         @include common.kbq-truncate-line();
@@ -96,12 +96,11 @@ $trigger-margin: 9px;
 }
 
 .kbq-popover__header_with-close-button {
-    padding-right: kbq-css-variable(size-4xl);
+    padding-right: var(--kbq-size-4xl);
 }
 
 .kbq-popover__footer {
-    padding: kbq-css-variable(popover-size-footer-padding-vertical)
-        kbq-css-variable(popover-size-footer-padding-horizontal);
+    padding: var(--kbq-popover-size-footer-padding-vertical) var(--kbq-popover-size-footer-padding-horizontal);
 }
 
 .kbq-popover__footer_bottom-overflow {
@@ -127,9 +126,9 @@ $arrow-padding: calc(18px - $trigger-margin);
 .kbq-popover__close {
     position: absolute;
     z-index: 2;
-    top: kbq-css-variable(size-s);
-    right: kbq-css-variable(size-s);
-    border-radius: kbq-css-variable(button-size-border-radius);
+    top: var(--kbq-size-s);
+    right: var(--kbq-size-s);
+    border-radius: var(--kbq-button-size-border-radius);
 }
 
 @include kbq-popover-theme();

--- a/packages/components/progress-bar/_progress-bar-theme.scss
+++ b/packages/components/progress-bar/_progress-bar-theme.scss
@@ -3,20 +3,20 @@
 @mixin kbq-progress-bar-theme() {
     .kbq-progress-bar.kbq-theme {
         .kbq-progress-bar__inner {
-            background-color: kbq-css-variable(progress-bar-bar-background);
+            background-color: var(--kbq-progress-bar-bar-background);
         }
 
         .kbq-progress-bar__line {
-            background-color: kbq-css-variable(progress-bar-bar-foreground);
+            background-color: var(--kbq-progress-bar-bar-foreground);
         }
     }
 
     .kbq-progress-bar-text {
-        color: kbq-css-variable(progress-bar-text-color);
+        color: var(--kbq-progress-bar-text-color);
     }
 
     .kbq-progress-bar-caption {
-        color: kbq-css-variable(progress-bar-caption-color);
+        color: var(--kbq-progress-bar-caption-color);
     }
 }
 

--- a/packages/components/progress-bar/progress-bar.scss
+++ b/packages/components/progress-bar/progress-bar.scss
@@ -21,25 +21,25 @@
     overflow: hidden;
 
     .kbq-progress-bar-text {
-        margin-bottom: kbq-css-variable(progress-bar-size-container-content-gap);
+        margin-bottom: var(--kbq-progress-bar-size-container-content-gap);
     }
 
     .kbq-progress-bar-caption {
-        margin-top: kbq-css-variable(progress-bar-size-container-content-gap);
+        margin-top: var(--kbq-progress-bar-size-container-content-gap);
     }
 
     & .kbq-progress-bar__inner {
         overflow: hidden;
 
-        height: kbq-css-variable(progress-bar-size-bar-height);
-        border-radius: kbq-css-variable(progress-bar-size-container-border-radius);
+        height: var(--kbq-progress-bar-size-bar-height);
+        border-radius: var(--kbq-progress-bar-size-container-border-radius);
     }
 
     & .kbq-progress-bar__line {
         height: 100%;
         transform-origin: top left;
 
-        border-radius: kbq-css-variable(progress-bar-size-bar-border-radius);
+        border-radius: var(--kbq-progress-bar-size-bar-border-radius);
     }
 
     &.kbq-progress-bar_determinate .kbq-progress-bar__line {

--- a/packages/components/progress-spinner/_progress-spinner-theme.scss
+++ b/packages/components/progress-spinner/_progress-spinner-theme.scss
@@ -3,16 +3,16 @@
 @mixin kbq-progress-spinner-theme() {
     .kbq-progress-spinner {
         .kbq-progress-spinner__circle {
-            stroke: kbq-css-variable(progress-spinner-circle-background);
+            stroke: var(--kbq-progress-spinner-circle-background);
         }
     }
 
     .kbq-progress-spinner-text {
-        color: kbq-css-variable(progress-spinner-text-color);
+        color: var(--kbq-progress-spinner-text-color);
     }
 
     .kbq-progress-spinner-caption {
-        color: kbq-css-variable(progress-spinner-caption-color);
+        color: var(--kbq-progress-spinner-caption-color);
     }
 }
 

--- a/packages/components/progress-spinner/progress-spinner.scss
+++ b/packages/components/progress-spinner/progress-spinner.scss
@@ -14,7 +14,7 @@
     display: flex;
     flex-direction: row;
 
-    gap: kbq-css-variable(progress-spinner-size-compact-content-gap-horizontal);
+    gap: var(--kbq-progress-spinner-size-compact-content-gap-horizontal);
 }
 
 .kbq-progress-spinner__circle {
@@ -27,8 +27,8 @@
 }
 
 .kbq-progress-spinner__inner {
-    width: kbq-css-variable(progress-spinner-size-compact-size);
-    height: kbq-css-variable(progress-spinner-size-compact-size);
+    width: var(--kbq-progress-spinner-size-compact-size);
+    height: var(--kbq-progress-spinner-size-compact-size);
 
     transform: rotateZ(-90deg);
 
@@ -37,16 +37,16 @@
 
 .kbq-progress-spinner__content {
     .kbq-progress-spinner-text {
-        margin-bottom: kbq-css-variable(progress-spinner-size-compact-content-gap-vertical);
+        margin-bottom: var(--kbq-progress-spinner-size-compact-content-gap-vertical);
     }
 }
 
 .kbq-progress-spinner_big {
-    gap: kbq-css-variable(progress-spinner-size-big-content-gap-horizontal);
+    gap: var(--kbq-progress-spinner-size-big-content-gap-horizontal);
 
     & .kbq-progress-spinner__inner {
-        width: kbq-css-variable(progress-spinner-size-big-size);
-        height: kbq-css-variable(progress-spinner-size-big-size);
+        width: var(--kbq-progress-spinner-size-big-size);
+        height: var(--kbq-progress-spinner-size-big-size);
     }
 
     & .kbq-progress-spinner__circle {

--- a/packages/components/radio/_radio-theme.scss
+++ b/packages/components/radio/_radio-theme.scss
@@ -4,14 +4,14 @@
     $base-path: radio-#{$type}-#{$state-name};
 
     & .kbq-radio-button__outer-circle {
-        border-color: kbq-css-variable(#{$base-path}-outer-circle-border);
-        background: kbq-css-variable(#{$base-path}-outer-circle-background);
+        border-color: var(--kbq-#{$base-path}-outer-circle-border);
+        background: var(--kbq-#{$base-path}-outer-circle-background);
         // FIXME: move under &.cdk-keyboard-focused, because used only for focused state.
-        box-shadow: kbq-css-variable(#{$base-path}-outer-circle-shadow);
+        box-shadow: var(--kbq-#{$base-path}-outer-circle-shadow);
     }
 
     & .kbq-radio-button__inner-circle {
-        background: kbq-css-variable(#{$base-path}-inner-circle-background);
+        background: var(--kbq-#{$base-path}-inner-circle-background);
     }
 }
 
@@ -19,7 +19,7 @@
     @include kbq-radio-state($type-name, default);
 
     & .kbq-hint .kbq-hint__text {
-        color: kbq-css-variable(radio-#{$type-name}-default-caption);
+        color: var(--kbq-radio-#{$type-name}-default-caption);
     }
 
     &:hover {
@@ -43,11 +43,11 @@
 
         & .kbq-radio-label {
             cursor: default;
-            color: kbq-css-variable(radio-#{$type-name}-states-disabled-caption);
+            color: var(--kbq-radio-#{$type-name}-states-disabled-caption);
         }
 
         & .kbq-hint .kbq-hint__text {
-            color: kbq-css-variable(radio-#{$type-name}-states-disabled-caption);
+            color: var(--kbq-radio-#{$type-name}-states-disabled-caption);
         }
     }
 }
@@ -60,12 +60,12 @@
 
         @include kbq-radio-color(theme);
 
-        color: kbq-css-variable(foreground-contrast);
+        color: var(--kbq-foreground-contrast);
 
         &.kbq-error {
             @include kbq-radio-color(error);
 
-            color: kbq-css-variable(foreground-contrast);
+            color: var(--kbq-foreground-contrast);
         }
     }
 }

--- a/packages/components/radio/radio.scss
+++ b/packages/components/radio/radio.scss
@@ -7,11 +7,11 @@
     flex-direction: column;
 
     &.kbq-radio-group_normal {
-        gap: kbq-css-variable(radio-size-normal-vertical-gap);
+        gap: var(--kbq-radio-size-normal-vertical-gap);
     }
 
     &.kbq-radio-group_big {
-        gap: kbq-css-variable(radio-size-big-vertical-gap);
+        gap: var(--kbq-radio-size-big-vertical-gap);
     }
 }
 
@@ -69,16 +69,16 @@
 
         top: kbq-css-half-difference(radio-font-normal-label-line-height, radio-size-normal-outer-size, 1px);
 
-        width: kbq-css-variable(radio-size-normal-outer-size);
-        height: kbq-css-variable(radio-size-normal-outer-size);
+        width: var(--kbq-radio-size-normal-outer-size);
+        height: var(--kbq-radio-size-normal-outer-size);
     }
 
     .kbq-radio-button__inner-circle {
         position: relative;
         margin: auto;
 
-        width: kbq-css-variable(radio-size-normal-inner-size);
-        height: kbq-css-variable(radio-size-normal-inner-size);
+        width: var(--kbq-radio-size-normal-inner-size);
+        height: var(--kbq-radio-size-normal-inner-size);
     }
 
     .kbq-radio__text-container {
@@ -87,11 +87,11 @@
     }
 
     & .kbq-hint {
-        margin-top: kbq-css-variable(radio-size-normal-vertical-content-padding);
+        margin-top: var(--kbq-radio-size-normal-vertical-content-padding);
     }
 
     [dir='rtl'] & {
-        padding-right: kbq-css-variable(radio-size-normal-horizontal-content-padding);
+        padding-right: var(--kbq-radio-size-normal-horizontal-content-padding);
         padding-left: 0;
     }
 }
@@ -112,21 +112,21 @@
         .kbq-radio-button__outer-circle {
             top: kbq-css-half-difference(radio-font-big-label-line-height, radio-size-big-outer-size, 1px);
 
-            width: kbq-css-variable(radio-size-big-outer-size);
-            height: kbq-css-variable(radio-size-big-outer-size);
+            width: var(--kbq-radio-size-big-outer-size);
+            height: var(--kbq-radio-size-big-outer-size);
         }
 
         .kbq-radio-button__inner-circle {
-            width: kbq-css-variable(radio-size-big-inner-size);
-            height: kbq-css-variable(radio-size-big-inner-size);
+            width: var(--kbq-radio-size-big-inner-size);
+            height: var(--kbq-radio-size-big-inner-size);
         }
 
         & .kbq-hint {
-            margin-top: kbq-css-variable(radio-size-big-vertical-content-padding);
+            margin-top: var(--kbq-radio-size-big-vertical-content-padding);
         }
 
         [dir='rtl'] & {
-            padding-right: kbq-css-variable(radio-size-big-horizontal-content-padding);
+            padding-right: var(--kbq-radio-size-big-horizontal-content-padding);
         }
     }
 }

--- a/packages/components/risk-level/_risk-level-theme.scss
+++ b/packages/components/risk-level/_risk-level-theme.scss
@@ -8,17 +8,17 @@
     $base: risk-level-#{$type}-#{$sub-type}-#{$style-name};
     border: transparent;
 
-    color: kbq-css-variable(#{$base}-color);
-    background: kbq-css-variable(#{$base}-background);
+    color: var(--kbq-#{$base}-color);
+    background: var(--kbq-#{$base}-background);
 }
 
 @mixin kbq-risk-level-outline-color($type, $sub-type, $style-name) {
     $base: risk-level-#{$type}-#{$sub-type}-#{$style-name};
 
-    border-color: kbq-css-variable(#{$base}-border);
+    border-color: var(--kbq-#{$base}-border);
 
-    color: kbq-css-variable(#{$base}-color);
-    background: kbq-css-variable(#{$base}-background);
+    color: var(--kbq-#{$base}-color);
+    background: var(--kbq-#{$base}-background);
 }
 
 @mixin kbq-risk-level-theme() {

--- a/packages/components/risk-level/risk-level.component.scss
+++ b/packages/components/risk-level/risk-level.component.scss
@@ -10,11 +10,11 @@
 
     border-style: solid;
 
-    padding: kbq-css-variable(risk-level-size-padding-vertical) kbq-css-variable(risk-level-size-padding-horizontal);
+    padding: var(--kbq-risk-level-size-padding-vertical) var(--kbq-risk-level-size-padding-horizontal);
 
     border: {
-        width: kbq-css-variable(risk-level-size-border-width);
-        radius: kbq-css-variable(risk-level-size-border-radius);
+        width: var(--kbq-risk-level-size-border-width);
+        radius: var(--kbq-risk-level-size-border-radius);
     }
 }
 

--- a/packages/components/scrollbar/_scrollbar-component-theme.scss
+++ b/packages/components/scrollbar/_scrollbar-component-theme.scss
@@ -5,21 +5,21 @@
         .os-scrollbar {
             .os-scrollbar-handle {
                 &::before {
-                    border-color: kbq-css-variable(scrollbar-thumb-default-background);
-                    background-color: kbq-css-variable(scrollbar-thumb-default-background);
+                    border-color: var(--kbq-scrollbar-thumb-default-background);
+                    background-color: var(--kbq-scrollbar-thumb-default-background);
                 }
 
                 &:hover {
                     &::before {
-                        border-color: kbq-css-variable(scrollbar-thumb-hover-background);
-                        background-color: kbq-css-variable(scrollbar-thumb-hover-background);
+                        border-color: var(--kbq-scrollbar-thumb-hover-background);
+                        background-color: var(--kbq-scrollbar-thumb-hover-background);
                     }
                 }
 
                 &:active {
                     &::before {
-                        border-color: kbq-css-variable(scrollbar-thumb-active-background);
-                        background-color: kbq-css-variable(scrollbar-thumb-active-background);
+                        border-color: var(--kbq-scrollbar-thumb-active-background);
+                        background-color: var(--kbq-scrollbar-thumb-active-background);
                     }
                 }
             }
@@ -27,17 +27,17 @@
             .os-scrollbar-track,
             .os-scrollbar-handle {
                 border-style: solid;
-                border-color: kbq-css-variable(scrollbar-track-default-border) !important;
-                background-color: kbq-css-variable(scrollbar-track-default-background);
+                border-color: var(--kbq-scrollbar-track-default-border) !important;
+                background-color: var(--kbq-scrollbar-track-default-background);
 
                 &:hover {
-                    border-color: kbq-css-variable(scrollbar-track-hover-border);
-                    background: kbq-css-variable(scrollbar-track-hover-background);
+                    border-color: var(--kbq-scrollbar-track-hover-border);
+                    background: var(--kbq-scrollbar-track-hover-background);
                 }
 
                 &:active {
-                    border-color: kbq-css-variable(scrollbar-track-active-border);
-                    background: kbq-css-variable(scrollbar-track-active-background);
+                    border-color: var(--kbq-scrollbar-track-active-border);
+                    background: var(--kbq-scrollbar-track-active-background);
                 }
             }
         }

--- a/packages/components/scrollbar/scrollbar.component.scss
+++ b/packages/components/scrollbar/scrollbar.component.scss
@@ -3,11 +3,11 @@
 @use './scrollbar-component-theme' as *;
 
 .kbq-scrollbar-component {
-    $scrollbar-size-thumb-width: kbq-css-variable(scrollbar-size-thumb-width);
-    $padding-vertical: kbq-css-variable(scrollbar-size-track-padding-vertical);
-    $padding-horizontal: kbq-css-variable(scrollbar-size-track-padding-horizontal);
-    $kbq-scrollbar-track-width: kbq-css-variable(scrollbar-size-track-dimension);
-    $thumb-min-height: kbq-css-variable(scrollbar-size-thumb-min-size);
+    $scrollbar-size-thumb-width: var(--kbq-scrollbar-size-thumb-width);
+    $padding-vertical: var(--kbq-scrollbar-size-track-padding-vertical);
+    $padding-horizontal: var(--kbq-scrollbar-size-track-padding-horizontal);
+    $kbq-scrollbar-track-width: var(--kbq-scrollbar-size-track-dimension);
+    $thumb-min-height: var(--kbq-scrollbar-size-thumb-min-size);
     $border-width: calc(($kbq-scrollbar-track-width - $scrollbar-size-thumb-width) / 4);
 
     .os-scrollbar-vertical {
@@ -59,7 +59,7 @@
         .os-scrollbar-handle::before,
         .os-scrollbar-track {
             box-sizing: border-box;
-            border-radius: kbq-css-variable(scrollbar-size-thumb-border-radius);
+            border-radius: var(--kbq-scrollbar-size-thumb-border-radius);
         }
 
         .os-scrollbar-track {

--- a/packages/components/select/_select-theme.scss
+++ b/packages/components/select/_select-theme.scss
@@ -4,38 +4,38 @@
 
 @mixin kbq-select-theme() {
     .kbq-select {
-        color: kbq-css-variable(foreground-contrast);
+        color: var(--kbq-foreground-contrast);
 
         &.ng-invalid {
-            color: kbq-css-variable(error-default);
+            color: var(--kbq-error-default);
         }
 
         &.kbq-disabled {
-            color: kbq-css-variable(foreground-text-disabled);
+            color: var(--kbq-foreground-text-disabled);
         }
     }
 
     .kbq-select__placeholder {
         text-overflow: ellipsis;
 
-        color: kbq-css-variable(foreground-text-disabled);
+        color: var(--kbq-foreground-text-disabled);
     }
 
     .kbq-select__panel {
-        box-shadow: kbq-css-variable(select-panel-dropdown-shadow);
-        background: kbq-css-variable(select-panel-dropdown-background);
+        box-shadow: var(--kbq-select-panel-dropdown-shadow);
+        background: var(--kbq-select-panel-dropdown-background);
 
         & .kbq-select__footer {
-            border-color: kbq-css-variable(divider-color);
+            border-color: var(--kbq-divider-color);
         }
     }
 
     .kbq-select__search-container {
-        border-bottom-color: kbq-css-variable(divider-color);
+        border-bottom-color: var(--kbq-divider-color);
     }
 
     .kbq-select__no-options-message {
-        color: kbq-css-variable(foreground-text-less-contrast);
+        color: var(--kbq-foreground-text-less-contrast);
     }
 }
 

--- a/packages/components/select/select.scss
+++ b/packages/components/select/select.scss
@@ -20,8 +20,8 @@
     @extend %kbq-select-content;
 
     &:not(:has(> .kbq-select__no-options-message)) .cdk-virtual-scroll-viewport {
-        min-height: kbq-css-variable(select-panel-size-max-height);
-        max-height: kbq-css-variable(select-panel-size-max-height);
+        min-height: var(--kbq-select-panel-size-max-height);
+        max-height: var(--kbq-select-panel-size-max-height);
 
         &.cdk-virtual-scroll-orientation-vertical .cdk-virtual-scroll-content-wrapper {
             max-width: 100%;

--- a/packages/components/sidepanel/_sidepanel-theme.scss
+++ b/packages/components/sidepanel/_sidepanel-theme.scss
@@ -2,17 +2,17 @@
 
 @mixin kbq-sidepanel-theme() {
     .kbq-sidepanel-title {
-        color: kbq-css-variable(sidepanel-header-text-color);
+        color: var(--kbq-sidepanel-header-text-color);
     }
 
     .kbq-sidepanel-content {
-        background-color: kbq-css-variable(sidepanel-container-background);
-        color: kbq-css-variable(sidepanel-content-text-color);
+        background-color: var(--kbq-sidepanel-container-background);
+        color: var(--kbq-sidepanel-content-text-color);
     }
 
     .kbq-sidepanel-container_shadowed {
         .kbq-sidepanel-content {
-            box-shadow: kbq-css-variable(sidepanel-container-box-shadow);
+            box-shadow: var(--kbq-sidepanel-container-box-shadow);
         }
     }
 }

--- a/packages/components/sidepanel/sidepanel.scss
+++ b/packages/components/sidepanel/sidepanel.scss
@@ -36,17 +36,17 @@
         max-width: 100%;
 
         &.kbq-sidepanel_small {
-            width: kbq-css-variable(sidepanel-size-small-width);
-            max-width: kbq-css-variable(sidepanel-size-small-width);
+            width: var(--kbq-sidepanel-size-small-width);
+            max-width: var(--kbq-sidepanel-size-small-width);
         }
 
         &.kbq-sidepanel_medium {
-            width: kbq-css-variable(sidepanel-size-medium-width);
-            max-width: kbq-css-variable(sidepanel-size-medium-width);
+            width: var(--kbq-sidepanel-size-medium-width);
+            max-width: var(--kbq-sidepanel-size-medium-width);
         }
 
         &.kbq-sidepanel_large {
-            width: kbq-css-variable(sidepanel-size-large-width);
+            width: var(--kbq-sidepanel-size-large-width);
         }
 
         .kbq-sidepanel-indent {
@@ -121,12 +121,11 @@
     flex-flow: row nowrap;
     flex: 0 0 auto;
 
-    padding: kbq-css-variable(sidepanel-size-header-padding-vertical)
-        kbq-css-variable(sidepanel-size-header-padding-right) kbq-css-variable(sidepanel-size-header-padding-vertical)
-        kbq-css-variable(sidepanel-size-header-padding-left);
+    padding: var(--kbq-sidepanel-size-header-padding-vertical) var(--kbq-sidepanel-size-header-padding-right)
+        var(--kbq-sidepanel-size-header-padding-vertical) var(--kbq-sidepanel-size-header-padding-left);
 
     .kbq-sidepanel-close {
-        margin-left: kbq-css-variable(sidepanel-size-close-button-margin-left);
+        margin-left: var(--kbq-sidepanel-size-close-button-margin-left);
     }
 }
 
@@ -143,11 +142,11 @@
     flex-direction: column;
     min-height: 0;
 
-    padding-right: kbq-css-variable(sidepanel-size-content-padding-horizontal);
+    padding-right: var(--kbq-sidepanel-size-content-padding-horizontal);
 
-    padding-left: kbq-css-variable(sidepanel-size-content-padding-horizontal);
+    padding-left: var(--kbq-sidepanel-size-content-padding-horizontal);
 
-    padding-bottom: kbq-css-variable(sidepanel-size-content-padding-bottom);
+    padding-bottom: var(--kbq-sidepanel-size-content-padding-bottom);
 }
 
 .kbq-sidepanel-footer {
@@ -158,9 +157,8 @@
     flex-flow: row nowrap;
     flex: 0 0 auto;
 
-    padding: kbq-css-variable(sidepanel-size-footer-padding-top)
-        kbq-css-variable(sidepanel-size-footer-padding-horizontal)
-        kbq-css-variable(sidepanel-size-footer-padding-bottom);
+    padding: var(--kbq-sidepanel-size-footer-padding-top) var(--kbq-sidepanel-size-footer-padding-horizontal)
+        var(--kbq-sidepanel-size-footer-padding-bottom);
 
     .kbq-sidepanel-actions {
         display: flex;
@@ -176,7 +174,7 @@
             justify-content: flex-end;
         }
 
-        gap: kbq-css-variable(sidepanel-size-footer-content-gap-horizontal);
+        gap: var(--kbq-sidepanel-size-footer-content-gap-horizontal);
     }
 }
 

--- a/packages/components/splitter/_splitter-theme.scss
+++ b/packages/components/splitter/_splitter-theme.scss
@@ -14,7 +14,7 @@
         }
 
         &[disabled] {
-            background-color: kbq-css-variable(background-background-disabled);
+            background-color: var(--kbq-background-background-disabled);
 
             cursor: default;
         }

--- a/packages/components/table/_table-theme.scss
+++ b/packages/components/table/_table-theme.scss
@@ -6,10 +6,10 @@
 @mixin kbq-table-theme() {
     .kbq-table {
         & > thead {
-            color: kbq-css-variable(foreground-contrast-secondary);
+            color: var(--kbq-foreground-contrast-secondary);
 
             & > tr > th {
-                border-bottom-color: kbq-css-variable(line-contrast-less);
+                border-bottom-color: var(--kbq-line-contrast-less);
             }
         }
 
@@ -17,11 +17,11 @@
             & > tr {
                 & > th,
                 & > td {
-                    color: kbq-css-variable(foreground-contrast);
+                    color: var(--kbq-foreground-contrast);
                 }
 
                 &:hover td {
-                    background-color: kbq-css-variable(states-background-transparent-hover);
+                    background-color: var(--kbq-states-background-transparent-hover);
                 }
             }
         }
@@ -30,7 +30,7 @@
             & > tbody > tr {
                 & th,
                 & td {
-                    border-bottom-color: kbq-css-variable(line-contrast-less);
+                    border-bottom-color: var(--kbq-line-contrast-less);
                 }
             }
         }

--- a/packages/components/table/table.scss
+++ b/packages/components/table/table.scss
@@ -15,10 +15,10 @@
             & > th,
             & > td {
                 padding: {
-                    top: kbq-css-variable(table-size-row-padding-vertical);
-                    right: kbq-css-variable(table-size-row-padding-horizontal);
-                    bottom: kbq-css-variable(table-size-row-padding-vertical);
-                    left: kbq-css-variable(table-size-row-padding-horizontal);
+                    top: var(--kbq-table-size-row-padding-vertical);
+                    right: var(--kbq-table-size-row-padding-horizontal);
+                    bottom: var(--kbq-table-size-row-padding-vertical);
+                    left: var(--kbq-table-size-row-padding-horizontal);
                 }
 
                 vertical-align: baseline;
@@ -29,14 +29,14 @@
 
     & > thead {
         & > tr > th {
-            border-bottom-width: kbq-css-variable(table-size-border-width);
+            border-bottom-width: var(--kbq-table-size-border-width);
             border-bottom-style: solid;
         }
     }
 
     .kbq-table-cell_has-button {
-        padding-top: kbq-css-variable(size-xxs);
-        padding-bottom: kbq-css-variable(size-xxs);
+        padding-top: var(--kbq-size-xxs);
+        padding-bottom: var(--kbq-size-xxs);
     }
 }
 
@@ -44,7 +44,7 @@
     & > tbody > tr {
         & th,
         & td {
-            border-bottom-width: kbq-css-variable(table-size-border-width);
+            border-bottom-width: var(--kbq-table-size-border-width);
             border-bottom-style: solid;
         }
     }
@@ -53,13 +53,13 @@
 .kbq-table:not(.kbq-table_bordered) {
     & > tbody > tr {
         & > td:first-child {
-            border-top-left-radius: kbq-css-variable(size-m);
-            border-bottom-left-radius: kbq-css-variable(size-m);
+            border-top-left-radius: var(--kbq-size-m);
+            border-bottom-left-radius: var(--kbq-size-m);
         }
 
         & > td:last-child {
-            border-top-right-radius: kbq-css-variable(size-m);
-            border-bottom-right-radius: kbq-css-variable(size-m);
+            border-top-right-radius: var(--kbq-size-m);
+            border-bottom-right-radius: var(--kbq-size-m);
         }
 
         &:first-child {

--- a/packages/components/tabs/_tabs-common.scss
+++ b/packages/components/tabs/_tabs-common.scss
@@ -24,10 +24,10 @@
         );
 
     border: {
-        width: kbq-css-variable(tabs-size-tab-item-focus-outline-width);
+        width: var(--kbq-tabs-size-tab-item-focus-outline-width);
         style: solid;
         color: transparent;
-        radius: kbq-css-variable(tabs-size-tab-item-border-radius);
+        radius: var(--kbq-tabs-size-tab-item-border-radius);
     }
 
     outline: none;
@@ -67,7 +67,7 @@
         display: flex;
         align-items: center;
 
-        gap: kbq-css-variable(tabs-size-tab-item-content-gap-horizontal);
+        gap: var(--kbq-tabs-size-tab-item-content-gap-horizontal);
     }
 
     &.kbq-tab-label_underlined:not(.kbq-tab-label_vertical):before {

--- a/packages/components/tabs/_tabs-theme.scss
+++ b/packages/components/tabs/_tabs-theme.scss
@@ -4,11 +4,11 @@
 @mixin kbq-tab-item-state($type, $sub-type, $style-name) {
     $base: tabs-tab-item-#{$type}-#{$sub-type}-#{$style-name};
 
-    background: kbq-css-variable(#{$base}-background);
-    color: kbq-css-variable(#{$base}-text-color);
+    background: var(--kbq-#{$base}-background);
+    color: var(--kbq-#{$base}-text-color);
 
     & .kbq-icon {
-        color: kbq-css-variable(#{$base}-icon-color);
+        color: var(--kbq-#{$base}-icon-color);
     }
 }
 
@@ -20,7 +20,7 @@
     }
 
     &.kbq-tab-label_empty {
-        color: kbq-css-variable(foreground-contrast-secondary);
+        color: var(--kbq-foreground-contrast-secondary);
     }
 
     &.kbq-selected {
@@ -40,7 +40,7 @@
     }
 
     &.cdk-keyboard-focused {
-        border-color: kbq-css-variable(tabs-tab-item-#{$type}-#{$sub-type}-states-focused-focus-outline-color);
+        border-color: var(--kbq-tabs-tab-item-#{$type}-#{$sub-type}-states-focused-focus-outline-color);
     }
 
     &.kbq-disabled {
@@ -58,7 +58,7 @@
         &.kbq-tab-group_filled {
             &.kbq-tab-group_on-background {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-filled-on-background-background);
+                    background: var(--kbq-tabs-tab-stack-filled-on-background-background);
                 }
 
                 & .kbq-tab-label {
@@ -68,7 +68,7 @@
 
             &.kbq-tab-group_on-surface {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-filled-on-surface-background);
+                    background: var(--kbq-tabs-tab-stack-filled-on-surface-background);
                 }
 
                 // FIXME: need check, tab-group has different subtype
@@ -81,7 +81,7 @@
         &.kbq-tab-group_transparent {
             &.kbq-tab-group_on-background {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-transparent-on-background-background);
+                    background: var(--kbq-tabs-tab-stack-transparent-on-background-background);
                 }
 
                 & .kbq-tab-label {
@@ -91,7 +91,7 @@
 
             &.kbq-tab-group_on-surface {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-transparent-on-surface-background);
+                    background: var(--kbq-tabs-tab-stack-transparent-on-surface-background);
                 }
 
                 & .kbq-tab-label {
@@ -105,7 +105,7 @@
         &.kbq-tab-nav-bar_filled {
             &.kbq-tab-nav-bar_on-background {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-filled-on-background-background);
+                    background: var(--kbq-tabs-tab-stack-filled-on-background-background);
                 }
 
                 & .kbq-tab-link {
@@ -115,7 +115,7 @@
 
             &.kbq-tab-nav-bar_on-surface {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-filled-on-surface-background);
+                    background: var(--kbq-tabs-tab-stack-filled-on-surface-background);
                 }
 
                 & .kbq-tab-link {
@@ -127,7 +127,7 @@
         &.kbq-tab-nav-bar_transparent {
             &.kbq-tab-nav-bar_on-background {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-transparent-on-background-background);
+                    background: var(--kbq-tabs-tab-stack-transparent-on-background-background);
                 }
 
                 & .kbq-tab-link {
@@ -137,7 +137,7 @@
 
             &.kbq-tab-nav-bar_on-surface {
                 .kbq-tab-header {
-                    background: kbq-css-variable(tabs-tab-stack-transparent-on-surface-background);
+                    background: var(--kbq-tabs-tab-stack-transparent-on-surface-background);
                 }
 
                 & .kbq-tab-link {

--- a/packages/components/tabs/tab-group.scss
+++ b/packages/components/tabs/tab-group.scss
@@ -18,7 +18,7 @@
     flex-direction: row;
 
     .kbq-tab-list__content {
-        gap: kbq-css-variable(tabs-size-tab-stack-vertical-content-gap-vertical) 0;
+        gap: var(--kbq-tabs-size-tab-stack-vertical-content-gap-vertical) 0;
     }
 
     & .kbq-tab-header__content {

--- a/packages/components/tabs/tab-header.scss
+++ b/packages/components/tabs/tab-header.scss
@@ -36,7 +36,7 @@
     bottom: 0;
     right: 0;
     height: 1px;
-    background: kbq-css-variable(line-contrast-less);
+    background: var(--kbq-line-contrast-less);
 }
 
 .kbq-tab-list__active-tab-underline {
@@ -49,7 +49,7 @@
     bottom: 0;
     height: 3px;
     border-radius: 2px 2px 0 0;
-    background: kbq-css-variable(line-contrast);
+    background: var(--kbq-line-contrast);
     transition: all 0.2s ease-in-out;
 }
 

--- a/packages/components/tabs/tab-nav-bar/tab-nav-bar.scss
+++ b/packages/components/tabs/tab-nav-bar/tab-nav-bar.scss
@@ -33,6 +33,6 @@
     &.kbq-tab-group_vertical {
         flex-direction: column;
         flex-grow: 0;
-        gap: kbq-css-variable(tabs-size-tab-stack-vertical-content-gap-vertical) 0;
+        gap: var(--kbq-tabs-size-tab-stack-vertical-content-gap-vertical) 0;
     }
 }

--- a/packages/components/tags/_tag-theme.scss
+++ b/packages/components/tags/_tag-theme.scss
@@ -5,14 +5,14 @@
 @mixin kbq-tag-state($type, $style-name) {
     $base: tag-#{$type}-#{$style-name};
 
-    background: kbq-css-variable(#{$base}-background);
+    background: var(--kbq-#{$base}-background);
 
     & .kbq-icon {
-        color: kbq-css-variable(#{$base}-icon);
+        color: var(--kbq-#{$base}-icon);
     }
 
     & .kbq-tag__text {
-        color: kbq-css-variable(#{$base}-text);
+        color: var(--kbq-#{$base}-text);
     }
 }
 
@@ -28,8 +28,8 @@
         @include kbq-tag-state($type, states-focus);
 
         box-shadow:
-            inset 0 0 0.1px 1px kbq-css-variable(tag-#{$type}-states-focus-outline),
-            0 0 0.1px 1px kbq-css-variable(tag-#{$type}-states-focus-outline);
+            inset 0 0 0.1px 1px var(--kbq-tag-#{$type}-states-focus-outline),
+            0 0 0.1px 1px var(--kbq-tag-#{$type}-states-focus-outline);
     }
 
     &.kbq-disabled {

--- a/packages/components/tags/tag-list.scss
+++ b/packages/components/tags/tag-list.scss
@@ -20,8 +20,8 @@
 
     min-height: unset;
 
-    padding-top: kbq-css-variable(tag-size-padding-vertical);
-    padding-bottom: kbq-css-variable(tag-size-padding-vertical);
+    padding-top: var(--kbq-tag-size-padding-vertical);
+    padding-bottom: var(--kbq-tag-size-padding-vertical);
     padding-left: 4px;
     padding-right: unset;
 }
@@ -35,7 +35,7 @@
 
     min-width: 0;
 
-    gap: kbq-css-variable(tag-list-size-content-gap);
+    gap: var(--kbq-tag-list-size-content-gap);
 
     & .kbq-tag-input {
         max-width: 100%;
@@ -53,8 +53,8 @@
 .kbq-form-field-type-tag-list {
     & .kbq-form-field__container {
         padding: kbq-difference-series-css-variables([tag-input-size-padding-vertical, form-field-size-border-width])
-            kbq-css-variable(tag-input-size-padding-right)
+            var(--kbq-tag-input-size-padding-right)
             kbq-difference-series-css-variables([tag-input-size-padding-vertical, form-field-size-border-width])
-            kbq-css-variable(tag-input-size-padding-left);
+            var(--kbq-tag-input-size-padding-left);
     }
 }

--- a/packages/components/tags/tag.scss
+++ b/packages/components/tags/tag.scss
@@ -7,7 +7,7 @@
 
     max-width: 100%;
 
-    padding: kbq-css-variable(tag-size-padding-vertical) kbq-css-variable(tag-size-padding-horizontal);
+    padding: var(--kbq-tag-size-padding-vertical) var(--kbq-tag-size-padding-horizontal);
 
     border-radius: 4px;
 
@@ -24,7 +24,7 @@
 
         flex-shrink: 0;
 
-        margin-right: kbq-css-variable(tag-size-close-button-margin-right);
+        margin-right: var(--kbq-tag-size-close-button-margin-right);
 
         &:hover {
             cursor: pointer;
@@ -40,11 +40,11 @@
         white-space: nowrap;
         overflow: hidden;
 
-        margin: 0 kbq-css-variable(tag-size-content-gap-horizontal);
+        margin: 0 var(--kbq-tag-size-content-gap-horizontal);
     }
 
     & .kbq-icon_left {
-        margin-left: kbq-css-variable(tag-size-icon-margin-left);
+        margin-left: var(--kbq-tag-size-icon-margin-left);
     }
 }
 

--- a/packages/components/textarea/textarea.scss
+++ b/packages/components/textarea/textarea.scss
@@ -19,7 +19,7 @@
 
     box-sizing: border-box;
 
-    padding: kbq-css-variable(textarea-size-padding-vertical) kbq-css-variable(textarea-size-padding-horizontal);
+    padding: var(--kbq-textarea-size-padding-vertical) var(--kbq-textarea-size-padding-horizontal);
 
     -webkit-appearance: none; // Chrome textarea height sizing fix
     vertical-align: bottom; // Chrome textarea height sizing fix
@@ -31,7 +31,7 @@
 
     &.kbq-textarea-resizable {
         resize: vertical;
-        min-height: kbq-css-variable(textarea-size-min-height);
+        min-height: var(--kbq-textarea-size-min-height);
     }
 }
 

--- a/packages/components/timepicker/timepicker.scss
+++ b/packages/components/timepicker/timepicker.scss
@@ -5,7 +5,7 @@
 
 .kbq-timepicker {
     // FIXME: default token doesn't exist
-    padding-right: kbq-css-variable(timepicker-size-padding-right);
+    padding-right: var(--kbq-timepicker-size-padding-right);
 }
 
 .kbq-form-field-type-timepicker {

--- a/packages/components/timezone/_timezone-option-theme.scss
+++ b/packages/components/timezone/_timezone-option-theme.scss
@@ -7,15 +7,15 @@
 @mixin kbq-timezone-option-theme() {
     .kbq-timezone-option__offset,
     .kbq-timezone-option__city {
-        color: kbq-css-variable(timezone-option-text);
+        color: var(--kbq-timezone-option-text);
     }
 
     .kbq-timezone-option__cities {
-        color: kbq-css-variable(timezone-option-caption);
+        color: var(--kbq-timezone-option-caption);
     }
 
     .kbq-timezone-select__panel.kbq-select__panel .kbq-optgroup-label {
-        color: kbq-css-variable(timezone-option-optgroup-label);
+        color: var(--kbq-timezone-option-optgroup-label);
     }
 }
 

--- a/packages/components/timezone/timezone-option.component.scss
+++ b/packages/components/timezone/timezone-option.component.scss
@@ -10,8 +10,8 @@
     flex-direction: row;
     align-items: flex-start;
 
-    padding: kbq-css-variable(timezone-option-size-padding);
-    column-gap: kbq-css-variable(timezone-option-size-column-gap);
+    padding: var(--kbq-timezone-option-size-padding);
+    column-gap: var(--kbq-timezone-option-size-column-gap);
 }
 
 .kbq-timezone-option__label {
@@ -29,12 +29,12 @@
 .kbq-timezone-option__cities {
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    max-height: kbq-css-variable(timezone-option-size-max-height);
+    max-height: var(--kbq-timezone-option-size-max-height);
     overflow: hidden;
 }
 
 .kbq-select__panel .kbq-timezone-option {
-    height: kbq-css-variable(timezone-option-size-height);
+    height: var(--kbq-timezone-option-size-height);
 }
 
 @include kbq-timezone-option-theme();

--- a/packages/components/timezone/timezone-select.component.scss
+++ b/packages/components/timezone/timezone-select.component.scss
@@ -8,7 +8,7 @@
 .kbq-timezone-select__panel.kbq-select__panel {
     .kbq-optgroup-label {
         display: block;
-        padding: kbq-css-variable(timezone-option-size-optgroup-label-padding);
+        padding: var(--kbq-timezone-option-size-optgroup-label-padding);
     }
 }
 

--- a/packages/components/toast/_toast-theme.scss
+++ b/packages/components/toast/_toast-theme.scss
@@ -5,16 +5,16 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-toast($style-name) {
-    box-shadow: kbq-css-variable(toast-#{$style-name}-container-shadow);
+    box-shadow: var(--kbq-toast-#{$style-name}-container-shadow);
 
-    background: kbq-css-variable(toast-#{$style-name}-container-background);
+    background: var(--kbq-toast-#{$style-name}-container-background);
 
     .kbq-toast__title {
-        color: kbq-css-variable(toast-#{$style-name}-container-title);
+        color: var(--kbq-toast-#{$style-name}-container-title);
     }
 
     .kbq-toast__text {
-        color: kbq-css-variable(toast-#{$style-name}-container-text);
+        color: var(--kbq-toast-#{$style-name}-container-text);
     }
 }
 

--- a/packages/components/toast/toast-container.component.scss
+++ b/packages/components/toast/toast-container.component.scss
@@ -8,8 +8,8 @@
     flex-direction: column;
     align-items: flex-end;
 
-    margin-top: kbq-css-variable(toast-stack-size-margin-top);
-    margin-right: kbq-css-variable(toast-stack-size-margin-right);
+    margin-top: var(--kbq-toast-stack-size-margin-top);
+    margin-right: var(--kbq-toast-stack-size-margin-right);
 
-    gap: kbq-css-variable(toast-stack-size-gap);
+    gap: var(--kbq-toast-stack-size-gap);
 }

--- a/packages/components/toast/toast.component.scss
+++ b/packages/components/toast/toast.component.scss
@@ -9,30 +9,30 @@
     display: flex;
     box-sizing: border-box;
 
-    width: kbq-css-variable(toast-size-container-width);
+    width: var(--kbq-toast-size-container-width);
 
     height: auto;
 
-    border-radius: kbq-css-variable(toast-size-container-border-radius);
+    border-radius: var(--kbq-toast-size-container-border-radius);
 
-    padding-left: kbq-css-variable(toast-size-container-padding-left);
-    padding-right: kbq-css-variable(toast-size-container-padding-right);
+    padding-left: var(--kbq-toast-size-container-padding-left);
+    padding-right: var(--kbq-toast-size-container-padding-right);
 }
 
 .kbq-toast__icon-container {
     flex-shrink: 0;
-    width: kbq-css-variable(toast-size-icon-width);
-    max-width: kbq-css-variable(toast-size-icon-width);
-    height: kbq-css-variable(toast-size-icon-height);
-    max-height: kbq-css-variable(toast-size-icon-height);
+    width: var(--kbq-toast-size-icon-width);
+    max-width: var(--kbq-toast-size-icon-width);
+    height: var(--kbq-toast-size-icon-height);
+    max-height: var(--kbq-toast-size-icon-height);
 
-    border-radius: kbq-css-variable(toast-size-container-border-radius);
+    border-radius: var(--kbq-toast-size-container-border-radius);
 
-    margin-right: kbq-css-variable(toast-size-icon-margin-right);
+    margin-right: var(--kbq-toast-size-icon-margin-right);
 
-    $padding-top: kbq-css-variable(toast-size-content-padding-top);
-    $toast-font-title-line-height: kbq-css-variable(toast-font-title-line-height);
-    $toast-size-icon-height: kbq-css-variable(toast-size-icon-height);
+    $padding-top: var(--kbq-toast-size-content-padding-top);
+    $toast-font-title-line-height: var(--kbq-toast-font-title-line-height);
+    $toast-size-icon-height: var(--kbq-toast-size-icon-height);
     padding-top: calc($padding-top + (($toast-font-title-line-height - $toast-size-icon-height) / 2));
 }
 
@@ -42,9 +42,9 @@
 
     flex: 1;
 
-    padding-top: kbq-css-variable(toast-size-content-padding-top);
-    padding-right: kbq-css-variable(size-s);
-    padding-bottom: kbq-css-variable(toast-size-content-padding-bottom);
+    padding-top: var(--kbq-toast-size-content-padding-top);
+    padding-right: var(--kbq-size-s);
+    padding-bottom: var(--kbq-toast-size-content-padding-bottom);
 
     overflow: hidden;
 }
@@ -61,7 +61,7 @@
 }
 
 .kbq-toast__title_with-content {
-    padding-bottom: kbq-css-variable(toast-size-caption-padding-bottom);
+    padding-bottom: var(--kbq-toast-size-caption-padding-bottom);
 }
 
 .kbq-toast__text {
@@ -78,9 +78,9 @@
 .kbq-toast__actions {
     display: flex;
 
-    padding-top: kbq-css-variable(toast-size-button-stack-padding-top);
+    padding-top: var(--kbq-toast-size-button-stack-padding-top);
 
-    gap: kbq-css-variable(toast-size-button-stack-content-gap-horizontal);
+    gap: var(--kbq-toast-size-button-stack-content-gap-horizontal);
 }
 
 .kbq-toast__close-button {
@@ -89,14 +89,14 @@
         calc(
                 kbq-difference-series-css-variables(
                         [kbq-sum-series-css-variables(
-                            [calc(kbq-css-variable(icon-button-size-small-vertical-padding) * 2),
+                            [calc(var(--kbq-icon-button-size-small-vertical-padding) * 2),
                             16px]
                         ),
                         toast-font-title-line-height]
                     ) / 2
             )]
     );
-    margin-right: kbq-css-variable(toast-size-close-button-margin-right);
+    margin-right: var(--kbq-toast-size-close-button-margin-right);
 }
 
 @include kbq-toast-theme();

--- a/packages/components/toggle/_toggle-theme.scss
+++ b/packages/components/toggle/_toggle-theme.scss
@@ -7,12 +7,12 @@
     $base: toggle-#{$type}-#{$state-name};
 
     .kbq-toggle-bar {
-        border-color: kbq-css-variable(#{$base}-border);
-        background: kbq-css-variable(#{$base}-background);
+        border-color: var(--kbq-#{$base}-border);
+        background: var(--kbq-#{$base}-background);
     }
 
     .kbq-toggle__circle {
-        background: kbq-css-variable(#{$base}-circle-background);
+        background: var(--kbq-#{$base}-circle-background);
     }
 }
 
@@ -35,8 +35,8 @@
         @include kbq-toggle-state($type, states-focused);
 
         & .kbq-toggle-bar {
-            border-color: kbq-css-variable(toggle-#{$type}-states-focused-focus-outline);
-            box-shadow: 0 0 0.1px 1px kbq-css-variable(toggle-#{$type}-states-focused-focus-outline);
+            border-color: var(--kbq-toggle-#{$type}-states-focused-focus-outline);
+            box-shadow: 0 0 0.1px 1px var(--kbq-toggle-#{$type}-states-focused-focus-outline);
         }
     }
 
@@ -44,8 +44,8 @@
         @include kbq-toggle-state($type, states-checked-focused);
 
         & .kbq-toggle-bar {
-            border-color: kbq-css-variable(toggle-#{$type}-states-checked-focused-focus-outline);
-            box-shadow: 0 0 0.1px 1px kbq-css-variable(toggle-#{$type}-states-checked-focused-focus-outline);
+            border-color: var(--kbq-toggle-#{$type}-states-checked-focused-focus-outline);
+            box-shadow: 0 0 0.1px 1px var(--kbq-toggle-#{$type}-states-checked-focused-focus-outline);
         }
     }
 
@@ -64,7 +64,7 @@
         }
 
         &.kbq-disabled {
-            color: kbq-css-variable(foreground-text-disabled);
+            color: var(--kbq-foreground-text-disabled);
         }
     }
 }

--- a/packages/components/toggle/toggle.scss
+++ b/packages/components/toggle/toggle.scss
@@ -53,12 +53,12 @@
             radius: 8px;
         }
 
-        height: kbq-css-variable(toggle-size-normal-height);
-        width: kbq-css-variable(toggle-size-normal-width);
+        height: var(--kbq-toggle-size-normal-height);
+        width: var(--kbq-toggle-size-normal-width);
     }
 
     .kbq-hint {
-        margin-top: kbq-css-variable(toggle-size-normal-vertical-content-padding);
+        margin-top: var(--kbq-toggle-size-normal-vertical-content-padding);
     }
 }
 
@@ -69,22 +69,22 @@
     flex: 1;
 
     &.left {
-        margin-right: kbq-css-variable(toggle-size-normal-horizontal-content-padding);
+        margin-right: var(--kbq-toggle-size-normal-horizontal-content-padding);
     }
 
     &.right {
-        margin-left: kbq-css-variable(toggle-size-normal-horizontal-content-padding);
+        margin-left: var(--kbq-toggle-size-normal-horizontal-content-padding);
     }
 }
 
 .kbq-toggle.kbq-toggle_big {
     & .kbq-toggle-bar {
-        height: kbq-css-variable(toggle-size-big-height);
-        width: kbq-css-variable(toggle-size-big-width);
+        height: var(--kbq-toggle-size-big-height);
+        width: var(--kbq-toggle-size-big-width);
     }
 
     & .kbq-hint {
-        margin-top: kbq-css-variable(toggle-size-big-vertical-content-padding);
+        margin-top: var(--kbq-toggle-size-big-vertical-content-padding);
     }
 
     .kbq-toggle-layout {

--- a/packages/components/tooltip/_tooltip-theme.scss
+++ b/packages/components/tooltip/_tooltip-theme.scss
@@ -1,17 +1,17 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-tooltip-color($style-name) {
-    box-shadow: kbq-css-variable(tooltip-#{$style-name}-shadow);
+    box-shadow: var(--kbq-tooltip-#{$style-name}-shadow);
 
     & .kbq-tooltip__inner {
-        color: kbq-css-variable(tooltip-#{$style-name}-text);
+        color: var(--kbq-tooltip-#{$style-name}-text);
 
-        background-color: kbq-css-variable(tooltip-#{$style-name}-background);
+        background-color: var(--kbq-tooltip-#{$style-name}-background);
     }
 
     & .kbq-tooltip__arrow {
-        background-color: kbq-css-variable(tooltip-#{$style-name}-background);
-        box-shadow: kbq-css-variable(tooltip-#{$style-name}-shadow);
+        background-color: var(--kbq-tooltip-#{$style-name}-background);
+        box-shadow: var(--kbq-tooltip-#{$style-name}-shadow);
     }
 }
 

--- a/packages/components/tooltip/tooltip.scss
+++ b/packages/components/tooltip/tooltip.scss
@@ -37,23 +37,23 @@ $trigger-margin_without-arrow: 4px;
 }
 
 .kbq-tooltip__inner {
-    border-radius: kbq-css-variable(tooltip-size-border-radius);
+    border-radius: var(--kbq-tooltip-size-border-radius);
     word-break: break-word;
 }
 
 .kbq-tooltip {
     box-sizing: border-box;
 
-    border-radius: kbq-css-variable(tooltip-size-border-radius);
+    border-radius: var(--kbq-tooltip-size-border-radius);
 
     white-space: pre-line;
 
     @include pop-up.popup-margins(kbq-tooltip, $trigger-margin);
 
-    max-width: kbq-css-variable(tooltip-size-max-width);
+    max-width: var(--kbq-tooltip-size-max-width);
 
     .kbq-tooltip__inner {
-        padding: kbq-css-variable(tooltip-size-padding-vertical) kbq-css-variable(tooltip-size-padding-horizontal);
+        padding: var(--kbq-tooltip-size-padding-vertical) var(--kbq-tooltip-size-padding-horizontal);
     }
 
     &.kbq-tooltip_arrowless {
@@ -67,15 +67,15 @@ $trigger-margin_without-arrow: 4px;
 .kbq-tooltip__arrow {
     position: absolute;
 
-    width: kbq-css-variable(tooltip-size-arrow-size);
-    height: kbq-css-variable(tooltip-size-arrow-size);
+    width: var(--kbq-tooltip-size-arrow-size);
+    height: var(--kbq-tooltip-size-arrow-size);
 
     transform: rotate(45deg);
 
     z-index: -1;
 }
 
-$arrow-offset: calc((#{kbq-css-variable(tooltip-size-arrow-size)} - 1px) / -2);
+$arrow-offset: calc((#{var(--kbq-tooltip-size-arrow-size)} - 1px) / -2);
 $arrow-padding: calc((18px + $trigger-margin) / 2);
 
 @include pop-up.popup-arrow-positions(kbq-tooltip, $arrow-offset, $arrow-padding);

--- a/packages/components/tree-select/_tree-select-theme.scss
+++ b/packages/components/tree-select/_tree-select-theme.scss
@@ -6,29 +6,29 @@
 
 @mixin kbq-tree-select-theme() {
     .kbq-tree-select {
-        color: kbq-css-variable(foreground-contrast);
+        color: var(--kbq-foreground-contrast);
 
         &.ng-invalid {
-            color: kbq-css-variable(error-default);
+            color: var(--kbq-error-default);
         }
 
         &.kbq-disabled {
-            color: kbq-css-variable(foreground-text-disabled);
+            color: var(--kbq-foreground-text-disabled);
         }
     }
 
     .kbq-select__placeholder {
         text-overflow: ellipsis;
 
-        color: kbq-css-variable(foreground-text-disabled);
+        color: var(--kbq-foreground-text-disabled);
     }
 
     .kbq-tree-select__panel {
-        box-shadow: kbq-css-variable(select-panel-dropdown-shadow);
-        background: kbq-css-variable(select-panel-dropdown-background);
+        box-shadow: var(--kbq-select-panel-dropdown-shadow);
+        background: var(--kbq-select-panel-dropdown-background);
 
         & .kbq-select__footer {
-            border-color: kbq-css-variable(divider-color);
+            border-color: var(--kbq-divider-color);
         }
     }
 }

--- a/packages/components/tree/_tree-theme.scss
+++ b/packages/components/tree/_tree-theme.scss
@@ -6,22 +6,22 @@
 @use '../core/styles/common/tokens' as *;
 
 @mixin kbq-tree-option($state-name) {
-    background: kbq-css-variable(tree-#{$state-name}-container-background);
+    background: var(--kbq-tree-#{$state-name}-container-background);
 
     .kbq-option-text {
-        color: kbq-css-variable(tree-#{$state-name}-text-color);
+        color: var(--kbq-tree-#{$state-name}-text-color);
     }
 
     .kbq-tree-node-toggle .kbq-icon {
-        color: kbq-css-variable(tree-#{$state-name}-tree-toggle-color);
+        color: var(--kbq-tree-#{$state-name}-tree-toggle-color);
     }
 
     .kbq-option-action .kbq-icon {
-        color: kbq-css-variable(tree-#{$state-name}-action-button-color);
+        color: var(--kbq-tree-#{$state-name}-action-button-color);
     }
 
     .kbq-option-caption {
-        color: kbq-css-variable(tree-#{$state-name}-caption-color);
+        color: var(--kbq-tree-#{$state-name}-caption-color);
     }
 }
 
@@ -39,7 +39,7 @@
 
         &.kbq-focused,
         &.kbq-active {
-            border-color: kbq-css-variable(tree-states-focused-focus-outline-color);
+            border-color: var(--kbq-tree-states-focused-focus-outline-color);
         }
 
         &.kbq-selected {

--- a/packages/components/tree/toggle.scss
+++ b/packages/components/tree/toggle.scss
@@ -13,8 +13,8 @@
 
     height: 100%;
     // FIXME: default token doesn't exist
-    padding-left: kbq-css-variable(tree-size-toggle-padding);
-    padding-right: kbq-css-variable(tree-size-toggle-padding);
+    padding-left: var(--kbq-tree-size-toggle-padding);
+    padding-right: var(--kbq-tree-size-toggle-padding);
 
     cursor: pointer;
 

--- a/packages/components/tree/tree-option.scss
+++ b/packages/components/tree/tree-option.scss
@@ -16,7 +16,7 @@
 
     word-wrap: break-word;
 
-    border-width: kbq-css-variable(tree-size-container-focus-outline-width);
+    border-width: var(--kbq-tree-size-container-focus-outline-width);
     border-style: solid;
     border-color: transparent;
 
@@ -33,7 +33,7 @@
         tree-size-container-focus-outline-width]
     );
 
-    gap: kbq-css-variable(tree-size-container-content-gap-horizontal);
+    gap: var(--kbq-tree-size-container-content-gap-horizontal);
 
     & .kbq-option-text {
         @include common.kbq-line-wrapper-base();
@@ -41,8 +41,8 @@
 
         @include common.kbq-truncate-line();
 
-        padding-top: kbq-css-variable(list-size-text-padding-vertical);
-        padding-bottom: kbq-css-variable(list-size-text-padding-vertical);
+        padding-top: var(--kbq-list-size-text-padding-vertical);
+        padding-bottom: var(--kbq-list-size-text-padding-vertical);
     }
 
     &:focus {


### PR DESCRIPTION
## Summary

Удалил миксин `kbq-css-variable`, заменил на css-vars в компонентах. Удалил использование `map.get` в миксине `kbq-css-font-variable`.

**BREAKING CHANGES:** `kbq-css-variable` removed, use css-var.

Важно:
Теперь, когда используются компоненты, значения CSS-переменных для них нужно определять явно, как указано в [гайде](https://koobiq.io/main/theming/overview#%D0%BA%D0%B0%D0%BA-%D0%B8%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D1%8C?). В коде нет заполнения значений по умолчанию.