### PR TITLE
chore(docs): increased docsearch container z-index, changed icon position for mobile

### DIFF
--- a/apps/docs/src/app/components/docsearch/docsearch.directive.ts
+++ b/apps/docs/src/app/components/docsearch/docsearch.directive.ts
@@ -11,7 +11,10 @@ const PROTOCOL = 'https:';
 /** Algolia DocSearch component implementation */
 @Directive({
     standalone: true,
-    selector: SELECTOR
+    selector: SELECTOR,
+    host: {
+        class: 'layout-align-center-center'
+    }
 })
 export class DocsearchDirective {
     private readonly DOCSEARCH_CONFIG: _DocSearchProps = {

--- a/apps/docs/src/styles/_docsearch.scss
+++ b/apps/docs/src/styles/_docsearch.scss
@@ -49,6 +49,9 @@
 }
 
 .DocSearch-Container {
+    // more than `.cdk-overlay-pane` z-index
+    z-index: 1001;
+
     @media (max-width: 768px) {
         display: flex;
         align-items: flex-end;


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/16691fb8-7d03-4486-8023-26b0fdf5e23e)

after:
![image](https://github.com/user-attachments/assets/fc8f458b-b19a-4bcd-a823-8babdacc8acb)

