### PR TITLE
chore(docs): injected locale service for stackblitz example (#DS-3291)

### DIFF
--- a/apps/docs/src/assets/stackblitz/src/main.ts
+++ b/apps/docs/src/assets/stackblitz/src/main.ts
@@ -1,11 +1,12 @@
 import { provideHttpClient } from '@angular/common/http';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { KBQ_LOCALE_SERVICE, KbqLocaleService } from '@koobiq/components/core';
 import { KoobiqDocsExample } from './example/koobiq-docs-example';
 
 bootstrapApplication(KoobiqDocsExample, {
     providers: [
         provideAnimations(),
-        provideHttpClient()
-    ]
+        provideHttpClient(),
+        { provide: KBQ_LOCALE_SERVICE, useClass: KbqLocaleService }]
 }).catch((err) => console.error(err));


### PR DESCRIPTION


## Summary

Properly provided locale service, making it a singleton available throughout the application.