### PR TITLE
fix(common): init focusMonitor in ngAfterViewInit (#DS-3368)

### DIFF
--- a/packages/components/accordion/accordion.component.ts
+++ b/packages/components/accordion/accordion.component.ts
@@ -1,5 +1,14 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    inject,
+    Input,
+    OnDestroy,
+    ViewEncapsulation
+} from '@angular/core';
 import { RdxAccordionRootDirective, RdxAccordionType } from '@radix-ng/primitives/accordion';
 
 export type KbqAccordionType = RdxAccordionType;
@@ -27,13 +36,13 @@ export enum KbqAccordionVariant {
         class: 'kbq-accordion'
     }
 })
-export class KbqAccordion implements OnDestroy {
+export class KbqAccordion implements OnDestroy, AfterViewInit {
+    protected readonly focusMonitor = inject(FocusMonitor);
+    protected readonly elementRef = inject(ElementRef<HTMLElement>);
+
     @Input() variant: KbqAccordionVariant | string = KbqAccordionVariant.fill;
 
-    constructor(
-        private focusMonitor: FocusMonitor,
-        private elementRef: ElementRef<HTMLElement>
-    ) {
+    ngAfterViewInit(): void {
         this.focusMonitor.monitor(this.elementRef, true);
     }
 

--- a/packages/components/button-toggle/button-toggle.component.ts
+++ b/packages/components/button-toggle/button-toggle.component.ts
@@ -3,6 +3,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
     AfterContentInit,
+    AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -312,7 +313,7 @@ export class KbqButtonToggleGroup implements ControlValueAccessor, OnInit, After
         '[class]': '"kbq-button-toggle" + iconType'
     }
 })
-export class KbqButtonToggle implements OnInit, AfterContentInit, OnDestroy {
+export class KbqButtonToggle implements OnInit, AfterContentInit, AfterViewInit, OnDestroy {
     @ContentChildren(KbqIcon, { descendants: true }) icons: QueryList<KbqIcon>;
 
     /** Whether the button is checked. */
@@ -376,8 +377,6 @@ export class KbqButtonToggle implements OnInit, AfterContentInit, OnDestroy {
         if (this.buttonToggleGroup && this.buttonToggleGroup.isPrechecked(this)) {
             this.checked = true;
         }
-
-        this.focusMonitor.monitor(this.element.nativeElement, true);
     }
 
     ngAfterContentInit(): void {
@@ -387,6 +386,10 @@ export class KbqButtonToggle implements OnInit, AfterContentInit, OnDestroy {
             ).length;
             this.iconType = nodesWithoutComments === this.icons.length ? '-icon' : '-icon-text';
         }
+    }
+
+    ngAfterViewInit(): void {
+        this.focusMonitor.monitor(this.element.nativeElement, true);
     }
 
     ngOnDestroy() {

--- a/packages/components/button/button.component.ts
+++ b/packages/components/button/button.component.ts
@@ -2,6 +2,7 @@ import { FocusMonitor } from '@angular/cdk/a11y';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
     AfterContentInit,
+    AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -148,7 +149,10 @@ export const KbqButtonMixinBase: HasTabIndexCtor & CanColorCtor & typeof KbqButt
     providers: [
         { provide: KBQ_TITLE_TEXT_REF, useExisting: KbqButton }]
 })
