### PR TITLE
chore(docs,toast): fix toast examples (#DS-3328)

### DIFF
--- a/apps/docs/src/app/components/code-snippet/code-snippet.ts
+++ b/apps/docs/src/app/components/code-snippet/code-snippet.ts
@@ -1,11 +1,11 @@
 import { Clipboard } from '@angular/cdk/clipboard';
 import { Component, ElementRef, inject } from '@angular/core';
-import { KbqToastModule, KbqToastService } from '@koobiq/components/toast';
+import { KbqToastService } from '@koobiq/components/toast';
 import { DocsLocaleState } from 'src/app/services/locale';
 
 @Component({
     standalone: true,
-    imports: [KbqToastModule],
+    imports: [],
     template: ``,
     // @TODO should be renamed to `docsCodeSnippet`
     // eslint-disable-next-line @angular-eslint/component-selector

--- a/apps/docs/src/app/components/component-viewer/component-viewer.component.ts
+++ b/apps/docs/src/app/components/component-viewer/component-viewer.component.ts
@@ -15,6 +15,7 @@ import { ActivatedRoute, Router, RouterLink, RouterLinkActive, RouterOutlet, Url
 import { KbqModalModule, KbqModalService } from '@koobiq/components/modal';
 import { KbqSidepanelService } from '@koobiq/components/sidepanel';
 import { KbqTabsModule } from '@koobiq/components/tabs';
+import { KbqToastModule } from '@koobiq/components/toast';
 import { filter, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DocsLocaleState } from 'src/app/services/locale';
@@ -195,7 +196,9 @@ export class DocsCdkOverviewComponent extends BaseOverviewComponent {
     standalone: true,
     imports: [
         DocsAnchorsComponent,
-        DocsLiveExampleComponent
+        DocsLiveExampleComponent,
+        // Prevents: "NullInjectorError: No provider for InjectionToken KbqToastFactory"
+        KbqToastModule
     ],
     selector: 'docs-component-overview',
     templateUrl: './component-overview.template.html',
@@ -276,7 +279,9 @@ export class DocsCdkApiComponent extends BaseOverviewComponent {
     standalone: true,
     imports: [
         DocsExampleViewerComponent,
-        DocsAnchorsComponent
+        DocsAnchorsComponent,
+        // Prevents: "NullInjectorError: No provider for InjectionToken KbqToastFactory"
+        KbqToastModule
     ],
     selector: 'docs-component-examples',
     template: `

--- a/apps/docs/src/app/components/example-viewer/example-viewer.ts
+++ b/apps/docs/src/app/components/example-viewer/example-viewer.ts
@@ -16,6 +16,7 @@ import {
     ViewContainerRef
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+import { KbqToastModule } from '@koobiq/components/toast';
 import { Observable, Subscription } from 'rxjs';
 import { shareReplay, take, tap } from 'rxjs/operators';
 import { DocsLiveExampleViewerComponent } from '../live-example-viewer/docs-live-example-viewer';
@@ -39,7 +40,7 @@ export class DocFetcher {
 
 @Component({
     standalone: true,
-    imports: [],
+    imports: [KbqToastModule],
     selector: 'docs-example-viewer',
     template: `
         Loading document...

--- a/apps/docs/src/app/components/example-viewer/example-viewer.ts
+++ b/apps/docs/src/app/components/example-viewer/example-viewer.ts
@@ -16,7 +16,6 @@ import {
     ViewContainerRef
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { KbqToastModule } from '@koobiq/components/toast';
 import { Observable, Subscription } from 'rxjs';
 import { shareReplay, take, tap } from 'rxjs/operators';
 import { DocsLiveExampleViewerComponent } from '../live-example-viewer/docs-live-example-viewer';
@@ -40,7 +39,7 @@ export class DocFetcher {
 
 @Component({
     standalone: true,
-    imports: [KbqToastModule],
+    imports: [],
     selector: 'docs-example-viewer',
     template: `
         Loading document...

--- a/apps/docs/src/app/components/live-example/docs-live-example.ts
+++ b/apps/docs/src/app/components/live-example/docs-live-example.ts
@@ -18,6 +18,7 @@ import {
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { KbqCodeBlockModule } from '@koobiq/components/code-block';
+import { KbqToastModule } from '@koobiq/components/toast';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 import { Observable, Subscription } from 'rxjs';
 import { shareReplay, take, tap } from 'rxjs/operators';
@@ -31,6 +32,7 @@ import { DocsLiveExampleViewerComponent } from '../live-example-viewer/docs-live
         KbqCodeBlockModule,
         DocsCodeSnippetComponent,
         KbqToolTipModule,
+        KbqToastModule,
         CdkPortal
     ],
     selector: 'docs-live-example',

--- a/packages/docs-examples/components/toast/toast-user-data/toast-user-data-example.ts
+++ b/packages/docs-examples/components/toast/toast-user-data/toast-user-data-example.ts
@@ -1,7 +1,7 @@
 import { Component, inject, TemplateRef } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqLinkModule } from '@koobiq/components/link';
-import { KbqToastData, KbqToastModule, KbqToastService, KbqToastStyle } from '@koobiq/components/toast';
+import { KbqToastData, KbqToastService, KbqToastStyle } from '@koobiq/components/toast';
 
 /**
  * @title Toast user data
@@ -11,8 +11,7 @@ import { KbqToastData, KbqToastModule, KbqToastService, KbqToastStyle } from '@k
     selector: 'toast-user-data-example',
     imports: [
         KbqLinkModule,
-        KbqButtonModule,
-        KbqToastModule
+        KbqButtonModule
     ],
     templateUrl: 'toast-user-data-example.html'
 })


### PR DESCRIPTION

## Summary

Added import for `KbqToastModule` for Examples tab , rendered with `DocsComponentExamplesComponent` 
