### PR TITLE
fix(file-upload): mark single upload with kbq-error on hasError = tru…

### DIFF
--- a/packages/components/file-upload/single-file-upload.component.html
+++ b/packages/components/file-upload/single-file-upload.component.html
@@ -2,7 +2,7 @@
     kbqFileDrop
     class="kbq-file-upload"
     [class.kbq-disabled]="disabled"
-    [class.kbq-error]="errors?.length"
+    [class.kbq-error]="file?.hasError"
     (filesDropped)="onFileDropped($event)"
 >
     @if (!file) {


### PR DESCRIPTION
## Summary
Заменил условие отображения класса `kbq-error`. Планируется в дальнейшем уйти от использования errors внутри компонента file-upload и опираться на [AbstractControl.errors
](https://angular.dev/api/forms/AbstractControl#errors)
