### PR TITLE
feat(visual): border-radius in сombobox options (#DS-3290)

### DIFF
--- a/packages/components/core/option/option-tokens.scss
+++ b/packages/components/core/option/option-tokens.scss
@@ -4,6 +4,7 @@
     --kbq-option-size-horizontal-padding: var(--kbq-size-m);
     --kbq-option-size-height: var(--kbq-size-3xl);
     --kbq-option-size-border-width: 2px;
+    --kbq-option-border-radius: var(--kbq-size-xs);
     /* LIST THEME TOKENS */
     @include list-tokens.list-theme-tokens;
 }

--- a/packages/components/core/option/option.scss
+++ b/packages/components/core/option/option.scss
@@ -4,6 +4,7 @@
 
 .kbq-option {
     @include common.kbq-list-item-base();
+    border-radius: var(--kbq-option-border-radius);
 
     &:not(.kbq-disabled) {
         cursor: pointer;

--- a/packages/components/core/styles/common/_list.scss
+++ b/packages/components/core/styles/common/_list.scss
@@ -64,7 +64,6 @@
     gap: var(--kbq-size-s);
 
     border: var(--kbq-size-3xs) solid transparent;
-    border-radius: var(--kbq-size-border-radius);
 
     padding: var(--kbq-size-xxs) kbq-difference-series-css-variables([size-m, size-3xs]);
 

--- a/packages/components/dropdown/dropdown-item.scss
+++ b/packages/components/dropdown/dropdown-item.scss
@@ -2,6 +2,7 @@
 
 .kbq-dropdown-item {
     width: 100%;
+    border-radius: var(--kbq-dropdown-item-border-radius);
 
     @include common.user-select(none);
     @include common.kbq-list-item-base();

--- a/packages/components/dropdown/dropdown-tokens.scss
+++ b/packages/components/dropdown/dropdown-tokens.scss
@@ -8,6 +8,7 @@
     /* THEME TOKENS */
     --kbq-dropdown-container-background: var(--kbq-background-card);
     --kbq-dropdown-container-shadow: var(--kbq-shadow-popup);
+    --kbq-dropdown-item-border-radius: var(--kbq-size-xs);
     /* LIST THEME TOKENS */
     @include list-tokens.list-theme-tokens;
 }

--- a/packages/components/list/list.scss
+++ b/packages/components/list/list.scss
@@ -15,6 +15,8 @@
 
     @include list.kbq-list-item-base();
 
+    border-radius: var(--kbq-size-border-radius);
+
     &:not(.kbq-disabled) {
         cursor: pointer;
     }

--- a/packages/components/tree-select/tree-select-tokens.scss
+++ b/packages/components/tree-select/tree-select-tokens.scss
@@ -3,3 +3,7 @@
     --kbq-select-panel-dropdown-background: var(--kbq-background-card);
     --kbq-select-panel-dropdown-shadow: var(--kbq-shadow-popup);
 }
+
+.kbq-tree-select__panel .kbq-tree-selection {
+    --kbq-tree-option-border-radius: var(--kbq-size-xs);
+}

--- a/packages/components/tree/tree-option.scss
+++ b/packages/components/tree/tree-option.scss
@@ -16,7 +16,7 @@
     border-width: var(--kbq-tree-size-container-focus-outline-width);
     border-style: solid;
     border-color: transparent;
-    border-radius: var(--kbq-size-border-radius);
+    border-radius: var(--kbq-tree-option-border-radius);
 
     padding-top: kbq-difference-series-css-variables(
         [ tree-size-container-padding-vertical,

--- a/packages/components/tree/tree-tokens.scss
+++ b/packages/components/tree/tree-tokens.scss
@@ -7,6 +7,7 @@
     --kbq-tree-size-container-content-gap-vertical: 0px;
     --kbq-tree-size-container-focus-outline-width: var(--kbq-size-3xs);
     --kbq-tree-size-text-padding-vertical: var(--kbq-size-3xs);
+    --kbq-tree-option-border-radius: var(--kbq-size-border-radius);
     /* THEME TOKENS */
     --kbq-tree-default-container-background: transparent;
     --kbq-tree-default-text-color: var(--kbq-foreground-contrast);


### PR DESCRIPTION
## Summary

Added utilities (CSS variables inside the component) for managing `border-radius`.
Removed `border-radius` initialization inside the `kbq-list-item-base` mixin for better flexibility.

<details>
  <summary>ru-RU description</summary>
  
  - добавил ручки (CSS-переменные внутри компонента) для радиусов
  - Убрал инициализацию `border-radius` внутри миксина `kbq-list-item-base` для гибкости
</details>
