### PR TITLE
chore(docs): fix algolia docsearch crawler name

### DIFF
--- a/.github/workflows/docs-stable.yml
+++ b/.github/workflows/docs-stable.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Deploy
         run: npx firebase deploy --only hosting:stable --token=${{ secrets.FIREBASE_DEPLOY_TOKEN }}
 
-      - name: Algolia DocSearch Crawler
+      - name: Run Algolia DocSearch Crawler
         uses: algolia/algoliasearch-crawler-github-actions@v1.1.12
         id: algolia_docsearch_crawler
         with:
@@ -36,3 +36,4 @@ jobs:
           algolia-app-id: 7N2W9AKEM6
           algolia-api-key: ${{ secrets.ALGOLIA_DOCSEARCH_API_KEY }}
           site-url: 'https://koobiq.io'
+          crawler-name: 'koobiq'


### PR DESCRIPTION
по умолчанию устанавливается некорректное имя (ожидается `koobiq`):
https://github.com/algolia/algoliasearch-crawler-github-actions/tree/v1.1.12/?tab=readme-ov-file#optional-parameters