### PR TITLE
feat(visual): removed legacy styling from optgroup-label (#DS-2652)

### DIFF
--- a/packages/components-dev/dropdown/module.ts
+++ b/packages/components-dev/dropdown/module.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { KbqButtonModule, KbqButtonStyles } from '@koobiq/components/button';
-import { KbqComponentColors } from '@koobiq/components/core';
+import { KbqComponentColors, KbqOptionModule } from '@koobiq/components/core';
 import { KbqDividerModule } from '@koobiq/components/divider';
 import { KbqDropdownModule } from '@koobiq/components/dropdown';
 import { KbqIconModule } from '@koobiq/components/icon';
@@ -67,7 +67,8 @@ export class DemoComponent {
         KbqButtonModule,
         KbqDropdownModule,
         KbqTitleModule,
-        KbqDividerModule
+        KbqDividerModule,
+        KbqOptionModule
     ],
     bootstrap: [
         DemoComponent

--- a/packages/components-dev/dropdown/template.html
+++ b/packages/components-dev/dropdown/template.html
@@ -94,7 +94,7 @@
 
         <kbq-divider />
 
-        <div class="kbq-dropdown__group-header kbq-dropdown__group-header_small">Subheading</div>
+        <kbq-optgroup label="Subheading" />
 
         <button disabled kbq-dropdown-item>Disabled</button>
 

--- a/packages/components/core/option/_optgroup-theme.scss
+++ b/packages/components/core/option/_optgroup-theme.scss
@@ -1,17 +1,18 @@
-@use '../styles/common/tokens' as *;
+@use '../styles/common/tokens';
 
 @mixin kbq-optgroup-theme() {
     .kbq-optgroup-label {
-        color: var(--kbq-foreground-contrast);
+        --kbq-optgroup-label-color: var(--kbq-foreground-contrast-secondary);
+        color: var(--kbq-optgroup-label-color);
     }
 
     .kbq-disabled .kbq-optgroup-label {
-        color: var(--kbq-states-foreground-disabled);
+        --kbq-optgroup-label-color: var(--kbq-states-foreground-disabled);
     }
 }
 
 @mixin kbq-optgroup-typography() {
     .kbq-optgroup-label {
-        @include kbq-typography-level-to-styles-css-variables(typography, subheading);
+        @include tokens.kbq-typography-level-to-styles-css-variables(typography, caps-compact-strong);
     }
 }

--- a/packages/components/core/option/optgroup.scss
+++ b/packages/components/core/option/optgroup.scss
@@ -4,7 +4,10 @@
 @use './optgroup-theme' as *;
 
 .kbq-optgroup-label {
-    padding-left: var(--kbq-size-m);
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    padding: var(--kbq-size-s) var(--kbq-size-l) var(--kbq-size-s) var(--kbq-size-m);
 
     @include vendor-prefixes.user-select(none);
     cursor: default;

--- a/packages/components/core/option/optgroup.ts
+++ b/packages/components/core/option/optgroup.ts
@@ -10,6 +10,7 @@ let uniqueOptgroupIdCounter = 0;
 
 /**
  * Component that is used to group instances of `kbq-option`.
+ * When options aren't provided as `ng-content`, used as a Group Header with styling.
  */
 @Component({
     selector: 'kbq-optgroup',

--- a/packages/components/dropdown/_dropdown-theme.scss
+++ b/packages/components/dropdown/_dropdown-theme.scss
@@ -56,6 +56,7 @@
     }
 
     .kbq-dropdown__group-header {
+        // @deprecated, use <kbq-optgroup label="Label" /> instead. Will be removed in the next major release
         &.kbq-dropdown__group-header_small {
             color: var(--kbq-foreground-contrast-secondary);
         }
@@ -79,6 +80,7 @@
     .kbq-dropdown__group-header {
         @include kbq-typography-level-to-styles-css-variables(typography, big-strong);
 
+        // @deprecated, use <kbq-optgroup label="Label" /> instead. Will be removed in the next major release
         &.kbq-dropdown__group-header_small {
             @include kbq-typography-level-to-styles-css-variables(typography, caps-compact-strong);
         }

--- a/packages/components/dropdown/dropdown-item.scss
+++ b/packages/components/dropdown/dropdown-item.scss
@@ -45,6 +45,7 @@
     @include common.user-select(none);
     @include common.kbq-list-header-base();
 
+    // @deprecated, use <kbq-optgroup label="Label" /> instead. Will be removed in the next major release
     &.kbq-dropdown__group-header_small {
         @include common.kbq-list-subheading-base();
     }

--- a/packages/components/select/select.component.karma-spec.ts
+++ b/packages/components/select/select.component.karma-spec.ts
@@ -77,6 +77,10 @@ function finishInit(fixture: ComponentFixture<any>) {
     fixture.autoDetectChanges();
 }
 
+const OPTGROUP_HEIGHT = 32;
+
+const DEFAULT_OPTION_HEIGHT = 32;
+
 /** The debounce interval when typing letters to select an option. */
 const LETTER_KEY_DEBOUNCE_INTERVAL = 200;
 
@@ -695,6 +699,12 @@ describe(KbqSelect.name, () => {
 
             it('should skip option group labels', fakeAsync(() => {
                 fixture.destroy();
+                const GROUPS_SKIPPED_COUNT = 2;
+                const OPTIONS_SKIPPED_COUNT = 3;
+                const EXPECTED_SCROLL_TOP =
+                    GROUPS_SKIPPED_COUNT * OPTGROUP_HEIGHT +
+                    OPTIONS_SKIPPED_COUNT * DEFAULT_OPTION_HEIGHT +
+                    DEFAULT_OPTION_HEIGHT / 2;
 
                 const groupFixture = TestBed.createComponent(SelectWithGroups);
 
@@ -713,7 +723,13 @@ describe(KbqSelect.name, () => {
 
                 // Note that we press down 5 times, but it will skip
                 // 3 options because the second group is disabled.
-                expect(Math.floor(panel.scrollTop)).withContext('Expected scroll to be at the 9th option.').toBe(158);
+                expect(Math.floor(panel.scrollTop))
+                    .withContext('Expected to place active option in the middle of overlay.')
+                    .toBe(EXPECTED_SCROLL_TOP);
+
+                expect(groupFixture.componentInstance.select.keyManager.activeItemIndex)
+                    .withContext('Expected scroll to be at the 9th option')
+                    .toBe(8);
             }));
 
             it('should scroll top the top when pressing HOME', fakeAsync(() => {

--- a/packages/docs-examples/components/dropdown/dropdown-disabled/dropdown-disabled-example.html
+++ b/packages/docs-examples/components/dropdown/dropdown-disabled/dropdown-disabled-example.html
@@ -42,7 +42,7 @@
 
     <kbq-divider />
 
-    <div class="kbq-dropdown__group-header kbq-dropdown__group-header_small">Subheading</div>
+    <kbq-optgroup label="Subheading" />
 
     <button disabled kbq-dropdown-item>
         <i kbq-icon="kbq-circle-xs_16" [color]="'contrast'"></i>

--- a/packages/docs-examples/components/dropdown/dropdown-disabled/dropdown-disabled-example.ts
+++ b/packages/docs-examples/components/dropdown/dropdown-disabled/dropdown-disabled-example.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqCheckboxModule } from '@koobiq/components/checkbox';
+import { KbqOptionModule } from '@koobiq/components/core';
 import { KbqDividerModule } from '@koobiq/components/divider';
 import { KbqDropdownModule } from '@koobiq/components/dropdown';
 import { KbqIconModule } from '@koobiq/components/icon';
@@ -20,7 +21,8 @@ import { KbqTitleModule } from '@koobiq/components/title';
         KbqDividerModule,
         KbqButtonModule,
         KbqIconModule,
-        KbqTitleModule
+        KbqTitleModule,
+        KbqOptionModule
     ],
     templateUrl: 'dropdown-disabled-example.html'
 })

--- a/packages/docs-examples/components/dropdown/dropdown-navigation-wrap/dropdown-navigation-wrap-example.html
+++ b/packages/docs-examples/components/dropdown/dropdown-navigation-wrap/dropdown-navigation-wrap-example.html
@@ -40,7 +40,7 @@
 
     <kbq-divider />
 
-    <div class="kbq-dropdown__group-header kbq-dropdown__group-header_small">Subheading</div>
+    <kbq-optgroup label="Subheading" />
 
     <button disabled kbq-dropdown-item>Disabled</button>
 

--- a/packages/docs-examples/components/dropdown/dropdown-navigation-wrap/dropdown-navigation-wrap-example.ts
+++ b/packages/docs-examples/components/dropdown/dropdown-navigation-wrap/dropdown-navigation-wrap-example.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
+import { KbqOptionModule } from '@koobiq/components/core';
 import { KbqDividerModule } from '@koobiq/components/divider';
 import { KbqDropdownModule } from '@koobiq/components/dropdown';
 import { KbqIconModule } from '@koobiq/components/icon';
@@ -14,7 +15,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
         KbqDropdownModule,
         KbqButtonModule,
         KbqIconModule,
-        KbqDividerModule
+        KbqDividerModule,
+        KbqOptionModule
     ],
     templateUrl: 'dropdown-navigation-wrap-example.html'
 })

--- a/packages/docs-examples/components/dropdown/dropdown-open-by-arrowdown/dropdown-open-by-arrow-down-example.html
+++ b/packages/docs-examples/components/dropdown/dropdown-open-by-arrowdown/dropdown-open-by-arrow-down-example.html
@@ -42,7 +42,7 @@
 
     <kbq-divider />
 
-    <div class="kbq-dropdown__group-header kbq-dropdown__group-header_small">Subheading</div>
+    <kbq-optgroup label="Subheading" />
 
     <button disabled kbq-dropdown-item>
         <i kbq-icon="kbq-circle-xs_16" [color]="'contrast'"></i>

--- a/packages/docs-examples/components/dropdown/dropdown-open-by-arrowdown/dropdown-open-by-arrow-down-example.ts
+++ b/packages/docs-examples/components/dropdown/dropdown-open-by-arrowdown/dropdown-open-by-arrow-down-example.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqCheckboxModule } from '@koobiq/components/checkbox';
+import { KbqOptionModule } from '@koobiq/components/core';
 import { KbqDividerModule } from '@koobiq/components/divider';
 import { KbqDropdownModule } from '@koobiq/components/dropdown';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
@@ -24,7 +25,8 @@ import { KbqTitleModule } from '@koobiq/components/title';
         KbqIconModule,
         KbqTitleModule,
         KbqFormFieldModule,
-        KbqInputModule
+        KbqInputModule,
+        KbqOptionModule
     ],
     templateUrl: 'dropdown-open-by-arrow-down-example.html'
 })

--- a/packages/docs-examples/components/dropdown/dropdown-overview/dropdown-overview-example.html
+++ b/packages/docs-examples/components/dropdown/dropdown-overview/dropdown-overview-example.html
@@ -40,7 +40,7 @@
 
     <kbq-divider />
 
-    <div class="kbq-dropdown__group-header kbq-dropdown__group-header_small">Subheading</div>
+    <kbq-optgroup label="Subheading" />
 
     <button disabled kbq-dropdown-item>
         <i kbq-icon="kbq-circle-xs_16" [color]="'contrast'"></i>

--- a/packages/docs-examples/components/dropdown/dropdown-overview/dropdown-overview-example.ts
+++ b/packages/docs-examples/components/dropdown/dropdown-overview/dropdown-overview-example.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
+import { KbqOptionModule } from '@koobiq/components/core';
 import { KbqDividerModule } from '@koobiq/components/divider';
 import { KbqDropdownModule } from '@koobiq/components/dropdown';
 import { KbqIconModule } from '@koobiq/components/icon';
@@ -16,7 +17,8 @@ import { KbqTitleModule } from '@koobiq/components/title';
         KbqDividerModule,
         KbqButtonModule,
         KbqIconModule,
-        KbqTitleModule
+        KbqTitleModule,
+        KbqOptionModule
     ],
     templateUrl: 'dropdown-overview-example.html'
 })

