### PR TITLE
fix(sidepanel): prevent capturing focus on initialization without backdrop (#DS-3073)

### DIFF
--- a/packages/components/sidepanel/sidepanel-config.ts
+++ b/packages/components/sidepanel/sidepanel-config.ts
@@ -20,6 +20,9 @@ export class KbqSidepanelConfig<D = any> {
     /** ID for the sidepanel. If omitted, a unique one will be generated. */
     id?: string;
 
+    /** capture focus on initialization. This option sets cdkTrapFocusAutoCapture. */
+    trapFocusAutoCapture?: boolean;
+
     /** Data being injected into the child component. */
     data?: D | null = null;
 

--- a/packages/components/sidepanel/sidepanel-container.component.html
+++ b/packages/components/sidepanel/sidepanel-container.component.html
@@ -3,7 +3,7 @@
         <div class="kbq-sidepanel-indent" (click)="exit()"></div>
     }
 
-    <div cdkTrapFocus cdkTrapFocusAutoCapture class="kbq-sidepanel-content">
+    <div cdkTrapFocus class="kbq-sidepanel-content" [cdkTrapFocusAutoCapture]="trapFocusAutoCapture">
         <ng-template cdkPortalOutlet />
     </div>
 </div>

--- a/packages/components/sidepanel/sidepanel-container.component.ts
+++ b/packages/components/sidepanel/sidepanel-container.component.ts
@@ -66,6 +66,10 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
         return `kbq-sidepanel_${this.sidepanelConfig.size}`;
     }
 
+    get trapFocusAutoCapture(): boolean {
+        return this.sidepanelConfig.trapFocusAutoCapture ?? !!this.sidepanelConfig.hasBackdrop;
+    }
+
     /** Whether the component has been destroyed. */
     private destroyed: boolean;
 

--- a/tools/public_api_guard/components/sidepanel.api.md
+++ b/tools/public_api_guard/components/sidepanel.api.md
@@ -95,6 +95,7 @@ export class KbqSidepanelConfig<D = any> {
     requiredBackdrop?: boolean;
     // (undocumented)
     size?: KbqSidepanelSize;
+    trapFocusAutoCapture?: boolean;
 }
 
 // @public (undocumented)
@@ -122,6 +123,8 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
     sidepanelConfig: KbqSidepanelConfig;
     // (undocumented)
     get size(): string;
+    // (undocumented)
+    get trapFocusAutoCapture(): boolean;
     // (undocumented)
     withIndent: boolean;
     // (undocumented)


### PR DESCRIPTION
По умолчанию отключил автоматический захват фокуса в "немодальном" режиме (при `backdrop = false`).
Так же добавил отдельный параметр `trapFocusAutoCapture` - по дефолту он не задан.