### PR TITLE
chore(docs): all examples fixed styles + remove encapsulation (DS-3107)

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -29,6 +29,7 @@ const config = {
                 ignoreTypes: ['app']
             }
         ],
+        'selector-pseudo-element-no-unknown': [true, { ignorePseudoElements: ['ng-deep'] }],
         'font-family-no-missing-generic-family-keyword': [
             true,
             {

--- a/packages/components/core/styles/visual/_layout.scss
+++ b/packages/components/core/styles/visual/_layout.scss
@@ -475,7 +475,7 @@
         '7xl': var(--kbq-size-7xl)
     );
 
-    $indents: 'padding', 'margin';
+    $indents: 'padding', 'margin', 'gap';
 
     @each $indent in $indents {
         @each $name, $value in $sizes {

--- a/packages/docs-examples/components/accordion/accordion-content/accordion-content-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-content/accordion-content-example.ts
@@ -3,13 +3,13 @@ import { KbqAccordionModule } from '@koobiq/components/accordion';
 import { KbqCheckboxModule } from '@koobiq/components/checkbox';
 
 /**
- * @title accordion-content
+ * @title Accordion content
  */
 @Component({
     standalone: true,
     selector: 'accordion-content-example',
     templateUrl: 'accordion-content-example.html',
-    styleUrl: 'accordion-content-example.css',
+    styleUrls: ['accordion-content-example.css'],
     imports: [KbqAccordionModule, KbqCheckboxModule]
 })
 export class AccordionContentExample {

--- a/packages/docs-examples/components/accordion/accordion-header/accordion-header-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-header/accordion-header-example.ts
@@ -5,7 +5,7 @@ import { KbqCheckboxModule } from '@koobiq/components/checkbox';
 import { KbqIcon, KbqIconButton } from '@koobiq/components/icon';
 
 /**
- * @title accordion-header
+ * @title Accordion header
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/accordion/accordion-in-panel/accordion-in-panel-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-in-panel/accordion-in-panel-example.ts
@@ -9,7 +9,7 @@ import {
 } from '@koobiq/components/sidepanel';
 
 /**
- * @title accordion-in-panel
+ * @title Accordion in panel
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/accordion/accordion-in-section/accordion-in-section-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-in-section/accordion-in-section-example.ts
@@ -2,13 +2,13 @@ import { Component } from '@angular/core';
 import { KbqAccordionModule } from '@koobiq/components/accordion';
 
 /**
- * @title accordion-in-section
+ * @title Accordion in section
  */
 @Component({
     standalone: true,
     selector: 'accordion-in-section-example',
     templateUrl: 'accordion-in-section-example.html',
-    styleUrl: 'accordion-in-section-example.css',
+    styleUrls: ['accordion-in-section-example.css'],
     imports: [KbqAccordionModule, KbqAccordionModule]
 })
 export class AccordionInSectionExample {}

--- a/packages/docs-examples/components/accordion/accordion-inactive-section/accordion-inactive-section-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-inactive-section/accordion-inactive-section-example.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { KbqAccordionModule } from '@koobiq/components/accordion';
 
 /**
- * @title accordion-inactive-section
+ * @title Accordion inactive section
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/accordion/accordion-overview/accordion-overview-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-overview/accordion-overview-example.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { KbqAccordionModule } from '@koobiq/components/accordion';
 
 /**
- * @title accordion-overview
+ * @title Accordion
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/accordion/accordion-sections/accordion-sections-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-sections/accordion-sections-example.ts
@@ -3,7 +3,7 @@ import { KbqAccordionModule } from '@koobiq/components/accordion';
 import { KbqButtonToggleModule } from '@koobiq/components/button-toggle';
 
 /**
- * @title accordion-sections
+ * @title Accordion sections
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/accordion/accordion-states/accordion-states-example.ts
+++ b/packages/docs-examples/components/accordion/accordion-states/accordion-states-example.ts
@@ -3,7 +3,7 @@ import { KbqAccordionModule, KbqAccordionVariant } from '@koobiq/components/acco
 import { KbqButtonToggleModule } from '@koobiq/components/button-toggle';
 
 /**
- * @title accordion-states
+ * @title Accordion states
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/alert/alert-close/alert-close-example.ts
+++ b/packages/docs-examples/components/alert/alert-close/alert-close-example.ts
@@ -6,7 +6,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqIconModule } from '@koobiq/components/icon';
 
 /**
- * @title Alert Close
+ * @title Alert close
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/alert/alert-close/alert-close-example.ts
+++ b/packages/docs-examples/components/alert/alert-close/alert-close-example.ts
@@ -1,5 +1,5 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqAlertModule } from '@koobiq/components/alert';
 import { KbqButtonStyles } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
@@ -19,7 +19,6 @@ import { KbqIconModule } from '@koobiq/components/icon';
             transition('true => false', animate('.2s'))])
 
     ],
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqAlertModule,
         KbqIconModule

--- a/packages/docs-examples/components/alert/alert-content/alert-content-example.css
+++ b/packages/docs-examples/components/alert/alert-content/alert-content-example.css
@@ -12,11 +12,6 @@ p + p {
     gap: 16px;
 }
 
-.layout-row,
-.layout-column {
-    gap: 16px;
-}
-
 .layout-column {
     width: 50%;
 }

--- a/packages/docs-examples/components/alert/alert-content/alert-content-example.css
+++ b/packages/docs-examples/components/alert/alert-content/alert-content-example.css
@@ -1,48 +1,48 @@
-.kbq-alert__text p {
+p {
     margin: 0 0;
 }
 
-.kbq-alert__text p + p {
+p + p {
     margin-top: 8px;
 }
 
-alert-content-example {
+:host {
     display: flex;
     flex-wrap: wrap;
     gap: 16px;
 }
 
-alert-content-example .layout-row,
-alert-content-example .layout-column {
+.layout-row,
+.layout-column {
     gap: 16px;
 }
 
-alert-content-example .layout-column {
+.layout-column {
     width: 50%;
 }
 
-alert-content-example .kbq-alert__button-stack {
+:host ::ng-deep .kbq-alert__button-stack {
     display: flex;
     flex-wrap: wrap;
     column-gap: 12px;
 }
 
 @media (1200px < width <= 1440px) {
-    alert-content-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-content-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }
 
 @media (width <= 1024px) {
-    alert-content-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-content-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }

--- a/packages/docs-examples/components/alert/alert-content/alert-content-example.html
+++ b/packages/docs-examples/components/alert/alert-content/alert-content-example.html
@@ -1,4 +1,4 @@
-<div class="layout-row flex-100">
+<div class="layout-row layout-gap-l flex-100">
     <div class="layout-column">
         <kbq-alert>
             <i kbq-icon-item="kbq-info-circle_16"></i>
@@ -63,7 +63,7 @@
     </div>
 </div>
 
-<div class="layout-row flex-100">
+<div class="layout-row layout-gap-l flex-100">
     <div class="layout-column">
         <kbq-alert>
             <i kbq-icon-item="kbq-info-circle_16"></i>
@@ -108,7 +108,7 @@
     </div>
 </div>
 
-<div class="layout-row flex-100">
+<div class="layout-row layout-gap-l flex-100">
     <div class="layout-column">
         <kbq-alert>
             <i kbq-icon-item="kbq-info-circle_16"></i>
@@ -147,7 +147,7 @@
     </div>
 </div>
 
-<div class="layout-row flex-100">
+<div class="layout-row layout-gap-l flex-100">
     <div class="layout-column">
         <kbq-alert>
             <i kbq-icon-item="kbq-info-circle_16"></i>
@@ -162,7 +162,7 @@
     </div>
 </div>
 
-<div class="layout-row flex-100">
+<div class="layout-row layout-gap-l flex-100">
     <div class="layout-column">
         <kbq-alert>
             <i kbq-icon-item="kbq-info-circle_16"></i>
@@ -177,7 +177,7 @@
     </div>
 </div>
 
-<div class="layout-row flex-100">
+<div class="layout-row layout-gap-l flex-100">
     <div class="layout-column">
         <kbq-alert>
             <p>

--- a/packages/docs-examples/components/alert/alert-content/alert-content-example.ts
+++ b/packages/docs-examples/components/alert/alert-content/alert-content-example.ts
@@ -1,5 +1,5 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqAlertColors, KbqAlertModule, KbqAlertStyles } from '@koobiq/components/alert';
 import { KbqButtonModule, KbqButtonStyles } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
@@ -7,13 +7,13 @@ import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqLinkModule } from '@koobiq/components/link';
 
 /**
- * @title Alert
+ * @title Alert content
  */
 @Component({
     standalone: true,
     selector: 'alert-content-example',
     templateUrl: 'alert-content-example.html',
-    styleUrl: 'alert-content-example.css',
+    styleUrls: ['alert-content-example.css'],
     animations: [
         trigger('hideShowAnimator', [
             state('true', style({ opacity: 1, display: '' })),
@@ -22,7 +22,6 @@ import { KbqLinkModule } from '@koobiq/components/link';
             transition('true => false', animate('.2s'))])
 
     ],
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqAlertModule,
         KbqButtonModule,

--- a/packages/docs-examples/components/alert/alert-size/alert-size-example.css
+++ b/packages/docs-examples/components/alert/alert-size/alert-size-example.css
@@ -1,8 +1,3 @@
-.layout-row,
-.layout-column {
-    gap: 16px;
-}
-
 .layout-column {
     width: 50%;
 }

--- a/packages/docs-examples/components/alert/alert-size/alert-size-example.css
+++ b/packages/docs-examples/components/alert/alert-size/alert-size-example.css
@@ -1,34 +1,34 @@
-alert-size-example .layout-row,
-alert-size-example .layout-column {
+.layout-row,
+.layout-column {
     gap: 16px;
 }
 
-alert-size-example .layout-column {
+.layout-column {
     width: 50%;
 }
 
-alert-size-example .kbq-alert__button-stack {
+:host ::ng-deep .kbq-alert__button-stack {
     display: flex;
     flex-wrap: wrap;
     column-gap: 12px;
 }
 
 @media (1200px < width <= 1440px) {
-    alert-size-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-size-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }
 
 @media (width <= 1024px) {
-    alert-size-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-size-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }

--- a/packages/docs-examples/components/alert/alert-size/alert-size-example.html
+++ b/packages/docs-examples/components/alert/alert-size/alert-size-example.html
@@ -1,4 +1,4 @@
-<div class="layout-row flex-100">
+<div class="layout-row layout-gap-l flex-100">
     <div class="layout-column">
         <kbq-alert>
             <i kbq-icon-item="kbq-info-circle_16"></i>

--- a/packages/docs-examples/components/alert/alert-size/alert-size-example.ts
+++ b/packages/docs-examples/components/alert/alert-size/alert-size-example.ts
@@ -1,18 +1,18 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqAlertModule } from '@koobiq/components/alert';
 import { KbqButtonStyles } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqLinkModule } from '@koobiq/components/link';
 
 /**
- * @title Alert Size
+ * @title Alert size
  */
 @Component({
     standalone: true,
     selector: 'alert-size-example',
     templateUrl: 'alert-size-example.html',
-    styleUrl: 'alert-size-example.css',
+    styleUrls: ['alert-size-example.css'],
     animations: [
         trigger('hideShowAnimator', [
             state('true', style({ opacity: 1, display: '' })),
@@ -24,8 +24,7 @@ import { KbqLinkModule } from '@koobiq/components/link';
     imports: [
         KbqAlertModule,
         KbqLinkModule
-    ],
-    encapsulation: ViewEncapsulation.None
+    ]
 })
 export class AlertSizeExample {
     colors = KbqComponentColors;

--- a/packages/docs-examples/components/alert/alert-status/alert-status-example.css
+++ b/packages/docs-examples/components/alert/alert-status/alert-status-example.css
@@ -1,8 +1,3 @@
-.layout-row,
-.layout-column {
-    gap: 16px;
-}
-
 .layout-column {
     width: 50%;
 }

--- a/packages/docs-examples/components/alert/alert-status/alert-status-example.css
+++ b/packages/docs-examples/components/alert/alert-status/alert-status-example.css
@@ -1,28 +1,28 @@
-alert-status-example .layout-row,
-alert-status-example .layout-column {
+.layout-row,
+.layout-column {
     gap: 16px;
 }
 
-alert-status-example .layout-column {
+.layout-column {
     width: 50%;
 }
 
 @media (1200px < width <= 1440px) {
-    alert-status-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-status-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }
 
 @media (width <= 1024px) {
-    alert-status-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-status-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }

--- a/packages/docs-examples/components/alert/alert-status/alert-status-example.html
+++ b/packages/docs-examples/components/alert/alert-status/alert-status-example.html
@@ -1,5 +1,5 @@
-<div class="layout-row flex-100">
-    <div class="layout-column">
+<div class="layout-row layout-gap-l flex-100">
+    <div class="layout-column layout-gap-l">
         <kbq-alert
             class="kbq-alert_theme"
             [alertStyle]="alertStyles.Colored"
@@ -24,7 +24,7 @@
             {{ text }}
         </kbq-alert>
     </div>
-    <div class="layout-column">
+    <div class="layout-column layout-gap-l">
         <kbq-alert
             [alertColor]="alertColors.Error"
             [alertStyle]="alertStyles.Colored"

--- a/packages/docs-examples/components/alert/alert-status/alert-status-example.ts
+++ b/packages/docs-examples/components/alert/alert-status/alert-status-example.ts
@@ -1,12 +1,12 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqAlertColors, KbqAlertModule, KbqAlertStyles } from '@koobiq/components/alert';
 import { KbqButtonStyles } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqIconModule } from '@koobiq/components/icon';
 
 /**
- * @title Alert Status
+ * @title Alert status
  */
 @Component({
     standalone: true,
@@ -24,8 +24,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
     imports: [
         KbqAlertModule,
         KbqIconModule
-    ],
-    encapsulation: ViewEncapsulation.None
+    ]
 })
 export class AlertStatusExample {
     colors = KbqComponentColors;

--- a/packages/docs-examples/components/alert/alert-variants/alert-variants-example.css
+++ b/packages/docs-examples/components/alert/alert-variants/alert-variants-example.css
@@ -1,8 +1,3 @@
-.layout-row,
-.layout-column {
-    gap: 16px;
-}
-
 .layout-column {
     width: 50%;
 }

--- a/packages/docs-examples/components/alert/alert-variants/alert-variants-example.css
+++ b/packages/docs-examples/components/alert/alert-variants/alert-variants-example.css
@@ -1,28 +1,28 @@
-alert-variants-example .layout-row,
-alert-variants-example .layout-column {
+.layout-row,
+.layout-column {
     gap: 16px;
 }
 
-alert-variants-example .layout-column {
+.layout-column {
     width: 50%;
 }
 
 @media (1200px < width <= 1440px) {
-    alert-variants-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-variants-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }
 
 @media (width <= 1024px) {
-    alert-variants-example .layout-row {
+    .layout-row {
         flex-wrap: wrap;
     }
 
-    alert-variants-example .layout-column {
+    .layout-column {
         width: 100%;
     }
 }

--- a/packages/docs-examples/components/alert/alert-variants/alert-variants-example.ts
+++ b/packages/docs-examples/components/alert/alert-variants/alert-variants-example.ts
@@ -1,17 +1,17 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqAlertColors, KbqAlertModule, KbqAlertStyles } from '@koobiq/components/alert';
 import { KbqButtonStyles } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqIconModule } from '@koobiq/components/icon';
 
 /**
- * @title Alert Variants
+ * @title Alert variants
  */
 @Component({
     standalone: true,
     selector: 'alert-variants-example',
-    styleUrl: 'alert-variants-example.css',
+    styleUrls: ['alert-variants-example.css'],
     animations: [
         trigger('hideShowAnimator', [
             state('true', style({ opacity: 1, display: '' })),
@@ -20,7 +20,6 @@ import { KbqIconModule } from '@koobiq/components/icon';
             transition('true => false', animate('.2s'))])
 
     ],
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqAlertModule,
         KbqIconModule

--- a/packages/docs-examples/components/alert/alert-variants/alert-variants-example.ts
+++ b/packages/docs-examples/components/alert/alert-variants/alert-variants-example.ts
@@ -25,7 +25,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
         KbqIconModule
     ],
     template: `
-        <div class="layout-row flex-100">
+        <div class="layout-row layout-gap-l flex-100">
             <div class="layout-column">
                 <kbq-alert [alertColor]="alertColors.Error">
                     <i

--- a/packages/docs-examples/components/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
+++ b/packages/docs-examples/components/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { KbqAutocompleteModule } from '@koobiq/components/autocomplete';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
@@ -8,12 +8,11 @@ import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
 /**
- * @title Basic Input
+ * @title Autocomplete
  */
 @Component({
     standalone: true,
     selector: 'autocomplete-overview-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqFormFieldModule,
         KbqAutocompleteModule,

--- a/packages/docs-examples/components/badge/badge-content/badge-content-example.css
+++ b/packages/docs-examples/components/badge/badge-content/badge-content-example.css
@@ -1,4 +1,0 @@
-.badge-content-example {
-    display: flex;
-    gap: 16px;
-}

--- a/packages/docs-examples/components/badge/badge-content/badge-content-example.ts
+++ b/packages/docs-examples/components/badge/badge-content/badge-content-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 
 /**
@@ -8,7 +8,6 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
     standalone: true,
     selector: 'badge-content-example',
     styleUrls: ['badge-content-example.css'],
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqBadgeModule
     ],

--- a/packages/docs-examples/components/badge/badge-content/badge-content-example.ts
+++ b/packages/docs-examples/components/badge/badge-content/badge-content-example.ts
@@ -7,12 +7,11 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 @Component({
     standalone: true,
     selector: 'badge-content-example',
-    styleUrls: ['badge-content-example.css'],
     imports: [
         KbqBadgeModule
     ],
     template: `
-        <div class="badge-content-example">
+        <div class="layout-row layout-gap-l">
             <kbq-badge [badgeColor]="colors.Success">Normal</kbq-badge>
             <kbq-badge [badgeColor]="colors.Success">
                 Normal

--- a/packages/docs-examples/components/badge/badge-fill-and-style/badge-fill-and-style-example.css
+++ b/packages/docs-examples/components/badge/badge-fill-and-style/badge-fill-and-style-example.css
@@ -13,8 +13,3 @@
 .badge-fill-and-style-example__badge {
     width: 100px;
 }
-
-.badge-fill-and-style-example__row {
-    display: flex;
-    gap: 16px;
-}

--- a/packages/docs-examples/components/badge/badge-fill-and-style/badge-fill-and-style-example.html
+++ b/packages/docs-examples/components/badge/badge-fill-and-style/badge-fill-and-style-example.html
@@ -1,5 +1,5 @@
 <div class="badge-fill-and-style-example">
-    <div class="badge-fill-and-style-example__row">
+    <div class="layout-row layout-gap-l">
         <div class="badge-fill-and-style-example__badge">
             <div class="badge-fill-and-style-example__badge-label kbq-extra-small-text">Theme</div>
             <kbq-badge [badgeColor]="colors.Theme">Badge</kbq-badge>
@@ -18,7 +18,7 @@
         </div>
     </div>
 
-    <div class="badge-fill-and-style-example__row">
+    <div class="layout-row layout-gap-l">
         <div class="badge-fill-and-style-example__badge">
             <div class="badge-fill-and-style-example__badge-label kbq-extra-small-text">Fade Theme</div>
             <kbq-badge [badgeColor]="colors.FadeTheme">Badge</kbq-badge>
@@ -41,7 +41,7 @@
         </div>
     </div>
 
-    <div class="badge-fill-and-style-example__row">
+    <div class="layout-row layout-gap-l">
         <div class="badge-fill-and-style-example__badge">
             <div class="badge-fill-and-style-example__badge-label kbq-extra-small-text">Outline Fade Theme</div>
             <kbq-badge

--- a/packages/docs-examples/components/badge/badge-fill-and-style/badge-fill-and-style-example.ts
+++ b/packages/docs-examples/components/badge/badge-fill-and-style/badge-fill-and-style-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 
 /**
@@ -11,8 +11,7 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
     styleUrls: ['badge-fill-and-style-example.css'],
     imports: [
         KbqBadgeModule
-    ],
-    encapsulation: ViewEncapsulation.None
+    ]
 })
 export class BadgeFillAndStyleExample {
     colors = KbqBadgeColors;

--- a/packages/docs-examples/components/badge/badge-list/badge-list-example.css
+++ b/packages/docs-examples/components/badge/badge-list/badge-list-example.css
@@ -13,7 +13,3 @@
 .badge-list-example__label {
     color: var(--kbq-foreground-contrast-secondary);
 }
-
-.badge-list-example__label_vertical {
-    margin-top: 16px;
-}

--- a/packages/docs-examples/components/badge/badge-list/badge-list-example.ts
+++ b/packages/docs-examples/components/badge/badge-list/badge-list-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 
 /**
@@ -8,7 +8,6 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
     standalone: true,
     selector: 'badge-list-example',
     styleUrls: ['badge-list-example.css'],
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqBadgeModule
     ],

--- a/packages/docs-examples/components/badge/badge-list/badge-list-example.ts
+++ b/packages/docs-examples/components/badge/badge-list/badge-list-example.ts
@@ -19,9 +19,7 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
                     <kbq-badge [badgeColor]="badge.color">{{ badge.name }}</kbq-badge>
                 }
             </div>
-            <div class="badge-list-example__label badge-list-example__label_vertical kbq-extra-small-text">
-                Vertical
-            </div>
+            <div class="badge-list-example__label layout-margin-top-l kbq-extra-small-text">Vertical</div>
             <div class="badge-list-example__list badge-list-example__list_vertical">
                 @for (badge of badges; track badge) {
                     <kbq-badge [badgeColor]="badge.color">{{ badge.name }}</kbq-badge>

--- a/packages/docs-examples/components/badge/badge-size/badge-size-example.css
+++ b/packages/docs-examples/components/badge/badge-size/badge-size-example.css
@@ -1,5 +1,0 @@
-.badge-size-example {
-    display: flex;
-    gap: 16px;
-    align-items: flex-start;
-}

--- a/packages/docs-examples/components/badge/badge-size/badge-size-example.ts
+++ b/packages/docs-examples/components/badge/badge-size/badge-size-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 
 /**
@@ -8,7 +8,6 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
     standalone: true,
     selector: 'badge-size-example',
     styleUrls: ['badge-size-example.css'],
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqBadgeModule
     ],

--- a/packages/docs-examples/components/badge/badge-size/badge-size-example.ts
+++ b/packages/docs-examples/components/badge/badge-size/badge-size-example.ts
@@ -7,12 +7,11 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 @Component({
     standalone: true,
     selector: 'badge-size-example',
-    styleUrls: ['badge-size-example.css'],
     imports: [
         KbqBadgeModule
     ],
     template: `
-        <div class="badge-size-example">
+        <div class="layout-row layout-gap-l">
             <kbq-badge [badgeColor]="colors.Success">Normal</kbq-badge>
             <kbq-badge
                 [badgeColor]="colors.Success"

--- a/packages/docs-examples/components/badge/badge-table/badge-table-example.css
+++ b/packages/docs-examples/components/badge/badge-table/badge-table-example.css
@@ -1,3 +1,0 @@
-.badge-table-example th {
-    width: 33.3%;
-}

--- a/packages/docs-examples/components/badge/badge-table/badge-table-example.html
+++ b/packages/docs-examples/components/badge/badge-table/badge-table-example.html
@@ -4,9 +4,9 @@
 >
     <thead>
         <tr>
-            <th>Столбец 1</th>
-            <th>Столбец 2</th>
-            <th>Столбец 3</th>
+            <th style="width: 33.3%">Столбец 1</th>
+            <th style="width: 33.3%">Столбец 2</th>
+            <th style="width: 33.3%">Столбец 3</th>
         </tr>
     </thead>
     <tbody>

--- a/packages/docs-examples/components/badge/badge-table/badge-table-example.ts
+++ b/packages/docs-examples/components/badge/badge-table/badge-table-example.ts
@@ -10,7 +10,6 @@ import { KbqTableModule } from '@koobiq/components/table';
     standalone: true,
     selector: 'badge-table-example',
     templateUrl: 'badge-table-example.html',
-    styleUrls: ['badge-table-example.css'],
     imports: [
         KbqBadgeModule,
         KbqLinkModule,

--- a/packages/docs-examples/components/badge/badge-table/badge-table-example.ts
+++ b/packages/docs-examples/components/badge/badge-table/badge-table-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 import { KbqLinkModule } from '@koobiq/components/link';
 import { KbqTableModule } from '@koobiq/components/table';
@@ -15,8 +15,7 @@ import { KbqTableModule } from '@koobiq/components/table';
         KbqBadgeModule,
         KbqLinkModule,
         KbqTableModule
-    ],
-    encapsulation: ViewEncapsulation.None
+    ]
 })
 export class BadgeTableExample {
     colors = KbqBadgeColors;

--- a/packages/docs-examples/components/badge/badge-tooltip/badge-tooltip-example.ts
+++ b/packages/docs-examples/components/badge/badge-tooltip/badge-tooltip-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
 import { PopUpPlacements } from '@koobiq/components/core';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
@@ -10,7 +10,6 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
     standalone: true,
     selector: 'badge-tooltip-example',
     styleUrls: ['badge-tooltip-example.css'],
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqBadgeModule,
         KbqToolTipModule

--- a/packages/docs-examples/components/button-toggle/button-toggle-alignment-overview/button-toggle-alignment-overview-example.css
+++ b/packages/docs-examples/components/button-toggle/button-toggle-alignment-overview/button-toggle-alignment-overview-example.css
@@ -1,55 +1,32 @@
-button-toggle-alignment-overview-example .kbq-button-toggle-group_stretched {
+.kbq-button-toggle-group_stretched {
     width: 100%;
 }
 
-button-toggle-alignment-overview-example .kbq-button-toggle-group_stretched .kbq-button-toggle {
+.kbq-button-toggle-group_stretched .kbq-button-toggle {
     flex: 1;
 }
 
-button-toggle-alignment-overview-example .kbq-button-toggle-group_stretched > .kbq-button-toggle > .kbq-button {
+.kbq-button-toggle-group_stretched > .kbq-button-toggle > ::ng-deep .kbq-button {
     flex: 1;
 }
 
-button-toggle-alignment-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button
-    .kbq-button-toggle-wrapper,
-button-toggle-alignment-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button-icon
-    .kbq-button-toggle-wrapper {
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button .kbq-button-toggle-wrapper,
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button-icon .kbq-button-toggle-wrapper {
     display: block !important;
 }
 
-button-toggle-alignment-overview-example
-    .kbq-button-toggle-group
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button .kbq-button-toggle-wrapper > :not(:last-child),
+.kbq-button-toggle-group
     .kbq-button-toggle
-    > .kbq-button
-    .kbq-button-toggle-wrapper
-    > :not(:last-child),
-button-toggle-alignment-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button-icon
+    > ::ng-deep
+    .kbq-button-icon
     .kbq-button-toggle-wrapper
     > :not(:last-child) {
     margin-right: 4px;
 }
 
-button-toggle-alignment-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button
-    .kbq-button-toggle-wrapper
-    .kbq-icon,
-button-toggle-alignment-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button-icon
-    .kbq-button-toggle-wrapper
-    .kbq-icon {
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button .kbq-button-toggle-wrapper .kbq-icon,
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button-icon .kbq-button-toggle-wrapper .kbq-icon {
     position: relative;
     top: -1px;
 }

--- a/packages/docs-examples/components/button-toggle/button-toggle-alignment-overview/button-toggle-alignment-overview-example.ts
+++ b/packages/docs-examples/components/button-toggle/button-toggle-alignment-overview/button-toggle-alignment-overview-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqButtonToggleModule } from '@koobiq/components/button-toggle';
 import { KbqIconModule } from '@koobiq/components/icon';
@@ -10,13 +10,12 @@ import { KbqIconModule } from '@koobiq/components/icon';
     standalone: true,
     selector: 'button-toggle-alignment-overview-example',
     templateUrl: 'button-toggle-alignment-overview-example.html',
-    styleUrl: 'button-toggle-alignment-overview-example.css',
+    styleUrls: ['button-toggle-alignment-overview-example.css'],
     imports: [
         KbqButtonToggleModule,
         FormsModule,
         KbqIconModule
-    ],
-    encapsulation: ViewEncapsulation.None
+    ]
 })
 export class ButtonToggleAlignmentOverviewExample {
     group = [

--- a/packages/docs-examples/components/button-toggle/button-toggle-tooltip-overview/button-toggle-tooltip-overview-example.css
+++ b/packages/docs-examples/components/button-toggle/button-toggle-tooltip-overview/button-toggle-tooltip-overview-example.css
@@ -1,55 +1,32 @@
-button-toggle-tooltip-overview-example .kbq-button-toggle-group_stretched {
+.kbq-button-toggle-group_stretched {
     width: 100%;
 }
 
-button-toggle-tooltip-overview-example .kbq-button-toggle-group_stretched .kbq-button-toggle {
+.kbq-button-toggle-group_stretched .kbq-button-toggle {
     flex: 1;
 }
 
-button-toggle-tooltip-overview-example .kbq-button-toggle-group_stretched > .kbq-button-toggle > .kbq-button {
+.kbq-button-toggle-group_stretched > .kbq-button-toggle > ::ng-deep .kbq-button {
     flex: 1;
 }
 
-button-toggle-tooltip-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button
-    .kbq-button-toggle-wrapper,
-button-toggle-tooltip-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button-icon
-    .kbq-button-toggle-wrapper {
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button .kbq-button-toggle-wrapper,
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button-icon .kbq-button-toggle-wrapper {
     display: block !important;
 }
 
-button-toggle-tooltip-overview-example
-    .kbq-button-toggle-group
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button .kbq-button-toggle-wrapper > :not(:last-child),
+.kbq-button-toggle-group
     .kbq-button-toggle
-    > .kbq-button
-    .kbq-button-toggle-wrapper
-    > :not(:last-child),
-button-toggle-tooltip-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button-icon
+    > ::ng-deep
+    .kbq-button-icon
     .kbq-button-toggle-wrapper
     > :not(:last-child) {
     margin-right: 4px;
 }
 
-button-toggle-tooltip-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button
-    .kbq-button-toggle-wrapper
-    .kbq-icon,
-button-toggle-tooltip-overview-example
-    .kbq-button-toggle-group
-    .kbq-button-toggle
-    > .kbq-button-icon
-    .kbq-button-toggle-wrapper
-    .kbq-icon {
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button .kbq-button-toggle-wrapper .kbq-icon,
+.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button-icon .kbq-button-toggle-wrapper .kbq-icon {
     position: relative;
     top: -1px;
 }

--- a/packages/docs-examples/components/button-toggle/button-toggle-tooltip-overview/button-toggle-tooltip-overview-example.ts
+++ b/packages/docs-examples/components/button-toggle/button-toggle-tooltip-overview/button-toggle-tooltip-overview-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqButtonToggleModule } from '@koobiq/components/button-toggle';
 import { KbqIconModule } from '@koobiq/components/icon';
@@ -9,8 +9,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 @Component({
     standalone: true,
     selector: 'button-toggle-tooltip-overview-example',
-    styleUrl: 'button-toggle-tooltip-overview-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['button-toggle-tooltip-overview-example.css'],
     imports: [
         KbqButtonToggleModule,
         FormsModule,

--- a/packages/docs-examples/components/button/button-content/button-content-example.ts
+++ b/packages/docs-examples/components/button/button-content/button-content-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqIconModule } from '@koobiq/components/icon';
@@ -9,8 +9,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 @Component({
     standalone: true,
     selector: 'button-content-example',
-    styleUrl: 'button-content-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['button-content-example.css'],
     imports: [
         KbqButtonModule,
         KbqIconModule

--- a/packages/docs-examples/components/button/button-fill-and-style/button-fill-and-style-example.ts
+++ b/packages/docs-examples/components/button/button-fill-and-style/button-fill-and-style-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqButtonModule, KbqButtonStyles } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 
@@ -9,11 +9,10 @@ import { KbqComponentColors } from '@koobiq/components/core';
     standalone: true,
     selector: 'button-fill-and-style-example',
     templateUrl: 'button-fill-and-style-example.html',
-    styleUrl: 'button-fill-and-style-example.css',
+    styleUrls: ['button-fill-and-style-example.css'],
     imports: [
         KbqButtonModule
-    ],
-    encapsulation: ViewEncapsulation.None
+    ]
 })
 export class ButtonFillAndStyleExample {
     colors = KbqComponentColors;

--- a/packages/docs-examples/components/button/button-fill-content/button-fill-content-example.css
+++ b/packages/docs-examples/components/button/button-fill-content/button-fill-content-example.css
@@ -5,7 +5,7 @@
     white-space: nowrap;
 }
 
-.fill-content__example-button .kbq-button-wrapper {
+.fill-content__example-button ::ng-deep .kbq-button-wrapper {
     display: inline-block;
     flex-grow: 1;
     overflow: hidden;

--- a/packages/docs-examples/components/button/button-fill-content/button-fill-content-example.ts
+++ b/packages/docs-examples/components/button/button-fill-content/button-fill-content-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 
@@ -8,8 +8,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'button-fill-content-example',
-    styleUrl: 'button-fill-content-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['button-fill-content-example.css'],
     imports: [
         KbqButtonModule
     ],

--- a/packages/docs-examples/components/button/button-fixed-content/button-fixed-content-example.css
+++ b/packages/docs-examples/components/button/button-fixed-content/button-fixed-content-example.css
@@ -10,7 +10,7 @@
     white-space: nowrap;
 }
 
-.fixed-content__example-button .kbq-button-wrapper {
+.fixed-content__example-button ::ng-deep .kbq-button-wrapper {
     display: inline-block;
     flex-grow: 1;
     overflow: hidden;

--- a/packages/docs-examples/components/button/button-fixed-content/button-fixed-content-example.ts
+++ b/packages/docs-examples/components/button/button-fixed-content/button-fixed-content-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 
@@ -8,8 +8,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'button-fixed-content-example',
-    styleUrl: 'button-fixed-content-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['button-fixed-content-example.css'],
     imports: [
         KbqButtonModule
     ],

--- a/packages/docs-examples/components/button/button-hug-content/button-hug-content-example.ts
+++ b/packages/docs-examples/components/button/button-hug-content/button-hug-content-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 
@@ -8,8 +8,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'button-hug-content-example',
-    styleUrl: 'button-hug-content-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['button-hug-content-example.css'],
     imports: [
         KbqButtonModule
     ],

--- a/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.css
+++ b/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.css
@@ -1,1 +1,0 @@
-/** No CSS for this example */

--- a/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.ts
+++ b/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.ts
@@ -8,7 +8,6 @@ import { KbqComponentColors } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'button-loading-state-example',
-    styleUrls: ['button-loading-state-example.css'],
     imports: [
         KbqButtonModule
     ],

--- a/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.ts
+++ b/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqComponentColors } from '@koobiq/components/core';
 
@@ -8,8 +8,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'button-loading-state-example',
-    styleUrl: 'button-loading-state-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['button-loading-state-example.css'],
     imports: [
         KbqButtonModule
     ],

--- a/packages/docs-examples/components/button/button-overview/button-overview-example.ts
+++ b/packages/docs-examples/components/button/button-overview/button-overview-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqCheckboxModule } from '@koobiq/components/checkbox';
@@ -10,8 +10,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'button-overview-example',
-    styleUrl: 'button-overview-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['button-overview-example.css'],
     imports: [
         KbqButtonModule,
         KbqCheckboxModule,

--- a/packages/docs-examples/components/checkbox/checkbox-indeterminate/checkbox-indeterminate-example.ts
+++ b/packages/docs-examples/components/checkbox/checkbox-indeterminate/checkbox-indeterminate-example.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component } from '@angular/core';
 import { KbqCheckboxModule } from '@koobiq/components/checkbox';
 
 interface ICheckbox {
@@ -12,7 +12,6 @@ interface ICheckbox {
 @Component({
     standalone: true,
     selector: 'checkbox-indeterminate-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqCheckboxModule
     ],

--- a/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.css
+++ b/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.css
@@ -1,8 +1,0 @@
-.example-section {
-    display: flex;
-    flex-direction: column;
-}
-
-.example-margin {
-    margin-bottom: 10px;
-}

--- a/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.css
+++ b/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.css
@@ -1,8 +1,8 @@
-checkbox-overview-example .example-section {
+.example-section {
     display: flex;
     flex-direction: column;
 }
 
-checkbox-overview-example .example-margin {
+.example-margin {
     margin-bottom: 10px;
 }

--- a/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.html
+++ b/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.html
@@ -1,17 +1,17 @@
-<div class="kbq-body example-section">
-    <kbq-checkbox class="example-margin">
+<div class="layout-column layout-margin-bottom-4xl">
+    <kbq-checkbox class="layout-margin-bottom-m">
         <kbq-hint>kbq-hint</kbq-hint>
         Default
     </kbq-checkbox>
     <kbq-checkbox
-        class="example-margin"
+        class="layout-margin-bottom-m"
         [checked]="true"
     >
         <kbq-hint>kbq-hint</kbq-hint>
         Checked
     </kbq-checkbox>
     <kbq-checkbox
-        class="example-margin"
+        class="layout-margin-bottom-m"
         [checked]="false"
     >
         <kbq-hint>kbq-hint</kbq-hint>
@@ -19,19 +19,16 @@
     </kbq-checkbox>
 </div>
 
-<br />
-<br />
-
-<div class="kbq-body example-section">
+<div class="layout-column">
     <kbq-checkbox
-        class="example-margin"
+        class="layout-margin-bottom-m"
         [big]="true"
     >
         <kbq-hint>kbq-hint</kbq-hint>
         Default
     </kbq-checkbox>
     <kbq-checkbox
-        class="example-margin"
+        class="layout-margin-bottom-m"
         [big]="true"
         [checked]="true"
     >
@@ -39,7 +36,7 @@
         Checked
     </kbq-checkbox>
     <kbq-checkbox
-        class="example-margin"
+        class="layout-margin-bottom-m"
         [big]="true"
         [checked]="false"
     >

--- a/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.ts
+++ b/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.ts
@@ -1,19 +1,18 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqCheckboxModule } from '@koobiq/components/checkbox';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
 
 /**
- * @title Checkbox overview
+ * @title Checkbox
  */
 @Component({
     standalone: true,
     selector: 'checkbox-overview-example',
     templateUrl: 'checkbox-overview-example.html',
-    styleUrl: 'checkbox-overview-example.css',
+    styleUrls: ['checkbox-overview-example.css'],
     imports: [
         KbqCheckboxModule,
         KbqFormFieldModule
-    ],
-    encapsulation: ViewEncapsulation.None
+    ]
 })
 export class CheckboxOverviewExample {}

--- a/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.ts
+++ b/packages/docs-examples/components/checkbox/checkbox-overview/checkbox-overview-example.ts
@@ -9,7 +9,6 @@ import { KbqFormFieldModule } from '@koobiq/components/form-field';
     standalone: true,
     selector: 'checkbox-overview-example',
     templateUrl: 'checkbox-overview-example.html',
-    styleUrls: ['checkbox-overview-example.css'],
     imports: [
         KbqCheckboxModule,
         KbqFormFieldModule

--- a/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.css
+++ b/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.css
@@ -1,8 +1,0 @@
-.kbq-body {
-    display: flex;
-    flex-direction: column;
-}
-
-kbq-pseudo-checkbox + kbq-pseudo-checkbox {
-    margin-top: 16px;
-}

--- a/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.css
+++ b/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.css
@@ -1,8 +1,8 @@
-pseudo-checkbox-example .kbq-body {
+.kbq-body {
     display: flex;
     flex-direction: column;
 }
 
-pseudo-checkbox-example kbq-pseudo-checkbox + kbq-pseudo-checkbox {
+kbq-pseudo-checkbox + kbq-pseudo-checkbox {
     margin-top: 16px;
 }

--- a/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.ts
+++ b/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.ts
@@ -7,15 +7,20 @@ import { KbqPseudoCheckboxModule } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'pseudo-checkbox-example',
-    styleUrls: ['pseudo-checkbox-example.css'],
     imports: [
         KbqPseudoCheckboxModule
     ],
     template: `
-        <div class="kbq-body">
+        <div class="layout-column">
             <kbq-pseudo-checkbox />
-            <kbq-pseudo-checkbox [state]="'indeterminate'" />
-            <kbq-pseudo-checkbox [state]="'checked'" />
+            <kbq-pseudo-checkbox
+                class="layout-margin-top-l"
+                [state]="'indeterminate'"
+            />
+            <kbq-pseudo-checkbox
+                class="layout-margin-top-l"
+                [state]="'checked'"
+            />
         </div>
     `
 })

--- a/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.ts
+++ b/packages/docs-examples/components/checkbox/pseudo-checkbox/pseudo-checkbox-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqPseudoCheckboxModule } from '@koobiq/components/core';
 
 /**
@@ -7,8 +7,7 @@ import { KbqPseudoCheckboxModule } from '@koobiq/components/core';
 @Component({
     standalone: true,
     selector: 'pseudo-checkbox-example',
-    styleUrl: 'pseudo-checkbox-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['pseudo-checkbox-example.css'],
     imports: [
         KbqPseudoCheckboxModule
     ],

--- a/packages/docs-examples/components/code-block/code-block-common/code-block-common-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-common/code-block-common-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 
 const codeTs = `class Greeter {
@@ -51,7 +51,6 @@ body {
 @Component({
     standalone: true,
     selector: 'code-block-common-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqCodeBlockModule
     ],

--- a/packages/docs-examples/components/code-block/code-block-cut/code-block-cut-example.css
+++ b/packages/docs-examples/components/code-block/code-block-cut/code-block-cut-example.css
@@ -1,3 +1,3 @@
-.docs-code-block-cut .kbq-code-block__code .kbq-code-block-actionbar {
+:host ::ng-deep .kbq-code-block-actionbar {
     display: none;
 }

--- a/packages/docs-examples/components/code-block/code-block-cut/code-block-cut-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-cut/code-block-cut-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 
 const codeJs2 = `function askPassword(ok, fail) {
@@ -30,8 +30,7 @@ askPassword(user.loginOk, user.loginFail);`;
 @Component({
     standalone: true,
     selector: 'code-block-cut-example',
-    styleUrl: 'code-block-cut-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['code-block-cut-example.css'],
     imports: [
         KbqCodeBlockModule
     ],

--- a/packages/docs-examples/components/code-block/code-block-line-numbers/code-block-line-numbers-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-line-numbers/code-block-line-numbers-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 import { KbqToggleModule } from '@koobiq/components/toggle';
@@ -14,12 +14,11 @@ const codeXML = `<?xml version="1.0" encoding="UTF-8"?>
   </breakfast_menu>`;
 
 /**
- * @title Basic code-block-line-numbers
+ * @title Code-block line numbers
  */
 @Component({
     standalone: true,
     selector: 'code-block-line-numbers-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqToggleModule,
         FormsModule,

--- a/packages/docs-examples/components/code-block/code-block-line-wrap/code-block-line-wrap-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-line-wrap/code-block-line-wrap-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 import { KbqToggleModule } from '@koobiq/components/toggle';
@@ -14,12 +14,11 @@ const codeXML = `<?xml version="1.0" encoding="UTF-8"?>
   </breakfast_menu>`;
 
 /**
- * @title Basic code-block-line-wrap
+ * @title Code-block line wrap
  */
 @Component({
     standalone: true,
     selector: 'code-block-line-wrap-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqToggleModule,
         FormsModule,

--- a/packages/docs-examples/components/code-block/code-block-noborder/code-block-noborder-example.css
+++ b/packages/docs-examples/components/code-block/code-block-noborder/code-block-noborder-example.css
@@ -1,11 +1,11 @@
-.code-block_no-border .kbq-tab-group {
+.code-block_no-border ::ng-deep .kbq-tab-group {
     height: 100%;
 }
 
-.code-block_no-border .kbq-tab-body__wrapper {
+.code-block_no-border ::ng-deep .kbq-tab-body__wrapper {
     border: none;
+}
 
-    .kbq-code-block__code > code {
-        padding: 0 0;
-    }
+.code-block_no-border ::ng-deep .kbq-code-block__code > code {
+    padding: 0 0;
 }

--- a/packages/docs-examples/components/code-block/code-block-noborder/code-block-noborder-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-noborder/code-block-noborder-example.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 import { KbqSidepanelModule, KbqSidepanelPosition, KbqSidepanelService } from '@koobiq/components/sidepanel';
@@ -7,7 +7,6 @@ import { take } from 'rxjs/operators';
 const codeJs2 = `import { Clipboard } from '@angular/cdk/clipboard';
 import {
     Component,
-    ViewEncapsulation,
     Input,
     Inject,
     InjectionToken,
@@ -77,8 +76,7 @@ const actionBarBlockLeftMargin = 24;
         '[class.kbq-code-block_no-header]': 'noHeader',
         '(window:resize)': 'resizeStream.next($event)'
     },
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class KbqCodeBlockComponent implements OnDestroy {
 
@@ -197,18 +195,17 @@ export class KbqCodeBlockComponent implements OnDestroy {
 `;
 
 /**
- * @title Code block no border
+ * @title Code-block noborder
  */
 @Component({
     standalone: true,
     selector: 'code-block-noborder-example',
-    styleUrl: 'code-block-noborder-example.css',
+    styleUrls: ['code-block-noborder-example.css'],
     imports: [
         KbqSidepanelModule,
         KbqCodeBlockModule,
         KbqButtonModule
     ],
-    encapsulation: ViewEncapsulation.None,
     template: `
         <div class="kbq-body">
             <button

--- a/packages/docs-examples/components/code-block/code-block-single-line/code-block-single-line-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-single-line/code-block-single-line-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 
 const codeTs2 = `getUserAddress('Rey.Padberg@karina.biz').then(console.log).catch(console.error)`;
@@ -9,7 +9,6 @@ const codeTs2 = `getUserAddress('Rey.Padberg@karina.biz').then(console.log).catc
 @Component({
     standalone: true,
     selector: 'code-block-single-line-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqCodeBlockModule
     ],

--- a/packages/docs-examples/components/code-block/code-block-stretch/code-block-stretch-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-stretch/code-block-stretch-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 import { KbqToggleModule } from '@koobiq/components/toggle';
@@ -24,7 +24,6 @@ const codeTs = `class Greeter {
 @Component({
     standalone: true,
     selector: 'code-block-stretch-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqToggleModule,
         FormsModule,

--- a/packages/docs-examples/components/code-block/code-block-styling/code-block-styling-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-styling/code-block-styling-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 import { KbqToggleModule } from '@koobiq/components/toggle';
@@ -53,7 +53,6 @@ body {
 @Component({
     standalone: true,
     selector: 'code-block-styling-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqToggleModule,
         FormsModule,

--- a/packages/docs-examples/components/code-block/code-block-tabs-with-overflow/code-block-tabs-with-overflow-example.css
+++ b/packages/docs-examples/components/code-block/code-block-tabs-with-overflow/code-block-tabs-with-overflow-example.css
@@ -1,4 +1,4 @@
-.code-block-with-overflow .kbq-code-block__code,
-.code-block-with-overflow .kbq-code-block__code.kbq-code-block__code_view-all {
+:host ::ng-deep .kbq-code-block__code,
+:host ::ng-deep .kbq-code-block__code.kbq-code-block__code_view-all {
     max-height: 200px;
 }

--- a/packages/docs-examples/components/code-block/code-block-tabs-with-overflow/code-block-tabs-with-overflow-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-tabs-with-overflow/code-block-tabs-with-overflow-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 
 const codeTs = `class Greeter {
@@ -51,8 +51,7 @@ body {
 @Component({
     standalone: true,
     selector: 'code-block-tabs-with-overflow-example',
-    styleUrl: 'code-block-tabs-with-overflow-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['code-block-tabs-with-overflow-example.css'],
     imports: [
         KbqCodeBlockModule
     ],

--- a/packages/docs-examples/components/code-block/code-block-tabs/code-block-tabs-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-tabs/code-block-tabs-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 
 const codeTs = `class Greeter {
@@ -51,7 +51,6 @@ body {
 @Component({
     standalone: true,
     selector: 'code-block-tabs-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqCodeBlockModule
     ],

--- a/packages/docs-examples/components/code-block/code-block-title/code-block-title-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-title/code-block-title-example.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { KbqCodeBlockModule, KbqCodeFile } from '@koobiq/components/code-block';
 
 const codeJs2 = `function askPassword(ok, fail) {
@@ -30,7 +30,6 @@ askPassword(user.loginOk, user.loginFail);`;
 @Component({
     standalone: true,
     selector: 'code-block-title-example',
-    encapsulation: ViewEncapsulation.None,
     imports: [
         KbqCodeBlockModule
     ],

--- a/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-cva-overview/file-upload-cva-overview-example.ts
@@ -3,7 +3,7 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { KbqFileItem, KbqFileUploadModule } from '@koobiq/components/file-upload';
 
 /**
- * @title File upload with Control Value Accessor
+ * @title File-upload with control value accessor
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-indeterminate-loading-overview/file-upload-indeterminate-loading-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-indeterminate-loading-overview/file-upload-indeterminate-loading-overview-example.ts
@@ -4,7 +4,7 @@ import { timer } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 /**
- * @title File Upload Indeterminate Loading
+ * @title File-upload indeterminate loading
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-compact-overview/file-upload-multiple-compact-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-compact-overview/file-upload-multiple-compact-overview-example.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { KbqFileUploadModule } from '@koobiq/components/file-upload';
 
 /**
- * @title File Upload Multiple Compact
+ * @title File-upload multiple compact
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-custom-text-overview/file-upload-multiple-custom-text-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-custom-text-overview/file-upload-multiple-custom-text-overview-example.ts
@@ -45,7 +45,7 @@ class FileUploadConfiguration implements KbqInputFileMultipleLabel {
 }
 
 /**
- * @title file upload multiple custom text
+ * @title File-upload multiple custom text
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-default-overview/file-upload-multiple-default-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-default-overview/file-upload-multiple-default-overview-example.ts
@@ -3,7 +3,7 @@ import { KbqFileUploadModule } from '@koobiq/components/file-upload';
 import { KbqIconModule } from '@koobiq/components/icon';
 
 /**
- * @title File Upload Multiple Default
+ * @title File-upload multiple default
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-default-validation-reactive-forms-overview/file-upload-multiple-default-validation-reactive-forms-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-default-validation-reactive-forms-overview/file-upload-multiple-default-validation-reactive-forms-overview-example.ts
@@ -8,7 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 const MAX_FILE_SIZE = 5 * 2 ** 20;
 
 /**
- * @title File Upload Multiple Default Validation Reactive Forms
+ * @title File-upload multiple default validation reactive forms
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-error-overview/file-upload-multiple-error-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-error-overview/file-upload-multiple-error-overview-example.ts
@@ -11,7 +11,7 @@ const maxFileExceeded = (file: File): string | null => {
 };
 
 /**
- * @title file upload Multiple error
+ * @title File-upload multiple error
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-single-error-overview/file-upload-single-error-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-error-overview/file-upload-single-error-overview-example.ts
@@ -3,7 +3,7 @@ import { KbqFileItem, KbqFileUploadModule } from '@koobiq/components/file-upload
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
 
 /**
- * @title file upload single error
+ * @title File-upload single error
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-single-overview/file-upload-single-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-overview/file-upload-single-overview-example.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { KbqFileUploadModule } from '@koobiq/components/file-upload';
 
 /**
- * @title File Upload Single
+ * @title File-upload single
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/file-upload/file-upload-single-validation-reactive-forms-overview/file-upload-single-validation-reactive-forms-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-validation-reactive-forms-overview/file-upload-single-validation-reactive-forms-overview-example.ts
@@ -8,7 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 const MAX_FILE_SIZE = 5 * 2 ** 20;
 
 /**
- * @title File Upload Single Validation Reactive Forms
+ * @title File-upload single validation reactive forms
  */
 @Component({
     standalone: true,

--- a/packages/docs-examples/components/forms/horizontal-form-labels/horizontal-form-labels-example.ts
+++ b/packages/docs-examples/components/forms/horizontal-form-labels/horizontal-form-labels-example.ts
@@ -11,7 +11,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     standalone: true,
     selector: 'horizontal-form-labels-example',
     templateUrl: 'horizontal-form-labels-example.html',
-    styleUrl: 'horizontal-form-labels-example.css',
+    styleUrls: ['horizontal-form-labels-example.css'],
     imports: [
         FormsModule,
         KbqFormsModule,

--- a/packages/docs-examples/components/icon-item/icon-item-color/icon-item-color-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-color/icon-item-color-example.ts
@@ -8,7 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 @Component({
     standalone: true,
     selector: 'icon-item-color-example',
-    styleUrl: 'icon-item-color-example.css',
+    styleUrls: ['icon-item-color-example.css'],
     imports: [
         KbqIconModule
     ],

--- a/packages/docs-examples/components/icon-item/icon-item-default/icon-item-default-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-default/icon-item-default-example.ts
@@ -8,7 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 @Component({
     standalone: true,
     selector: 'icon-item-default-example',
-    styleUrl: 'icon-item-default-example.css',
+    styleUrls: ['icon-item-default-example.css'],
     imports: [
         KbqIconModule
     ],

--- a/packages/docs-examples/components/icon-item/icon-item-size/icon-item-size-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-size/icon-item-size-example.ts
@@ -8,7 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 @Component({
     standalone: true,
     selector: 'icon-item-size-example',
-    styleUrl: 'icon-item-size-example.css',
+    styleUrls: ['icon-item-size-example.css'],
     imports: [
         KbqIconModule
     ],

--- a/packages/docs-examples/components/icon-item/icon-item-variant/icon-item-variant-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-variant/icon-item-variant-example.ts
@@ -8,7 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 @Component({
     standalone: true,
     selector: 'icon-item-variant-example',
-    styleUrl: 'icon-item-variant-example.css',
+    styleUrls: ['icon-item-variant-example.css'],
     imports: [
         KbqIconModule
     ],

--- a/packages/docs-examples/components/layout-flex/layout-flex-alignment/layout-flex-alignment-example.ts
+++ b/packages/docs-examples/components/layout-flex/layout-flex-alignment/layout-flex-alignment-example.ts
@@ -8,7 +8,7 @@ import { KbqRadioModule } from '@koobiq/components/radio';
 @Component({
     standalone: true,
     selector: 'layout-flex-alignment-example',
-    styleUrl: 'layout-flex-alignment-example.css',
+    styleUrls: ['layout-flex-alignment-example.css'],
     imports: [
         KbqRadioModule,
         FormsModule

--- a/packages/docs-examples/components/layout-flex/layout-flex-behaviour-modifiers/layout-flex-behaviour-modifiers-example.ts
+++ b/packages/docs-examples/components/layout-flex/layout-flex-behaviour-modifiers/layout-flex-behaviour-modifiers-example.ts
@@ -8,7 +8,7 @@ import { KbqRadioModule } from '@koobiq/components/radio';
 @Component({
     standalone: true,
     selector: 'layout-flex-behaviour-modifiers-example',
-    styleUrl: 'layout-flex-behaviour-modifiers-example.css',
+    styleUrls: ['layout-flex-behaviour-modifiers-example.css'],
     imports: [
         KbqRadioModule,
         FormsModule

--- a/packages/docs-examples/components/layout-flex/layout-flex-offsets/layout-flex-offsets-example.ts
+++ b/packages/docs-examples/components/layout-flex/layout-flex-offsets/layout-flex-offsets-example.ts
@@ -8,7 +8,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
 @Component({
     standalone: true,
     selector: 'layout-flex-offsets-example',
-    styleUrl: 'layout-flex-offsets-example.css',
+    styleUrls: ['layout-flex-offsets-example.css'],
     imports: [KbqSelectModule, KbqFormFieldModule],
     template: `
         <div class="docs-layout-flex-offsets layout-margin-top-4xl">

--- a/packages/docs-examples/components/layout-flex/layout-flex-order/layout-flex-order-example.ts
+++ b/packages/docs-examples/components/layout-flex/layout-flex-order/layout-flex-order-example.ts
@@ -8,7 +8,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
 @Component({
     standalone: true,
     selector: 'layout-flex-order-example',
-    styleUrl: 'layout-flex-order-example.css',
+    styleUrls: ['layout-flex-order-example.css'],
     imports: [KbqSelectModule, KbqFormFieldModule],
     template: `
         <div class="docs-layout-flex-order layout-margin-top-4xl">

--- a/packages/docs-examples/components/layout-flex/layout-flex-overview/layout-flex-overview-example.ts
+++ b/packages/docs-examples/components/layout-flex/layout-flex-overview/layout-flex-overview-example.ts
@@ -8,7 +8,7 @@ import { KbqRadioModule } from '@koobiq/components/radio';
 @Component({
     standalone: true,
     selector: 'layout-flex-overview-example',
-    styleUrl: 'layout-flex-overview-example.css',
+    styleUrls: ['layout-flex-overview-example.css'],
     imports: [
         KbqRadioModule,
         FormsModule

--- a/packages/docs-examples/components/link/link-color/link-color-example.ts
+++ b/packages/docs-examples/components/link/link-color/link-color-example.ts
@@ -7,7 +7,7 @@ import { KbqLinkModule } from '@koobiq/components/link';
 @Component({
     standalone: true,
     selector: 'link-color-example',
-    styleUrl: 'link-color-example.css',
+    styleUrls: ['link-color-example.css'],
     imports: [KbqLinkModule],
     template: `
         <table>

--- a/packages/docs-examples/components/markdown/markdown-article/markdown-article-example.ts
+++ b/packages/docs-examples/components/markdown/markdown-article/markdown-article-example.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { KbqMarkdownModule } from '@koobiq/components/markdown';
 
 /**
@@ -9,8 +9,7 @@ import { KbqMarkdownModule } from '@koobiq/components/markdown';
     imports: [KbqMarkdownModule],
     selector: 'markdown-article-example',
     templateUrl: './markdown-article-example.html',
-    styleUrl: './markdown-article-example.css',
-    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['./markdown-article-example.css'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MarkdownArticleExample {}

--- a/packages/docs-examples/components/navbar/navbar-vertical/navbar-vertical-example.ts
+++ b/packages/docs-examples/components/navbar/navbar-vertical/navbar-vertical-example.ts
@@ -14,7 +14,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
     selector: 'navbar-vertical-example',
     templateUrl: 'navbar-vertical-example.html',
     styles: `
-        :host::ng-deep.kbq-vertical-navbar__container {
+        :host ::ng-deep .kbq-vertical-navbar__container {
             border-top-left-radius: 12px;
         }
     `,

--- a/packages/docs-examples/components/popover/popover-close/popover-close-example.ts
+++ b/packages/docs-examples/components/popover/popover-close/popover-close-example.ts
@@ -14,7 +14,7 @@ import { KbqPopoverModule } from '@koobiq/components/popover';
     standalone: true,
     selector: 'popover-close-example',
     templateUrl: 'popover-close-example.html',
-    styleUrl: 'popover-close-example.css',
+    styleUrls: ['popover-close-example.css'],
     imports: [KbqFormFieldModule, KbqInputModule, KbqButtonModule, KbqPopoverModule, KbqIconModule, KbqDropdownModule]
 })
 export class PopoverCloseExample {

--- a/packages/docs-examples/components/popover/popover-content/popover-content-example.ts
+++ b/packages/docs-examples/components/popover/popover-content/popover-content-example.ts
@@ -15,7 +15,7 @@ import { KbqPopoverModule } from '@koobiq/components/popover';
     standalone: true,
     selector: 'popover-content-example',
     templateUrl: 'popover-content-example.html',
-    styleUrl: 'popover-content-example.css',
+    styleUrls: ['popover-content-example.css'],
     imports: [
         KbqDropdownModule,
         KbqButtonModule,

--- a/packages/docs-examples/components/sidepanel/sidepanel-modal-mode/sidepanel-modal-mode-example.html
+++ b/packages/docs-examples/components/sidepanel/sidepanel-modal-mode/sidepanel-modal-mode-example.html
@@ -1,0 +1,60 @@
+<div class="kbq-form-horizontal">
+    <div class="kbq-form__row">
+        <label class="kbq-form__label">Position</label>
+        <kbq-form-field
+            style="min-width: 120px"
+            class="kbq-form__control flex-10"
+        >
+            <kbq-select [(value)]="position">
+                <kbq-option [value]="'right'">Right</kbq-option>
+                <kbq-option [value]="'left'">Left</kbq-option>
+                <kbq-option [value]="'top'">Top</kbq-option>
+                <kbq-option [value]="'bottom'">Bottom</kbq-option>
+            </kbq-select>
+        </kbq-form-field>
+    </div>
+</div>
+
+<br />
+
+<button
+    kbq-button
+    [color]="'contrast'"
+    (click)="openSidepanel()"
+>
+    <span>Open sidepanel</span>
+</button>
+
+<ng-template>
+    <kbq-sidepanel-header [closeable]="true">Sidepanel Template Content</kbq-sidepanel-header>
+    <kbq-sidepanel-body style="padding-top: 8px; padding-bottom: 8px">
+        <div
+            style="padding: 8px"
+            class="kbq-subheading"
+        >
+            Sidepanel Template Body
+        </div>
+
+        @for (item of array; track item; let i = $index) {
+            <div style="padding: 8px">
+                {{ i + 1 }}
+            </div>
+        }
+    </kbq-sidepanel-body>
+
+    <kbq-sidepanel-footer>
+        <kbq-sidepanel-actions align="left">
+            <button
+                cdkFocusInitial
+                kbq-button
+                [color]="'contrast'"
+            >
+                <span>Button</span>
+            </button>
+        </kbq-sidepanel-actions>
+
+        <kbq-sidepanel-actions align="right">
+            <span>Action</span>
+        </kbq-sidepanel-actions>
+    </kbq-sidepanel-footer>
+</ng-template>

--- a/packages/docs-examples/components/sidepanel/sidepanel-modal-mode/sidepanel-modal-mode-example.ts
+++ b/packages/docs-examples/components/sidepanel/sidepanel-modal-mode/sidepanel-modal-mode-example.ts
@@ -10,69 +10,8 @@ import { KbqSidepanelModule, KbqSidepanelPosition, KbqSidepanelService } from '@
 @Component({
     standalone: true,
     selector: 'sidepanel-modal-mode-example',
-    imports: [KbqFormFieldModule, KbqSelectModule, KbqButtonModule, KbqSidepanelModule],
-    template: `
-        <div class="kbq-form-horizontal">
-            <div class="kbq-form__row">
-                <label class="kbq-form__label">Position</label>
-                <kbq-form-field
-                    class="kbq-form__control flex-10"
-                    style="min-width: 120px"
-                >
-                    <kbq-select [(value)]="position">
-                        <kbq-option [value]="'right'">Right</kbq-option>
-                        <kbq-option [value]="'left'">Left</kbq-option>
-                        <kbq-option [value]="'top'">Top</kbq-option>
-                        <kbq-option [value]="'bottom'">Bottom</kbq-option>
-                    </kbq-select>
-                </kbq-form-field>
-            </div>
-        </div>
-
-        <br />
-
-        <button
-            [color]="'contrast'"
-            (click)="openSidepanel()"
-            kbq-button
-        >
-            <span>Open sidepanel</span>
-        </button>
-
-        <ng-template>
-            <kbq-sidepanel-header [closeable]="true">Sidepanel Template Content</kbq-sidepanel-header>
-            <kbq-sidepanel-body style="padding-top: 8px; padding-bottom: 8px">
-                <div
-                    class="kbq-subheading"
-                    style="padding: 8px"
-                >
-                    Sidepanel Template Body
-                </div>
-
-                @for (item of array; track item; let i = $index) {
-                    <div style="padding: 8px">
-                        {{ i + 1 }}
-                    </div>
-                }
-            </kbq-sidepanel-body>
-
-            <kbq-sidepanel-footer>
-                <kbq-sidepanel-actions align="left">
-                    <button
-                        [color]="'contrast'"
-                        cdkFocusInitial
-                        kbq-button
-                    >
-                        <span>Button</span>
-                    </button>
-                </kbq-sidepanel-actions>
-
-                <kbq-sidepanel-actions align="right">
-                    <span>Action</span>
-                </kbq-sidepanel-actions>
-            </kbq-sidepanel-footer>
-        </ng-template>
-    `
+    templateUrl: 'sidepanel-modal-mode-example.html',
+    imports: [KbqFormFieldModule, KbqSelectModule, KbqButtonModule, KbqSidepanelModule]
 })
 export class SidepanelModalModeExample {
     position = KbqSidepanelPosition.Right;

--- a/packages/docs-examples/components/sidepanel/sidepanel-normal-mode/sidepanel-normal-mode-example.html
+++ b/packages/docs-examples/components/sidepanel/sidepanel-normal-mode/sidepanel-normal-mode-example.html
@@ -1,0 +1,60 @@
+<div class="kbq-form-horizontal">
+    <div class="kbq-form__row">
+        <label class="kbq-form__label">Position</label>
+        <kbq-form-field
+            style="min-width: 120px"
+            class="kbq-form__control flex-10"
+        >
+            <kbq-select [(value)]="position">
+                <kbq-option [value]="'right'">Right</kbq-option>
+                <kbq-option [value]="'left'">Left</kbq-option>
+                <kbq-option [value]="'top'">Top</kbq-option>
+                <kbq-option [value]="'bottom'">Bottom</kbq-option>
+            </kbq-select>
+        </kbq-form-field>
+    </div>
+</div>
+
+<br />
+
+<button
+    kbq-button
+    [color]="'contrast'"
+    (click)="toggleSidepanel()"
+>
+    <span>{{ isOpened ? 'Close sidepanel' : 'Open sidepanel' }}</span>
+</button>
+
+<ng-template>
+    <kbq-sidepanel-header [closeable]="true">Sidepanel Template Content</kbq-sidepanel-header>
+    <kbq-sidepanel-body style="padding-top: 8px; padding-bottom: 8px">
+        <div
+            style="padding: 8px"
+            class="kbq-subheading"
+        >
+            Sidepanel Template Body
+        </div>
+
+        @for (item of array; track item; let i = $index) {
+            <div style="padding: 8px">
+                {{ i + 1 }}
+            </div>
+        }
+    </kbq-sidepanel-body>
+
+    <kbq-sidepanel-footer>
+        <kbq-sidepanel-actions align="left">
+            <button
+                cdkFocusInitial
+                kbq-button
+                [color]="'contrast'"
+            >
+                <span>Button</span>
+            </button>
+        </kbq-sidepanel-actions>
+
+        <kbq-sidepanel-actions align="right">
+            <span>Action</span>
+        </kbq-sidepanel-actions>
+    </kbq-sidepanel-footer>
+</ng-template>

--- a/packages/docs-examples/components/sidepanel/sidepanel-normal-mode/sidepanel-normal-mode-example.ts
+++ b/packages/docs-examples/components/sidepanel/sidepanel-normal-mode/sidepanel-normal-mode-example.ts
@@ -11,69 +11,8 @@ import { take } from 'rxjs/operators';
 @Component({
     standalone: true,
     selector: 'sidepanel-normal-mode-example',
-    imports: [KbqFormFieldModule, KbqSelectModule, KbqButtonModule, KbqSidepanelModule],
-    template: `
-        <div class="kbq-form-horizontal">
-            <div class="kbq-form__row">
-                <label class="kbq-form__label">Position</label>
-                <kbq-form-field
-                    class="kbq-form__control flex-10"
-                    style="min-width: 120px"
-                >
-                    <kbq-select [(value)]="position">
-                        <kbq-option [value]="'right'">Right</kbq-option>
-                        <kbq-option [value]="'left'">Left</kbq-option>
-                        <kbq-option [value]="'top'">Top</kbq-option>
-                        <kbq-option [value]="'bottom'">Bottom</kbq-option>
-                    </kbq-select>
-                </kbq-form-field>
-            </div>
-        </div>
-
-        <br />
-
-        <button
-            [color]="'contrast'"
-            (click)="toggleSidepanel()"
-            kbq-button
-        >
-            <span>{{ isOpened ? 'Close sidepanel' : 'Open sidepanel' }}</span>
-        </button>
-
-        <ng-template>
-            <kbq-sidepanel-header [closeable]="true">Sidepanel Template Content</kbq-sidepanel-header>
-            <kbq-sidepanel-body style="padding-top: 8px; padding-bottom: 8px">
-                <div
-                    class="kbq-subheading"
-                    style="padding: 8px"
-                >
-                    Sidepanel Template Body
-                </div>
-
-                @for (item of array; track item; let i = $index) {
-                    <div style="padding: 8px">
-                        {{ i + 1 }}
-                    </div>
-                }
-            </kbq-sidepanel-body>
-
-            <kbq-sidepanel-footer>
-                <kbq-sidepanel-actions align="left">
-                    <button
-                        [color]="'contrast'"
-                        cdkFocusInitial
-                        kbq-button
-                    >
-                        <span>Button</span>
-                    </button>
-                </kbq-sidepanel-actions>
-
-                <kbq-sidepanel-actions align="right">
-                    <span>Action</span>
-                </kbq-sidepanel-actions>
-            </kbq-sidepanel-footer>
-        </ng-template>
-    `
+    templateUrl: 'sidepanel-normal-mode-example.html',
+    imports: [KbqFormFieldModule, KbqSelectModule, KbqButtonModule, KbqSidepanelModule]
 })
 export class SidepanelNormalModeExample {
     position = KbqSidepanelPosition.Right;

--- a/packages/docs-examples/components/sidepanel/sidepanel-sizes/sidepanel-sizes-example.html
+++ b/packages/docs-examples/components/sidepanel/sidepanel-sizes/sidepanel-sizes-example.html
@@ -4,7 +4,7 @@
 >
     <button
         kbq-button
-        style="margin-bottom: 16px"
+        class="layout-margin-bottom-l"
         (click)="showSmall()"
     >
         Small
@@ -12,7 +12,7 @@
 
     <button
         kbq-button
-        style="margin-bottom: 16px"
+        class="layout-margin-bottom-l"
         (click)="showMedium()"
     >
         Medium

--- a/packages/docs-examples/components/sidepanel/sidepanel-sizes/sidepanel-sizes-example.html
+++ b/packages/docs-examples/components/sidepanel/sidepanel-sizes/sidepanel-sizes-example.html
@@ -1,0 +1,61 @@
+<div
+    style="width: 200px"
+    class="layout-column"
+>
+    <button
+        kbq-button
+        style="margin-bottom: 16px"
+        (click)="showSmall()"
+    >
+        Small
+    </button>
+
+    <button
+        kbq-button
+        style="margin-bottom: 16px"
+        (click)="showMedium()"
+    >
+        Medium
+    </button>
+
+    <button
+        kbq-button
+        (click)="showLarge()"
+    >
+        Large
+    </button>
+</div>
+
+<ng-template>
+    <kbq-sidepanel-header [closeable]="true">Sidepanel Template Content</kbq-sidepanel-header>
+    <kbq-sidepanel-body style="padding-top: 8px; padding-bottom: 8px">
+        <div
+            style="padding: 8px"
+            class="kbq-subheading"
+        >
+            Sidepanel Template Body
+        </div>
+
+        @for (item of array; track item; let i = $index) {
+            <div style="padding: 8px">
+                {{ i + 1 }}
+            </div>
+        }
+    </kbq-sidepanel-body>
+
+    <kbq-sidepanel-footer>
+        <kbq-sidepanel-actions align="left">
+            <button
+                cdkFocusInitial
+                kbq-button
+                [color]="'contrast'"
+            >
+                <span>Button</span>
+            </button>
+        </kbq-sidepanel-actions>
+
+        <kbq-sidepanel-actions align="right">
+            <span>Action</span>
+        </kbq-sidepanel-actions>
+    </kbq-sidepanel-footer>
+</ng-template>

--- a/packages/docs-examples/components/sidepanel/sidepanel-sizes/sidepanel-sizes-example.ts
+++ b/packages/docs-examples/components/sidepanel/sidepanel-sizes/sidepanel-sizes-example.ts
@@ -13,73 +13,11 @@ import {
 @Component({
     standalone: true,
     selector: 'sidepanel-sizes-example',
+    templateUrl: 'sidepanel-sizes-example.html',
     imports: [
         KbqButtonModule,
         KbqSidepanelModule
-    ],
-    template: `
-        <div
-            class="layout-column"
-            style="width: 200px"
-        >
-            <button
-                (click)="showSmall()"
-                kbq-button
-                style="margin-bottom: 16px"
-            >
-                Small
-            </button>
-
-            <button
-                (click)="showMedium()"
-                kbq-button
-                style="margin-bottom: 16px"
-            >
-                Medium
-            </button>
-
-            <button
-                (click)="showLarge()"
-                kbq-button
-            >
-                Large
-            </button>
-        </div>
-
-        <ng-template>
-            <kbq-sidepanel-header [closeable]="true">Sidepanel Template Content</kbq-sidepanel-header>
-            <kbq-sidepanel-body style="padding-top: 8px; padding-bottom: 8px">
-                <div
-                    class="kbq-subheading"
-                    style="padding: 8px"
-                >
-                    Sidepanel Template Body
-                </div>
-
-                @for (item of array; track item; let i = $index) {
-                    <div style="padding: 8px">
-                        {{ i + 1 }}
-                    </div>
-                }
-            </kbq-sidepanel-body>
-
-            <kbq-sidepanel-footer>
-                <kbq-sidepanel-actions align="left">
-                    <button
-                        [color]="'contrast'"
-                        cdkFocusInitial
-                        kbq-button
-                    >
-                        <span>Button</span>
-                    </button>
-                </kbq-sidepanel-actions>
-
-                <kbq-sidepanel-actions align="right">
-                    <span>Action</span>
-                </kbq-sidepanel-actions>
-            </kbq-sidepanel-footer>
-        </ng-template>
-    `
+    ]
 })
 export class SidepanelSizesExample {
     size = KbqSidepanelPosition.Right;

--- a/packages/docs-examples/components/tabs/tabs-actionbar/tabs-actionbar-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-actionbar/tabs-actionbar-example.ts
@@ -9,7 +9,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-actionbar-example',
-    styleUrls: ['tabs-actionbar-example.css'],
+    styleUrl: 'tabs-actionbar-example.css',
     imports: [
         KbqTabsModule,
         KbqButtonModule,

--- a/packages/docs-examples/components/tabs/tabs-actionbar/tabs-actionbar-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-actionbar/tabs-actionbar-example.ts
@@ -9,7 +9,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-actionbar-example',
-    styleUrl: 'tabs-actionbar-example.css',
+    styleUrls: ['tabs-actionbar-example.css'],
     imports: [
         KbqTabsModule,
         KbqButtonModule,

--- a/packages/docs-examples/components/tabs/tabs-custom/tabs-custom-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-custom/tabs-custom-example.ts
@@ -8,7 +8,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-custom-example',
-    styleUrl: 'tabs-custom-example.css',
+    styleUrls: ['tabs-custom-example.css'],
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-custom/tabs-custom-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-custom/tabs-custom-example.ts
@@ -8,7 +8,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-custom-example',
-    styleUrls: ['tabs-custom-example.css'],
+    styleUrl: 'tabs-custom-example.css',
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-disabled/tabs-disabled-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-disabled/tabs-disabled-example.ts
@@ -7,7 +7,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-disabled-example',
-    styleUrl: 'tabs-disabled-example.css',
+    styleUrls: ['tabs-disabled-example.css'],
     imports: [
         KbqTabsModule
     ],

--- a/packages/docs-examples/components/tabs/tabs-disabled/tabs-disabled-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-disabled/tabs-disabled-example.ts
@@ -7,7 +7,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-disabled-example',
-    styleUrls: ['tabs-disabled-example.css'],
+    styleUrl: 'tabs-disabled-example.css',
     imports: [
         KbqTabsModule
     ],

--- a/packages/docs-examples/components/tabs/tabs-empty/tabs-empty-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-empty/tabs-empty-example.ts
@@ -8,7 +8,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-empty-example',
-    styleUrls: ['tabs-empty-example.css'],
+    styleUrl: 'tabs-empty-example.css',
     imports: [
         KbqTabsModule
     ],

--- a/packages/docs-examples/components/tabs/tabs-empty/tabs-empty-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-empty/tabs-empty-example.ts
@@ -8,7 +8,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-empty-example',
-    styleUrl: 'tabs-empty-example.css',
+    styleUrls: ['tabs-empty-example.css'],
     imports: [
         KbqTabsModule
     ],

--- a/packages/docs-examples/components/tabs/tabs-underlined/tabs-underlined-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-underlined/tabs-underlined-example.ts
@@ -8,7 +8,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-underlined-example',
-    styleUrl: 'tabs-underlined-example.css',
+    styleUrls: ['tabs-underlined-example.css'],
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-underlined/tabs-underlined-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-underlined/tabs-underlined-example.ts
@@ -8,7 +8,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-underlined-example',
-    styleUrls: ['tabs-underlined-example.css'],
+    styleUrl: 'tabs-underlined-example.css',
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-vertical-icons/tabs-vertical-icons-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-vertical-icons/tabs-vertical-icons-example.ts
@@ -9,7 +9,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-vertical-icons-example',
-    styleUrls: ['tabs-vertical-icons-example.css'],
+    styleUrl: 'tabs-vertical-icons-example.css',
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-vertical-icons/tabs-vertical-icons-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-vertical-icons/tabs-vertical-icons-example.ts
@@ -9,7 +9,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-vertical-icons-example',
-    styleUrl: 'tabs-vertical-icons-example.css',
+    styleUrls: ['tabs-vertical-icons-example.css'],
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-vertical/tabs-vertical-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-vertical/tabs-vertical-example.ts
@@ -9,7 +9,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-vertical-example',
-    styleUrl: 'tabs-vertical-example.css',
+    styleUrls: ['tabs-vertical-example.css'],
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-vertical/tabs-vertical-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-vertical/tabs-vertical-example.ts
@@ -9,7 +9,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-vertical-example',
-    styleUrls: ['tabs-vertical-example.css'],
+    styleUrl: 'tabs-vertical-example.css',
     imports: [
         KbqTabsModule,
         KbqIconModule

--- a/packages/docs-examples/components/tabs/tabs-with-scroll-vertical/tabs-with-scroll-vertical-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-with-scroll-vertical/tabs-with-scroll-vertical-example.ts
@@ -7,7 +7,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-with-scroll-vertical-example',
-    styleUrls: ['tabs-with-scroll-vertical-example.css'],
+    styleUrl: 'tabs-with-scroll-vertical-example.css',
     imports: [KbqTabsModule],
     encapsulation: ViewEncapsulation.None,
     template: `

--- a/packages/docs-examples/components/tabs/tabs-with-scroll-vertical/tabs-with-scroll-vertical-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-with-scroll-vertical/tabs-with-scroll-vertical-example.ts
@@ -7,7 +7,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
 @Component({
     standalone: true,
     selector: 'tabs-with-scroll-vertical-example',
-    styleUrl: 'tabs-with-scroll-vertical-example.css',
+    styleUrls: ['tabs-with-scroll-vertical-example.css'],
     imports: [KbqTabsModule],
     encapsulation: ViewEncapsulation.None,
     template: `

--- a/packages/docs-examples/components/typography/typography-overview/typography-overview-example.css
+++ b/packages/docs-examples/components/typography/typography-overview/typography-overview-example.css
@@ -1,7 +1,0 @@
-small {
-    color: rgba(0, 0, 0, 0.3);
-}
-
-.typography-group {
-    margin-bottom: 20px;
-}

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -1212,7 +1212,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "HorizontalFormLabelsExample",
     "files": [
       "horizontal-form-labels-example.ts",
-      "horizontal-form-labels-example.html"
+      "horizontal-form-labels-example.html",
+      "horizontal-form-labels-example.css"
     ],
     "selector": "horizontal-form-labels-example",
     "additionalComponents": [],
@@ -1250,7 +1251,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Icon-item color",
     "componentName": "IconItemColorExample",
     "files": [
-      "icon-item-color-example.ts"
+      "icon-item-color-example.ts",
+      "icon-item-color-example.css"
     ],
     "selector": "icon-item-color-example",
     "additionalComponents": [],
@@ -1262,7 +1264,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Icon-item",
     "componentName": "IconItemDefaultExample",
     "files": [
-      "icon-item-default-example.ts"
+      "icon-item-default-example.ts",
+      "icon-item-default-example.css"
     ],
     "selector": "icon-item-default-example",
     "additionalComponents": [],
@@ -1274,7 +1277,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Icon-item size",
     "componentName": "IconItemSizeExample",
     "files": [
-      "icon-item-size-example.ts"
+      "icon-item-size-example.ts",
+      "icon-item-size-example.css"
     ],
     "selector": "icon-item-size-example",
     "additionalComponents": [],
@@ -1286,7 +1290,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Icon Item Variant",
     "componentName": "IconItemVariantExample",
     "files": [
-      "icon-item-variant-example.ts"
+      "icon-item-variant-example.ts",
+      "icon-item-variant-example.css"
     ],
     "selector": "icon-item-variant-example",
     "additionalComponents": [],
@@ -1334,7 +1339,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Layout-flex alignment",
     "componentName": "LayoutFlexAlignmentExample",
     "files": [
-      "layout-flex-alignment-example.ts"
+      "layout-flex-alignment-example.ts",
+      "layout-flex-alignment-example.css"
     ],
     "selector": "layout-flex-alignment-example",
     "additionalComponents": [],
@@ -1346,7 +1352,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Layout-flex behaviour modifiers",
     "componentName": "LayoutFlexBehaviourModifiersExample",
     "files": [
-      "layout-flex-behaviour-modifiers-example.ts"
+      "layout-flex-behaviour-modifiers-example.ts",
+      "layout-flex-behaviour-modifiers-example.css"
     ],
     "selector": "layout-flex-behaviour-modifiers-example",
     "additionalComponents": [],
@@ -1358,7 +1365,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Layout-flex offsets",
     "componentName": "LayoutFlexOffsetsExample",
     "files": [
-      "layout-flex-offsets-example.ts"
+      "layout-flex-offsets-example.ts",
+      "layout-flex-offsets-example.css"
     ],
     "selector": "layout-flex-offsets-example",
     "additionalComponents": [],
@@ -1370,7 +1378,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Layout-flex order",
     "componentName": "LayoutFlexOrderExample",
     "files": [
-      "layout-flex-order-example.ts"
+      "layout-flex-order-example.ts",
+      "layout-flex-order-example.css"
     ],
     "selector": "layout-flex-order-example",
     "additionalComponents": [],
@@ -1382,7 +1391,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Layout-flex",
     "componentName": "LayoutFlexOverviewExample",
     "files": [
-      "layout-flex-overview-example.ts"
+      "layout-flex-overview-example.ts",
+      "layout-flex-overview-example.css"
     ],
     "selector": "layout-flex-overview-example",
     "additionalComponents": [],
@@ -1418,7 +1428,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Link color",
     "componentName": "LinkColorExample",
     "files": [
-      "link-color-example.ts"
+      "link-color-example.ts",
+      "link-color-example.css"
     ],
     "selector": "link-color-example",
     "additionalComponents": [],
@@ -1671,7 +1682,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "MarkdownArticleExample",
     "files": [
       "markdown-article-example.ts",
-      "./markdown-article-example.html"
+      "./markdown-article-example.html",
+      "./markdown-article-example.css"
     ],
     "selector": "markdown-article-example",
     "additionalComponents": [],
@@ -1981,7 +1993,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "PopoverCloseExample",
     "files": [
       "popover-close-example.ts",
-      "popover-close-example.html"
+      "popover-close-example.html",
+      "popover-close-example.css"
     ],
     "selector": "popover-close-example",
     "additionalComponents": [],
@@ -2006,7 +2019,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "PopoverContentExample",
     "files": [
       "popover-content-example.ts",
-      "popover-content-example.html"
+      "popover-content-example.html",
+      "popover-content-example.css"
     ],
     "selector": "popover-content-example",
     "additionalComponents": [],
@@ -2313,7 +2327,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Sidepanel modal mode",
     "componentName": "SidepanelModalModeExample",
     "files": [
-      "sidepanel-modal-mode-example.ts"
+      "sidepanel-modal-mode-example.ts",
+      "sidepanel-modal-mode-example.html"
     ],
     "selector": "sidepanel-modal-mode-example",
     "additionalComponents": [],
@@ -2325,7 +2340,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Sidepanel normal mode",
     "componentName": "SidepanelNormalModeExample",
     "files": [
-      "sidepanel-normal-mode-example.ts"
+      "sidepanel-normal-mode-example.ts",
+      "sidepanel-normal-mode-example.html"
     ],
     "selector": "sidepanel-normal-mode-example",
     "additionalComponents": [],
@@ -2350,7 +2366,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Sidepanel sizes",
     "componentName": "SidepanelSizesExample",
     "files": [
-      "sidepanel-sizes-example.ts"
+      "sidepanel-sizes-example.ts",
+      "sidepanel-sizes-example.html"
     ],
     "selector": "sidepanel-sizes-example",
     "additionalComponents": [],
@@ -2483,7 +2500,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs actionbar",
     "componentName": "TabsActionbarExample",
     "files": [
-      "tabs-actionbar-example.ts"
+      "tabs-actionbar-example.ts",
+      "tabs-actionbar-example.css"
     ],
     "selector": "tabs-actionbar-example",
     "additionalComponents": [],
@@ -2495,7 +2513,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs custom",
     "componentName": "TabsCustomExample",
     "files": [
-      "tabs-custom-example.ts"
+      "tabs-custom-example.ts",
+      "tabs-custom-example.css"
     ],
     "selector": "tabs-custom-example",
     "additionalComponents": [],
@@ -2507,7 +2526,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs disabled",
     "componentName": "TabsDisabledExample",
     "files": [
-      "tabs-disabled-example.ts"
+      "tabs-disabled-example.ts",
+      "tabs-disabled-example.css"
     ],
     "selector": "tabs-disabled-example",
     "additionalComponents": [],
@@ -2519,7 +2539,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs empty",
     "componentName": "TabsEmptyExample",
     "files": [
-      "tabs-empty-example.ts"
+      "tabs-empty-example.ts",
+      "tabs-empty-example.css"
     ],
     "selector": "tabs-empty-example",
     "additionalComponents": [],
@@ -2555,7 +2576,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs underlined",
     "componentName": "TabsUnderlinedExample",
     "files": [
-      "tabs-underlined-example.ts"
+      "tabs-underlined-example.ts",
+      "tabs-underlined-example.css"
     ],
     "selector": "tabs-underlined-example",
     "additionalComponents": [],
@@ -2567,7 +2589,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs vertical icons",
     "componentName": "TabsVerticalIconsExample",
     "files": [
-      "tabs-vertical-icons-example.ts"
+      "tabs-vertical-icons-example.ts",
+      "tabs-vertical-icons-example.css"
     ],
     "selector": "tabs-vertical-icons-example",
     "additionalComponents": [],
@@ -2579,7 +2602,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs vertical",
     "componentName": "TabsVerticalExample",
     "files": [
-      "tabs-vertical-example.ts"
+      "tabs-vertical-example.ts",
+      "tabs-vertical-example.css"
     ],
     "selector": "tabs-vertical-example",
     "additionalComponents": [],
@@ -2591,7 +2615,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Tabs with scroll vertical",
     "componentName": "TabsWithScrollVerticalExample",
     "files": [
-      "tabs-with-scroll-vertical-example.ts"
+      "tabs-with-scroll-vertical-example.ts",
+      "tabs-with-scroll-vertical-example.css"
     ],
     "selector": "tabs-with-scroll-vertical-example",
     "additionalComponents": [],

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -213,8 +213,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Badge content",
     "componentName": "BadgeContentExample",
     "files": [
-      "badge-content-example.ts",
-      "badge-content-example.css"
+      "badge-content-example.ts"
     ],
     "selector": "badge-content-example",
     "additionalComponents": [],
@@ -253,8 +252,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Badge size",
     "componentName": "BadgeSizeExample",
     "files": [
-      "badge-size-example.ts",
-      "badge-size-example.css"
+      "badge-size-example.ts"
     ],
     "selector": "badge-size-example",
     "additionalComponents": [],
@@ -267,8 +265,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "BadgeTableExample",
     "files": [
       "badge-table-example.ts",
-      "badge-table-example.html",
-      "badge-table-example.css"
+      "badge-table-example.html"
     ],
     "selector": "badge-table-example",
     "additionalComponents": [],
@@ -463,8 +460,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "CheckboxOverviewExample",
     "files": [
       "checkbox-overview-example.ts",
-      "checkbox-overview-example.html",
-      "checkbox-overview-example.css"
+      "checkbox-overview-example.html"
     ],
     "selector": "checkbox-overview-example",
     "additionalComponents": [],
@@ -476,8 +472,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Pseudo checkbox",
     "componentName": "PseudoCheckboxExample",
     "files": [
-      "pseudo-checkbox-example.ts",
-      "pseudo-checkbox-example.css"
+      "pseudo-checkbox-example.ts"
     ],
     "selector": "pseudo-checkbox-example",
     "additionalComponents": [],

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -294,7 +294,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "ButtonToggleAlignmentOverviewExample",
     "files": [
       "button-toggle-alignment-overview-example.ts",
-      "button-toggle-alignment-overview-example.html"
+      "button-toggle-alignment-overview-example.html",
+      "button-toggle-alignment-overview-example.css"
     ],
     "selector": "button-toggle-alignment-overview-example",
     "additionalComponents": [],
@@ -345,7 +346,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button toggle tooltip",
     "componentName": "ButtonToggleTooltipOverviewExample",
     "files": [
-      "button-toggle-tooltip-overview-example.ts"
+      "button-toggle-tooltip-overview-example.ts",
+      "button-toggle-tooltip-overview-example.css"
     ],
     "selector": "button-toggle-tooltip-overview-example",
     "additionalComponents": [],
@@ -423,8 +425,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button loading state",
     "componentName": "ButtonLoadingStateExample",
     "files": [
-      "button-loading-state-example.ts",
-      "button-loading-state-example.css"
+      "button-loading-state-example.ts"
     ],
     "selector": "button-loading-state-example",
     "additionalComponents": [],

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -26,11 +26,12 @@ export interface LiveExample {
 export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   "accordion-content": {
     "packagePath": "components/accordion/accordion-content",
-    "title": "accordion-content",
+    "title": "Accordion content",
     "componentName": "AccordionContentExample",
     "files": [
       "accordion-content-example.ts",
-      "accordion-content-example.html"
+      "accordion-content-example.html",
+      "accordion-content-example.css"
     ],
     "selector": "accordion-content-example",
     "additionalComponents": [],
@@ -39,7 +40,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "accordion-header": {
     "packagePath": "components/accordion/accordion-header",
-    "title": "accordion-header",
+    "title": "Accordion header",
     "componentName": "AccordionHeaderExample",
     "files": [
       "accordion-header-example.ts",
@@ -52,7 +53,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "accordion-in-panel": {
     "packagePath": "components/accordion/accordion-in-panel",
-    "title": "accordion-in-panel",
+    "title": "Accordion in panel",
     "componentName": "AccordionInPanelExample",
     "files": [
       "accordion-in-panel-example.ts",
@@ -65,11 +66,12 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "accordion-in-section": {
     "packagePath": "components/accordion/accordion-in-section",
-    "title": "accordion-in-section",
+    "title": "Accordion in section",
     "componentName": "AccordionInSectionExample",
     "files": [
       "accordion-in-section-example.ts",
-      "accordion-in-section-example.html"
+      "accordion-in-section-example.html",
+      "accordion-in-section-example.css"
     ],
     "selector": "accordion-in-section-example",
     "additionalComponents": [],
@@ -78,7 +80,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "accordion-inactive-section": {
     "packagePath": "components/accordion/accordion-inactive-section",
-    "title": "accordion-inactive-section",
+    "title": "Accordion inactive section",
     "componentName": "AccordionInactiveSectionExample",
     "files": [
       "accordion-inactive-section-example.ts",
@@ -91,7 +93,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "accordion-overview": {
     "packagePath": "components/accordion/accordion-overview",
-    "title": "accordion-overview",
+    "title": "Accordion",
     "componentName": "AccordionOverviewExample",
     "files": [
       "accordion-overview-example.ts",
@@ -104,7 +106,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "accordion-sections": {
     "packagePath": "components/accordion/accordion-sections",
-    "title": "accordion-sections",
+    "title": "Accordion sections",
     "componentName": "AccordionSectionsExample",
     "files": [
       "accordion-sections-example.ts",
@@ -117,7 +119,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "accordion-states": {
     "packagePath": "components/accordion/accordion-states",
-    "title": "accordion-states",
+    "title": "Accordion states",
     "componentName": "AccordionStatesExample",
     "files": [
       "accordion-states-example.ts",
@@ -130,7 +132,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "alert-close": {
     "packagePath": "components/alert/alert-close",
-    "title": "Alert Close",
+    "title": "Alert close",
     "componentName": "AlertCloseExample",
     "files": [
       "alert-close-example.ts"
@@ -142,11 +144,12 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "alert-content": {
     "packagePath": "components/alert/alert-content",
-    "title": "Alert",
+    "title": "Alert content",
     "componentName": "AlertContentExample",
     "files": [
       "alert-content-example.ts",
-      "alert-content-example.html"
+      "alert-content-example.html",
+      "alert-content-example.css"
     ],
     "selector": "alert-content-example",
     "additionalComponents": [],
@@ -155,11 +158,12 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "alert-size": {
     "packagePath": "components/alert/alert-size",
-    "title": "Alert Size",
+    "title": "Alert size",
     "componentName": "AlertSizeExample",
     "files": [
       "alert-size-example.ts",
-      "alert-size-example.html"
+      "alert-size-example.html",
+      "alert-size-example.css"
     ],
     "selector": "alert-size-example",
     "additionalComponents": [],
@@ -168,7 +172,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "alert-status": {
     "packagePath": "components/alert/alert-status",
-    "title": "Alert Status",
+    "title": "Alert status",
     "componentName": "AlertStatusExample",
     "files": [
       "alert-status-example.ts",
@@ -181,10 +185,11 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "alert-variants": {
     "packagePath": "components/alert/alert-variants",
-    "title": "Alert Variants",
+    "title": "Alert variants",
     "componentName": "AlertVariantsExample",
     "files": [
-      "alert-variants-example.ts"
+      "alert-variants-example.ts",
+      "alert-variants-example.css"
     ],
     "selector": "alert-variants-example",
     "additionalComponents": [],
@@ -193,7 +198,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "autocomplete-overview": {
     "packagePath": "components/autocomplete/autocomplete-overview",
-    "title": "Basic Input",
+    "title": "Autocomplete",
     "componentName": "AutocompleteOverviewExample",
     "files": [
       "autocomplete-overview-example.ts"
@@ -352,7 +357,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button content",
     "componentName": "ButtonContentExample",
     "files": [
-      "button-content-example.ts"
+      "button-content-example.ts",
+      "button-content-example.css"
     ],
     "selector": "button-content-example",
     "additionalComponents": [],
@@ -365,7 +371,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "componentName": "ButtonFillAndStyleExample",
     "files": [
       "button-fill-and-style-example.ts",
-      "button-fill-and-style-example.html"
+      "button-fill-and-style-example.html",
+      "button-fill-and-style-example.css"
     ],
     "selector": "button-fill-and-style-example",
     "additionalComponents": [],
@@ -377,7 +384,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button fill content",
     "componentName": "ButtonFillContentExample",
     "files": [
-      "button-fill-content-example.ts"
+      "button-fill-content-example.ts",
+      "button-fill-content-example.css"
     ],
     "selector": "button-fill-content-example",
     "additionalComponents": [],
@@ -389,7 +397,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button fixed content",
     "componentName": "ButtonFixedContentExample",
     "files": [
-      "button-fixed-content-example.ts"
+      "button-fixed-content-example.ts",
+      "button-fixed-content-example.css"
     ],
     "selector": "button-fixed-content-example",
     "additionalComponents": [],
@@ -401,7 +410,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button hug content",
     "componentName": "ButtonHugContentExample",
     "files": [
-      "button-hug-content-example.ts"
+      "button-hug-content-example.ts",
+      "button-hug-content-example.css"
     ],
     "selector": "button-hug-content-example",
     "additionalComponents": [],
@@ -413,7 +423,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button loading state",
     "componentName": "ButtonLoadingStateExample",
     "files": [
-      "button-loading-state-example.ts"
+      "button-loading-state-example.ts",
+      "button-loading-state-example.css"
     ],
     "selector": "button-loading-state-example",
     "additionalComponents": [],
@@ -425,7 +436,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Button overview",
     "componentName": "ButtonOverviewExample",
     "files": [
-      "button-overview-example.ts"
+      "button-overview-example.ts",
+      "button-overview-example.css"
     ],
     "selector": "button-overview-example",
     "additionalComponents": [],

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -459,11 +459,12 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "checkbox-overview": {
     "packagePath": "components/checkbox/checkbox-overview",
-    "title": "Checkbox overview",
+    "title": "Checkbox",
     "componentName": "CheckboxOverviewExample",
     "files": [
       "checkbox-overview-example.ts",
-      "checkbox-overview-example.html"
+      "checkbox-overview-example.html",
+      "checkbox-overview-example.css"
     ],
     "selector": "checkbox-overview-example",
     "additionalComponents": [],
@@ -475,7 +476,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Pseudo checkbox",
     "componentName": "PseudoCheckboxExample",
     "files": [
-      "pseudo-checkbox-example.ts"
+      "pseudo-checkbox-example.ts",
+      "pseudo-checkbox-example.css"
     ],
     "selector": "pseudo-checkbox-example",
     "additionalComponents": [],
@@ -499,7 +501,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Code-block cut",
     "componentName": "CodeBlockCutExample",
     "files": [
-      "code-block-cut-example.ts"
+      "code-block-cut-example.ts",
+      "code-block-cut-example.css"
     ],
     "selector": "code-block-cut-example",
     "additionalComponents": [],
@@ -508,7 +511,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "code-block-line-numbers": {
     "packagePath": "components/code-block/code-block-line-numbers",
-    "title": "Basic code-block-line-numbers",
+    "title": "Code-block line numbers",
     "componentName": "CodeBlockLineNumbersExample",
     "files": [
       "code-block-line-numbers-example.ts"
@@ -520,7 +523,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "code-block-line-wrap": {
     "packagePath": "components/code-block/code-block-line-wrap",
-    "title": "Basic code-block-line-wrap",
+    "title": "Code-block line wrap",
     "componentName": "CodeBlockLineWrapExample",
     "files": [
       "code-block-line-wrap-example.ts"
@@ -532,10 +535,11 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "code-block-noborder": {
     "packagePath": "components/code-block/code-block-noborder",
-    "title": "Code block no border",
+    "title": "Code-block noborder",
     "componentName": "CodeBlockNoborderExample",
     "files": [
-      "code-block-noborder-example.ts"
+      "code-block-noborder-example.ts",
+      "code-block-noborder-example.css"
     ],
     "selector": "code-block-noborder-example",
     "additionalComponents": [],
@@ -583,7 +587,8 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "title": "Code-block tabs with overflow",
     "componentName": "CodeBlockTabsWithOverflowExample",
     "files": [
-      "code-block-tabs-with-overflow-example.ts"
+      "code-block-tabs-with-overflow-example.ts",
+      "code-block-tabs-with-overflow-example.css"
     ],
     "selector": "code-block-tabs-with-overflow-example",
     "additionalComponents": [],
@@ -975,7 +980,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-cva-overview": {
     "packagePath": "components/file-upload/file-upload-cva-overview",
-    "title": "File upload with Control Value Accessor",
+    "title": "File-upload with control value accessor",
     "componentName": "FileUploadCvaOverviewExample",
     "files": [
       "file-upload-cva-overview-example.ts"
@@ -987,7 +992,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-indeterminate-loading-overview": {
     "packagePath": "components/file-upload/file-upload-indeterminate-loading-overview",
-    "title": "File Upload Indeterminate Loading",
+    "title": "File-upload indeterminate loading",
     "componentName": "FileUploadIndeterminateLoadingOverviewExample",
     "files": [
       "file-upload-indeterminate-loading-overview-example.ts"
@@ -999,7 +1004,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-multiple-compact-overview": {
     "packagePath": "components/file-upload/file-upload-multiple-compact-overview",
-    "title": "File Upload Multiple Compact",
+    "title": "File-upload multiple compact",
     "componentName": "FileUploadMultipleCompactOverviewExample",
     "files": [
       "file-upload-multiple-compact-overview-example.ts"
@@ -1011,7 +1016,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-multiple-custom-text-overview": {
     "packagePath": "components/file-upload/file-upload-multiple-custom-text-overview",
-    "title": "file upload multiple custom text",
+    "title": "File-upload multiple custom text",
     "componentName": "FileUploadMultipleCustomTextOverviewExample",
     "files": [
       "file-upload-multiple-custom-text-overview-example.ts"
@@ -1023,7 +1028,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-multiple-default-overview": {
     "packagePath": "components/file-upload/file-upload-multiple-default-overview",
-    "title": "File Upload Multiple Default",
+    "title": "File-upload multiple default",
     "componentName": "FileUploadMultipleDefaultOverviewExample",
     "files": [
       "file-upload-multiple-default-overview-example.ts"
@@ -1035,7 +1040,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-multiple-default-validation-reactive-forms-overview": {
     "packagePath": "components/file-upload/file-upload-multiple-default-validation-reactive-forms-overview",
-    "title": "File Upload Multiple Default Validation Reactive Forms",
+    "title": "File-upload multiple default validation reactive forms",
     "componentName": "FileUploadMultipleDefaultValidationReactiveFormsOverviewExample",
     "files": [
       "file-upload-multiple-default-validation-reactive-forms-overview-example.ts"
@@ -1047,7 +1052,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-multiple-error-overview": {
     "packagePath": "components/file-upload/file-upload-multiple-error-overview",
-    "title": "file upload Multiple error",
+    "title": "File-upload multiple error",
     "componentName": "FileUploadMultipleErrorOverviewExample",
     "files": [
       "file-upload-multiple-error-overview-example.ts"
@@ -1059,7 +1064,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-single-error-overview": {
     "packagePath": "components/file-upload/file-upload-single-error-overview",
-    "title": "file upload single error",
+    "title": "File-upload single error",
     "componentName": "FileUploadSingleErrorOverviewExample",
     "files": [
       "file-upload-single-error-overview-example.ts"
@@ -1071,7 +1076,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-single-overview": {
     "packagePath": "components/file-upload/file-upload-single-overview",
-    "title": "File Upload Single",
+    "title": "File-upload single",
     "componentName": "FileUploadSingleOverviewExample",
     "files": [
       "file-upload-single-overview-example.ts"
@@ -1083,7 +1088,7 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
   },
   "file-upload-single-validation-reactive-forms-overview": {
     "packagePath": "components/file-upload/file-upload-single-validation-reactive-forms-overview",
-    "title": "File Upload Single Validation Reactive Forms",
+    "title": "File-upload single validation reactive forms",
     "componentName": "FileUploadSingleValidationReactiveFormsOverviewExample",
     "files": [
       "file-upload-single-validation-reactive-forms-overview-example.ts"


### PR DESCRIPTION
- removed encapsulation from all examples
- clear and fixes styles as array in all examples
- sidepanel examples templates