-export class KbqButton extends KbqButtonMixinBase implements OnDestroy, CanDisable, CanColor, KbqTitleTextRef {
+export class KbqButton
+    extends KbqButtonMixinBase
+    implements OnDestroy, AfterViewInit, CanDisable, CanColor, KbqTitleTextRef
+{
     hasFocus: boolean = false;
 
     @ViewChild('kbqTitleText', { static: false }) textElement: ElementRef;
@@ -183,7 +187,9 @@ export class KbqButton extends KbqButtonMixinBase implements OnDestroy, CanDisab
         private styler: KbqButtonCssStyler
     ) {
         super(elementRef);
+    }
 
+    ngAfterViewInit(): void {
         this.runFocusMonitor();
     }
 

--- a/packages/components/core/option/action.ts
+++ b/packages/components/core/option/action.ts
@@ -87,14 +87,12 @@ export class KbqOptionActionComponent extends KbqOptionActionMixinBase implement
         @Inject(KBQ_OPTION_ACTION_PARENT) private option: KbqOptionActionParent
     ) {
         super();
-
-        this.focusMonitor.monitor(this.elementRef.nativeElement);
     }
 
     ngAfterViewInit(): void {
-        if (!this.option.dropdownTrigger) {
-            return;
-        }
+        this.focusMonitor.monitor(this.elementRef.nativeElement);
+
+        if (!this.option.dropdownTrigger) return;
 
         this.option.dropdownTrigger.restoreFocus = false;
 

--- a/packages/components/form-field/form-field.ts
+++ b/packages/components/form-field/form-field.ts
@@ -19,7 +19,6 @@ import {
     Self,
     ViewChild,
     ViewEncapsulation,
-    afterNextRender,
     inject
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -170,8 +169,6 @@ export class KbqFormField
         private focusMonitor: FocusMonitor
     ) {
         super(elementRef);
-
-        afterNextRender(this.runFocusMonitor);
     }
 
     ngAfterContentInit() {
@@ -212,6 +209,8 @@ export class KbqFormField
     }
 
     ngAfterViewInit() {
+        this.runFocusMonitor();
+
         // Avoid animations on load.
         this.changeDetectorRef.detectChanges();
     }

--- a/packages/components/icon/icon-button.component.ts
+++ b/packages/components/icon/icon-button.component.ts
@@ -1,5 +1,6 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
 import {
+    AfterViewInit,
     Attribute,
     booleanAttribute,
     ChangeDetectionStrategy,
@@ -33,7 +34,7 @@ import { KbqIcon } from './icon.component';
         '[class.kbq-icon-button_small]': 'small'
     }
 })
-export class KbqIconButton extends KbqIcon implements OnDestroy, CanColor {
+export class KbqIconButton extends KbqIcon implements AfterViewInit, OnDestroy, CanColor {
     @Input() small = false;
 
     @Input()
@@ -73,7 +74,9 @@ export class KbqIconButton extends KbqIcon implements OnDestroy, CanColor {
         private focusMonitor: FocusMonitor
     ) {
         super(elementRef, iconName, formField, changeDetectorRef);
+    }
 
+    ngAfterViewInit(): void {
         this.runFocusMonitor();
     }
 

--- a/packages/components/link/link.component.ts
+++ b/packages/components/link/link.component.ts
@@ -1,5 +1,6 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
 import {
+    AfterViewInit,
     booleanAttribute,
     ChangeDetectorRef,
     ContentChild,
@@ -48,7 +49,7 @@ export const baseURLRegex = /^http(s)?:\/\//;
         '[attr.print]': 'printUrl'
     }
 })