--- a/packages/docs-examples/components/list/list-groups/list-groups-example.ts
+++ b/packages/docs-examples/components/list/list-groups/list-groups-example.ts
@@ -10,51 +10,51 @@ import { KbqListModule } from '@koobiq/components/list';
     imports: [KbqListModule],
     template: `
         <kbq-list-selection>
-            @for (group of pokemonTypes; track group) {
-                <kbq-optgroup [disabled]="group.disabled" [label]="group.name">
-                    @for (pokemon of group.pokemon; track pokemon) {
-                        <kbq-list-option [value]="pokemon.value">
-                            {{ pokemon.viewValue }}
+            @for (category of securityCategories; track category) {
+                <kbq-optgroup [disabled]="category.disabled" [label]="category.categoryName">
+                    @for (securityItem of category.securityItems; track securityItem.id) {
+                        <kbq-list-option [value]="securityItem.id">
+                            {{ securityItem.displayName }}
                         </kbq-list-option>
                     }
                 </kbq-optgroup>
             }
-            <kbq-list-option [value]="'mime-11'">Mr. Mime</kbq-list-option>
+            <kbq-list-option [value]="'rbac-11'">Role-Based Access Control (RBAC)</kbq-list-option>
         </kbq-list-selection>
     `
 })
 export class ListGroupsExample {
-    pokemonTypes = [
+    securityCategories = [
         {
-            name: 'Grass',
-            pokemon: [
-                { value: 'bulbasaur-0', viewValue: 'Bulbasaur' },
-                { value: 'oddish-1', viewValue: 'Oddish' },
-                { value: 'bellsprout-2', viewValue: 'Bellsprout' }
+            categoryName: 'Network Security',
+            securityItems: [
+                { id: 'firewall-0', displayName: 'Firewall' },
+                { id: 'vpn-1', displayName: 'Virtual Private Network (VPN)' },
+                { id: 'ids-2', displayName: 'Intrusion Detection System (IDS)' }
             ]
         },
         {
-            name: 'Water',
+            categoryName: 'Application Security',
             disabled: true,
-            pokemon: [
-                { value: 'squirtle-3', viewValue: 'Squirtle' },
-                { value: 'psyduck-4', viewValue: 'Psyduck' },
-                { value: 'horsea-5', viewValue: 'Horsea' }
+            securityItems: [
+                { id: 'sast-3', displayName: 'Static Application Security Testing (SAST)' },
+                { id: 'owasp-4', displayName: 'OWASP Top 10' },
+                { id: 'code-review-5', displayName: 'Code Review' }
             ]
         },
         {
-            name: 'Fire',
-            pokemon: [
-                { value: 'charmander-6', viewValue: 'Charmander' },
-                { value: 'vulpix-7', viewValue: 'Vulpix' },
-                { value: 'flareon-8', viewValue: 'Flareon' }
+            categoryName: 'Cloud Security',
+            securityItems: [
+                { id: 'iam-6', displayName: 'Identity and Access Management (IAM)' },
+                { id: 'cspm-7', displayName: 'Cloud Security Posture Management (CSPM)' },
+                { id: 'casb-8', displayName: 'Cloud Access Security Broker (CASB)' }
             ]
         },
         {
-            name: 'Psychic',
-            pokemon: [
-                { value: 'mew-9', viewValue: 'Mew' },
-                { value: 'mewtwo-10', viewValue: 'Mewtwo' }
+            categoryName: 'Endpoint Security',
+            securityItems: [
+                { id: 'antivirus-9', displayName: 'Antivirus' },
+                { id: 'edr-10', displayName: 'Endpoint Detection and Response (EDR)' }
             ]
         }
     ];

--- a/packages/docs-examples/components/select/select-disabled/select-disabled-example.html
+++ b/packages/docs-examples/components/select/select-disabled/select-disabled-example.html
@@ -25,17 +25,17 @@
 <div class="layout-row example-row">
     <div class="kbq-form__label">Для групп</div>
     <kbq-form-field>
-        <kbq-select [value]="pokemonTypes[0].pokemon[0].value">
-            @for (group of pokemonTypes; track group) {
-                <kbq-optgroup [disabled]="group.disabled" [label]="group.name">
-                    @for (pokemon of group.pokemon; track pokemon) {
-                        <kbq-option [value]="pokemon.value">
-                            {{ pokemon.viewValue }}
+        <kbq-select [(value)]="securityCategories[0].securityItems[0].id">
+            @for (category of securityCategories; track category) {
+                <kbq-optgroup [disabled]="category.disabled" [label]="category.categoryName">
+                    @for (securityItem of category.securityItems; track securityItem.id) {
+                        <kbq-option [value]="securityItem.id">
+                            {{ securityItem.displayName }}
                         </kbq-option>
                     }
                 </kbq-optgroup>
             }
-            <kbq-option [value]="'mime-11'">Mr. Mime</kbq-option>
+            <kbq-option [value]="'rbac-11'">Role-Based Access Control (RBAC)</kbq-option>
         </kbq-select>
     </kbq-form-field>
 </div>

--- a/packages/docs-examples/components/select/select-disabled/select-disabled-example.ts
+++ b/packages/docs-examples/components/select/select-disabled/select-disabled-example.ts
@@ -48,37 +48,37 @@ const localeDataSet = {
     `
 })
 export class SelectDisabledExample {
-    pokemonTypes = [
+    securityCategories = [
         {
-            name: 'Grass',
-            pokemon: [
-                { value: 'bulbasaur-0', viewValue: 'Bulbasaur' },
-                { value: 'oddish-1', viewValue: 'Oddish' },
-                { value: 'bellsprout-2', viewValue: 'Bellsprout' }
+            categoryName: 'Network Security',
+            securityItems: [
+                { id: 'firewall-0', displayName: 'Firewall' },
+                { id: 'vpn-1', displayName: 'Virtual Private Network (VPN)' },
+                { id: 'ids-2', displayName: 'Intrusion Detection System (IDS)' }
             ]
         },
         {
-            name: 'Water',
+            categoryName: 'Application Security',
             disabled: true,
-            pokemon: [
-                { value: 'squirtle-3', viewValue: 'Squirtle' },
-                { value: 'psyduck-4', viewValue: 'Psyduck' },
-                { value: 'horsea-5', viewValue: 'Horsea' }
+            securityItems: [
+                { id: 'sast-3', displayName: 'Static Application Security Testing (SAST)' },
+                { id: 'owasp-4', displayName: 'OWASP Top 10' },
+                { id: 'code-review-5', displayName: 'Code Review' }
             ]
         },
         {
-            name: 'Fire',
-            pokemon: [
-                { value: 'charmander-6', viewValue: 'Charmander' },
-                { value: 'vulpix-7', viewValue: 'Vulpix' },
-                { value: 'flareon-8', viewValue: 'Flareon' }
+            categoryName: 'Cloud Security',
+            securityItems: [
+                { id: 'iam-6', displayName: 'Identity and Access Management (IAM)' },
+                { id: 'cspm-7', displayName: 'Cloud Security Posture Management (CSPM)' },
+                { id: 'casb-8', displayName: 'Cloud Access Security Broker (CASB)' }
             ]
         },
         {
-            name: 'Psychic',
-            pokemon: [
-                { value: 'mew-9', viewValue: 'Mew' },
-                { value: 'mewtwo-10', viewValue: 'Mewtwo' }
+            categoryName: 'Endpoint Security',
+            securityItems: [
+                { id: 'antivirus-9', displayName: 'Antivirus' },
+                { id: 'edr-10', displayName: 'Endpoint Detection and Response (EDR)' }
             ]
         }
     ];

--- a/packages/docs-examples/components/select/select-groups/select-groups-example.ts
+++ b/packages/docs-examples/components/select/select-groups/select-groups-example.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
+import { KbqListModule } from '@koobiq/components/list';
 import { KbqSelectModule } from '@koobiq/components/select';
 
 /**
@@ -8,21 +9,21 @@ import { KbqSelectModule } from '@koobiq/components/select';
 @Component({
     standalone: true,
     selector: 'select-groups-example',
-    imports: [KbqFormFieldModule, KbqSelectModule],
+    imports: [KbqFormFieldModule, KbqSelectModule, KbqListModule],
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="pokemonTypes[0].pokemon[0].value">
-                @for (group of pokemonTypes; track group) {
-                    <kbq-optgroup [disabled]="group.disabled" [label]="group.name">
-                        @for (pokemon of group.pokemon; track pokemon) {
-                            <kbq-option [value]="pokemon.value">
-                                {{ pokemon.viewValue }}
+            <kbq-select [(value)]="securityCategories[0].securityItems[0].id">
+                @for (category of securityCategories; track category) {
+                    <kbq-optgroup [disabled]="category.disabled" [label]="category.categoryName">
+                        @for (securityItem of category.securityItems; track securityItem.id) {
+                            <kbq-option [value]="securityItem.id">
+                                {{ securityItem.displayName }}
                             </kbq-option>
                         }
                     </kbq-optgroup>
                 }
-                <kbq-option [value]="'mime-11'">Mr. Mime</kbq-option>
+                <kbq-option [value]="'rbac-11'">Role-Based Access Control (RBAC)</kbq-option>
             </kbq-select>
         </kbq-form-field>
     `,
@@ -39,37 +40,37 @@ import { KbqSelectModule } from '@koobiq/components/select';
     `
 })
 export class SelectGroupsExample {
-    pokemonTypes = [
+    securityCategories = [
         {
-            name: 'Grass',
-            pokemon: [
-                { value: 'bulbasaur-0', viewValue: 'Bulbasaur' },
-                { value: 'oddish-1', viewValue: 'Oddish' },
-                { value: 'bellsprout-2', viewValue: 'Bellsprout' }
+            categoryName: 'Network Security',
+            securityItems: [
+                { id: 'firewall-0', displayName: 'Firewall' },
+                { id: 'vpn-1', displayName: 'Virtual Private Network (VPN)' },
+                { id: 'ids-2', displayName: 'Intrusion Detection System (IDS)' }
             ]
         },
         {
-            name: 'Water',
+            categoryName: 'Application Security',
             disabled: true,
-            pokemon: [
-                { value: 'squirtle-3', viewValue: 'Squirtle' },
-                { value: 'psyduck-4', viewValue: 'Psyduck' },
-                { value: 'horsea-5', viewValue: 'Horsea' }
+            securityItems: [
+                { id: 'sast-3', displayName: 'Static Application Security Testing (SAST)' },
+                { id: 'owasp-4', displayName: 'OWASP Top 10' },
+                { id: 'code-review-5', displayName: 'Code Review' }
             ]
         },
         {
-            name: 'Fire',
-            pokemon: [
-                { value: 'charmander-6', viewValue: 'Charmander' },
-                { value: 'vulpix-7', viewValue: 'Vulpix' },
-                { value: 'flareon-8', viewValue: 'Flareon' }
+            categoryName: 'Cloud Security',
+            securityItems: [
+                { id: 'iam-6', displayName: 'Identity and Access Management (IAM)' },
+                { id: 'cspm-7', displayName: 'Cloud Security Posture Management (CSPM)' },
+                { id: 'casb-8', displayName: 'Cloud Access Security Broker (CASB)' }
             ]
         },
         {
-            name: 'Psychic',
-            pokemon: [
-                { value: 'mew-9', viewValue: 'Mew' },
-                { value: 'mewtwo-10', viewValue: 'Mewtwo' }
+            categoryName: 'Endpoint Security',
+            securityItems: [
+                { id: 'antivirus-9', displayName: 'Antivirus' },
+                { id: 'edr-10', displayName: 'Endpoint Detection and Response (EDR)' }
             ]
         }
     ];


### PR DESCRIPTION
## Summary
  
  - Updated label styles inside the `kbq-optgroup` component.  
  - Since the styles for the `.kbq-dropdown__group-header.kbq-dropdown__group-header_small` subtitle and the `kbq-optgroup` component are identical, I suggested using the latter as it's simpler. Marked the subtitle styles as `deprecated` and updated the examples.  
  - Changed the example data with groups, replacing Pokémon with Information Security concepts (finally 🙂).  

<details>
  <summary>ru-RU description</summary>
  
  - Обновил стили лейбла внутри компонента `kbq-optgroup`.
  - Так как стили подзаголовка `.kbq-dropdown__group-header.kbq-dropdown__group-header_small` и компонента `kbq-optgroup` одинаковые, предложил использовать последний, так как он попроще. Пометил стили подзаголовка как `deprecated` и изменил примеры.
  - Изменил данные в примерах с группами, поменял покемонов на ИБ понятия (finally 🙂)
</details>

