### PR TITLE
fix(tree,icon): aligned icons color with design (#DS-2875)

### DIFF
--- a/packages/components/icon/icon.component.ts
+++ b/packages/components/icon/icon.component.ts
@@ -25,7 +25,10 @@ export class KbqIconBase {
 }
 
 /** @docs-private */
-export const KbqIconMixinBase: CanColorCtor & typeof KbqIconBase = mixinColor(KbqIconBase, KbqComponentColors.Contrast);
+export const KbqIconMixinBase: CanColorCtor & typeof KbqIconBase = mixinColor(
+    KbqIconBase,
+    KbqComponentColors.ContrastFade
+);
 
 @Component({
     standalone: true,

--- a/packages/components/icon/icon.component.ts
+++ b/packages/components/icon/icon.component.ts
@@ -25,10 +25,7 @@ export class KbqIconBase {
 }
 
 /** @docs-private */
-export const KbqIconMixinBase: CanColorCtor & typeof KbqIconBase = mixinColor(
-    KbqIconBase,
-    KbqComponentColors.ContrastFade
-);
+export const KbqIconMixinBase: CanColorCtor & typeof KbqIconBase = mixinColor(KbqIconBase, KbqComponentColors.Contrast);
 
 @Component({
     standalone: true,

--- a/packages/components/tree/_tree-theme.scss
+++ b/packages/components/tree/_tree-theme.scss
@@ -51,7 +51,7 @@
             @include kbq-tree-option(states-disabled);
 
             & .kbq-icon {
-                cursor: default;
+                color: var(--kbq-states-icon-disabled);
             }
         }
     }

--- a/packages/components/tree/tree-option.scss
+++ b/packages/components/tree/tree-option.scss
@@ -46,6 +46,12 @@
         outline: none;
     }
 
+    &.kbq-disabled {
+        .kbq-icon {
+            cursor: default;
+        }
+    }
+
     &:not(.kbq-disabled) {
         cursor: pointer;
     }


### PR DESCRIPTION
## Summary

updated disabled state for icon in tree.


Also, moved `cursor: default` property for disabled icon from theme file to component geometry file.