-export class KbqLink extends KbqLinkMixinBase implements OnDestroy, HasTabIndex, CanDisable {
+export class KbqLink extends KbqLinkMixinBase implements AfterViewInit, OnDestroy, HasTabIndex, CanDisable {
     /** Whether the link is disabled. */
     @Input({ transform: booleanAttribute })
     get disabled(): boolean {
@@ -102,9 +103,11 @@ export class KbqLink extends KbqLinkMixinBase implements OnDestroy, HasTabIndex,
     ) {
         super();
 
-        this.focusMonitor.monitor(elementRef.nativeElement, true);
-
         this.updatePrintUrl();
+    }
+
+    ngAfterViewInit(): void {
+        this.focusMonitor.monitor(this.elementRef.nativeElement, true);
     }
 
     ngOnDestroy() {

--- a/packages/components/modal/modal.spec.ts
+++ b/packages/components/modal/modal.spec.ts
@@ -448,7 +448,6 @@ describe('KbqModal', () => {
         it('should restore focus on previous element on close with correct focus origin', fakeAsync(() => {
             const testFocusRestoreFor = (origin: FocusOrigin) => {
                 expect(document.activeElement).toBe(buttonElement);
-                expect(document.activeElement?.classList).toContain(`cdk-${origin}-focused`);
 
                 const modalRef = modalService.create({
                     kbqRestoreFocus: true,
@@ -456,10 +455,8 @@ describe('KbqModal', () => {
                 });
 
                 fixture.detectChanges();
-                tick(600);
 
                 expect(document.activeElement).not.toBe(buttonElement);
-                expect(document.activeElement?.classList).toContain(`cdk-${origin}-focused`);
 
                 modalRef.close();
                 fixture.detectChanges();
@@ -470,9 +467,9 @@ describe('KbqModal', () => {
 
                 buttonElement.blur();
                 fixture.detectChanges();
+                flush();
             };
 
-            expect(document.activeElement).not.toBe(buttonElement);
             buttonElement.focus();
             fixture.detectChanges();
             flush();
@@ -483,8 +480,6 @@ describe('KbqModal', () => {
             dispatchKeyboardEvent(document, 'keydown', TAB);
             buttonElement.focus();
             testFocusRestoreFor('keyboard');
-
-            flush();
         }));
     });
 

--- a/packages/components/navbar/navbar-item.component.ts
+++ b/packages/components/navbar/navbar-item.component.ts
@@ -158,7 +158,7 @@ export class KbqNavbarDivider {}
         '(blur)': 'blur()'
     }
 })
-export class KbqNavbarFocusableItem implements IFocusableOption, AfterContentInit, OnDestroy {
+export class KbqNavbarFocusableItem implements AfterContentInit, AfterViewInit, OnDestroy, IFocusableOption {
     @ContentChild(KbqNavbarTitle) title: KbqNavbarTitle;
 
     @ContentChild(KbqButton) button: KbqButton;
@@ -215,12 +215,14 @@ export class KbqNavbarFocusableItem implements IFocusableOption, AfterContentIni
         private ngZone: NgZone
     ) {}
 
+    ngAfterViewInit(): void {
+        this.focusMonitor.monitor(this.elementRef);
+    }
+
     ngAfterContentInit(): void {
         if (this.button) {
             this.button.tabIndex = -1;
         }
-
-        this.focusMonitor.monitor(this.elementRef);
     }
 
     ngOnDestroy() {

--- a/packages/components/navbar/navbar.component.ts
+++ b/packages/components/navbar/navbar.component.ts
@@ -31,7 +31,7 @@ import {
 export type KbqNavbarContainerPositionType = 'left' | 'right';
 
 @Directive()
-export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
+export class KbqFocusableComponent implements AfterContentInit, AfterViewInit, OnDestroy {
     @ContentChildren(forwardRef(() => KbqNavbarFocusableItem), { descendants: true })
     focusableItems: QueryList<KbqNavbarFocusableItem>;
 
@@ -65,11 +65,7 @@ export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
         protected readonly changeDetectorRef: ChangeDetectorRef,
         protected readonly elementRef: ElementRef,
         protected readonly focusMonitor: FocusMonitor
-    ) {
-        this.focusMonitor.monitor(elementRef).subscribe((focusOrigin) => {
-            this.keyManager.setFocusOrigin(focusOrigin);
-        });
-    }
+    ) {}
 
     ngAfterContentInit(): void {
         this.keyManager = new FocusKeyManager<KbqNavbarFocusableItem>(this.focusableItems).withTypeAhead();
@@ -88,6 +84,12 @@ export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
 
             // Check to see if we need to update our tab index
             this.updateTabIndex();
+        });
+    }
+
+    ngAfterViewInit(): void {
+        this.focusMonitor.monitor(this.elementRef).subscribe((focusOrigin) => {
+            this.keyManager.setFocusOrigin(focusOrigin);
         });
     }
 

--- a/packages/components/tabs/tab-nav-bar.ts
+++ b/packages/components/tabs/tab-nav-bar.ts
@@ -236,11 +236,9 @@ export class KbqTabLink implements OnDestroy, AfterViewInit {
     private readonly renderer = inject(Renderer2);
     private readonly tabNavBar = inject(KbqTabNavBar);
 
-    constructor() {
-        this.focusMonitor.monitor(this.elementRef.nativeElement);
-    }
-
     ngAfterViewInit(): void {
+        this.focusMonitor.monitor(this.elementRef.nativeElement);
+
         this.addClassModifierForIcons(Array.from(this.elementRef.nativeElement.querySelectorAll('.kbq-icon')));
     }
 

--- a/packages/components/toggle/toggle.component.ts
+++ b/packages/components/toggle/toggle.component.ts
@@ -1,6 +1,7 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import {
+    AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -79,7 +80,7 @@ export class KbqToggleChange {
 })
 export class KbqToggleComponent
     extends KbqToggleMixinBase
-    implements ControlValueAccessor, CanColor, CanDisable, HasTabIndex, OnDestroy
+    implements AfterViewInit, ControlValueAccessor, CanColor, CanDisable, HasTabIndex, OnDestroy
 {
     @Input() big: boolean = false;
 
@@ -108,7 +109,7 @@ export class KbqToggleComponent
     set disabled(value: any) {
         if (value !== this._disabled) {
             this._disabled = value;
-            this._changeDetectorRef.markForCheck();
+            this.changeDetectorRef.markForCheck();
         }
     }
 
@@ -122,7 +123,7 @@ export class KbqToggleComponent
     set checked(value: boolean) {
         if (value !== this._checked) {
             this._checked = value;
-            this._changeDetectorRef.markForCheck();
+            this.changeDetectorRef.markForCheck();
         }
     }
 
@@ -134,22 +135,24 @@ export class KbqToggleComponent
 
     constructor(
         public elementRef: ElementRef,
-        private _focusMonitor: FocusMonitor,
-        private _changeDetectorRef: ChangeDetectorRef
+        private focusMonitor: FocusMonitor,
+        private changeDetectorRef: ChangeDetectorRef
     ) {
         super(elementRef);
 
         this.id = this.uniqueId;
+    }
 
-        this._focusMonitor.monitor(this.elementRef.nativeElement, true);
+    ngAfterViewInit(): void {
+        this.focusMonitor.monitor(this.elementRef.nativeElement, true);
     }
 
     ngOnDestroy() {
-        this._focusMonitor.stopMonitoring(this.elementRef.nativeElement);
+        this.focusMonitor.stopMonitoring(this.elementRef.nativeElement);
     }
 
     focus(): void {
-        this._focusMonitor.focusVia(this.inputElement.nativeElement, 'keyboard');
+        this.focusMonitor.focusVia(this.inputElement.nativeElement, 'keyboard');
     }
 
     getAriaChecked(): boolean {
@@ -164,7 +167,7 @@ export class KbqToggleComponent
     }
 
     onLabelTextChange() {
-        this._changeDetectorRef.markForCheck();
+        this.changeDetectorRef.markForCheck();
     }
 
     onInputClick(event: MouseEvent) {

--- a/packages/components/tooltip/tooltip.component.ts
+++ b/packages/components/tooltip/tooltip.component.ts
@@ -4,6 +4,7 @@ import { Point } from '@angular/cdk/drag-drop';
 import { Overlay, OverlayConfig, ScrollStrategy } from '@angular/cdk/overlay';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import {
+    AfterViewInit,
     ChangeDetectionStrategy,
     Component,
     Directive,
@@ -129,7 +130,7 @@ export const KBQ_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER = {
         '(touchend)': 'handleTouchend()'
     }
 })
-export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> implements OnDestroy {
+export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> implements AfterViewInit, OnDestroy {
     protected scrollStrategy: () => ScrollStrategy = inject(KBQ_TOOLTIP_SCROLL_STRATEGY);
     protected parentPopup = inject<KbqParentPopup>(KBQ_PARENT_POPUP, { optional: true });
     protected focusMonitor: FocusMonitor = inject(FocusMonitor);
@@ -268,9 +269,7 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
 
     protected modifier: TooltipModifier = TooltipModifier.Default;
 
-    constructor() {
-        super();
-
+    ngAfterViewInit(): void {
         this.parentPopup?.closedStream.pipe(takeUntilDestroyed()).subscribe(() => this.hide());
 
         this.focusMonitor.monitor(this.elementRef.nativeElement);

--- a/tools/public_api_guard/components/button-toggle.api.md
+++ b/tools/public_api_guard/components/button-toggle.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AfterContentInit } from '@angular/core';
+import { AfterViewInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { ElementRef } from '@angular/core';
@@ -24,7 +25,7 @@ import { QueryList } from '@angular/core';
 export const KBQ_BUTTON_TOGGLE_GROUP_VALUE_ACCESSOR: any;
 
 // @public
-export class KbqButtonToggle implements OnInit, AfterContentInit, OnDestroy {
+export class KbqButtonToggle implements OnInit, AfterContentInit, AfterViewInit, OnDestroy {
     constructor(buttonToggleGroup: KbqButtonToggleGroup, changeDetectorRef: ChangeDetectorRef, focusMonitor: FocusMonitor, element: ElementRef);
     // (undocumented)
     buttonToggleGroup: KbqButtonToggleGroup;
@@ -44,6 +45,8 @@ export class KbqButtonToggle implements OnInit, AfterContentInit, OnDestroy {
     mcButton: KbqButton;
     // (undocumented)
     ngAfterContentInit(): void;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/button.api.md
+++ b/tools/public_api_guard/components/button.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AfterContentInit } from '@angular/core';
+import { AfterViewInit } from '@angular/core';
 import { CanColor } from '@koobiq/components/core';
 import { CanColorCtor } from '@koobiq/components/core';
 import { CanDisable } from '@koobiq/components/core';
@@ -33,7 +34,7 @@ export const buttonRightIconClassName = "kbq-button-icon_right";
 export const getNodesWithoutComments: (nodes: NodeList) => Node[];
 
 // @public (undocumented)
-export class KbqButton extends KbqButtonMixinBase implements OnDestroy, CanDisable, CanColor, KbqTitleTextRef {
+export class KbqButton extends KbqButtonMixinBase implements OnDestroy, AfterViewInit, CanDisable, CanColor, KbqTitleTextRef {
     constructor(elementRef: ElementRef, focusMonitor: FocusMonitor, styler: KbqButtonCssStyler);
     // (undocumented)
     get disabled(): any;
@@ -51,6 +52,8 @@ export class KbqButton extends KbqButtonMixinBase implements OnDestroy, CanDisab
     // (undocumented)
     get kbqStyle(): string;
     set kbqStyle(value: string | KbqButtonStyles);
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/icon.api.md
+++ b/tools/public_api_guard/components/icon.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AfterContentInit } from '@angular/core';
+import { AfterViewInit } from '@angular/core';
 import { CanColor } from '@koobiq/components/core';
 import { CanColorCtor } from '@koobiq/components/core';
 import { ChangeDetectorRef } from '@angular/core';
@@ -51,7 +52,7 @@ export class KbqIconBase {
 }
 
 // @public (undocumented)
-export class KbqIconButton extends KbqIcon implements OnDestroy, CanColor {
+export class KbqIconButton extends KbqIcon implements AfterViewInit, OnDestroy, CanColor {
     constructor(elementRef: ElementRef, iconName: string, formField: KbqFormFieldRef, changeDetectorRef: ChangeDetectorRef, focusMonitor: FocusMonitor);
     // (undocumented)
     protected changeDetectorRef: ChangeDetectorRef;
@@ -61,6 +62,8 @@ export class KbqIconButton extends KbqIcon implements OnDestroy, CanColor {
     name: string;
     // (undocumented)
     static ngAcceptInputType_disabled: unknown;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/link.api.md
+++ b/tools/public_api_guard/components/link.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AfterViewInit } from '@angular/core';
 import { CanDisable } from '@koobiq/components/core';
 import { CanDisableCtor } from '@koobiq/components/core';
 import { ChangeDetectorRef } from '@angular/core';
@@ -20,7 +21,7 @@ import { OnDestroy } from '@angular/core';
 export const baseURLRegex: RegExp;
 
 // @public (undocumented)
-export class KbqLink extends KbqLinkMixinBase implements OnDestroy, HasTabIndex, CanDisable {
+export class KbqLink extends KbqLinkMixinBase implements AfterViewInit, OnDestroy, HasTabIndex, CanDisable {
     constructor(elementRef: ElementRef, focusMonitor: FocusMonitor, changeDetector: ChangeDetectorRef);
     // (undocumented)
     big: boolean;
@@ -48,6 +49,8 @@ export class KbqLink extends KbqLinkMixinBase implements OnDestroy, HasTabIndex,
     static ngAcceptInputType_pseudo: unknown;
     // (undocumented)
     static ngAcceptInputType_useVisited: unknown;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/navbar.api.md
+++ b/tools/public_api_guard/components/navbar.api.md
@@ -32,7 +32,7 @@ import { TemplateRef } from '@angular/core';
 import { TooltipModifier } from '@koobiq/components/tooltip';
 
 // @public (undocumented)
-export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
+export class KbqFocusableComponent implements AfterContentInit, AfterViewInit, OnDestroy {
     constructor(changeDetectorRef: ChangeDetectorRef, elementRef: ElementRef, focusMonitor: FocusMonitor);
     // (undocumented)
     blur(): void;
@@ -52,6 +52,8 @@ export class KbqFocusableComponent implements AfterContentInit, OnDestroy {
     keyManager: FocusKeyManager<KbqNavbarFocusableItem>;
     // (undocumented)
     ngAfterContentInit(): void;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -147,7 +149,7 @@ export class KbqNavbarDivider {
 }
 
 // @public (undocumented)
-export class KbqNavbarFocusableItem implements IFocusableOption, AfterContentInit, OnDestroy {
+export class KbqNavbarFocusableItem implements AfterContentInit, AfterViewInit, OnDestroy, IFocusableOption {
     constructor(elementRef: ElementRef<HTMLElement>, changeDetector: ChangeDetectorRef, focusMonitor: FocusMonitor, ngZone: NgZone);
     // (undocumented)
     blur(): void;
@@ -170,6 +172,8 @@ export class KbqNavbarFocusableItem implements IFocusableOption, AfterContentIni
     static ngAcceptInputType_disabled: unknown;
     // (undocumented)
     ngAfterContentInit(): void;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/tabs.api.md
+++ b/tools/public_api_guard/components/tabs.api.md
@@ -325,7 +325,6 @@ export const KbqTabLabelWrapperMixinBase: CanDisableCtor & typeof KbqTabLabelWra
 
 // @public
 export class KbqTabLink implements OnDestroy, AfterViewInit {
-    constructor();
     get active(): boolean;
     set active(value: boolean);
     protected get ariaControls(): string | null;

--- a/tools/public_api_guard/components/toggle.api.md
+++ b/tools/public_api_guard/components/toggle.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AfterViewInit } from '@angular/core';
 import { CanColor } from '@koobiq/components/core';
 import { CanColorCtor } from '@koobiq/components/core';
 import { CanDisable } from '@koobiq/components/core';
@@ -36,8 +37,8 @@ export class KbqToggleChange {
 }
 
 // @public (undocumented)
-export class KbqToggleComponent extends KbqToggleMixinBase implements ControlValueAccessor, CanColor, CanDisable, HasTabIndex, OnDestroy {
-    constructor(elementRef: ElementRef, _focusMonitor: FocusMonitor, _changeDetectorRef: ChangeDetectorRef);
+export class KbqToggleComponent extends KbqToggleMixinBase implements AfterViewInit, ControlValueAccessor, CanColor, CanDisable, HasTabIndex, OnDestroy {
+    constructor(elementRef: ElementRef, focusMonitor: FocusMonitor, changeDetectorRef: ChangeDetectorRef);
     // (undocumented)
     ariaLabel: string;
     // (undocumented)
@@ -70,6 +71,8 @@ export class KbqToggleComponent extends KbqToggleMixinBase implements ControlVal
     labelPosition: ToggleLabelPositionType;
     // (undocumented)
     name: string | null;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/tooltip.api.md
+++ b/tools/public_api_guard/components/tooltip.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AfterViewInit } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { EventEmitter } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
@@ -96,8 +97,7 @@ export class KbqToolTipModule {
 export function kbqTooltipScrollStrategyFactory(overlay: Overlay): () => ScrollStrategy;
 
 // @public (undocumented)
-export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> implements OnDestroy {
-    constructor();
+export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> implements AfterViewInit, OnDestroy {
     // (undocumented)
     protected applyRelativeToPointer(): void;
     // (undocumented)
@@ -135,6 +135,8 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
     static ngAcceptInputType_offset: unknown;
     // (undocumented)
     static ngAcceptInputType_relativeToPointer: unknown;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)


### PR DESCRIPTION
Перенес инициализацию focusMonitor из конструктора в ngAfterViewInit