### PR TITLE
fix(docs): missing icon in "badge content" example

### DIFF
--- a/packages/docs-examples/components/badge/badge-content/badge-content-example.ts
+++ b/packages/docs-examples/components/badge/badge-content/badge-content-example.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
+import { KbqIconModule } from '@koobiq/components/icon';
 
 /**
  * @title Badge content
@@ -8,7 +9,8 @@ import { KbqBadgeColors, KbqBadgeModule } from '@koobiq/components/badge';
     standalone: true,
     selector: 'badge-content-example',
     imports: [
-        KbqBadgeModule
+        KbqBadgeModule,
+        KbqIconModule
     ],
     template: `
         <div class="layout-row layout-gap-l">


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
-->

## Summary

Hi!

Noticed that icons were missing in docs for badge component ("badge content" section).

before:
![2024-11-21T20:59:23,526337605+05:00](https://github.com/user-attachments/assets/1b80650a-f669-48f6-b8d0-6b835712cab8)

after:
![2024-11-21T20:58:55,145359122+05:00](https://github.com/user-attachments/assets/f3623b00-3ae4-4205-ae6f-a445092d64a0)


## List of notable changes:

- **updated** documentation for "badge content" by adding import of `KbqIconModule`.

## What should reviewers focus on?
