### PR TITLE
feat(popover,tooltip): added adjusted arrow positioning (#DS-3369)

### DIFF
--- a/packages/components-dev/tooltip/module.ts
+++ b/packages/components-dev/tooltip/module.ts
@@ -10,6 +10,7 @@ import { KbqFormFieldModule } from '@koobiq/components/form-field';
 import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqInputModule } from '@koobiq/components/input';
 import { KbqSelectModule } from '@koobiq/components/select';
+import { KbqToggleModule } from '@koobiq/components/toggle';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 
 @Component({
@@ -60,6 +61,7 @@ export class DemoComponent {
              добра и зла», написанного в 45 году до нашей эры. Впервые этот текст был применен для набора шрифтовых образцов
             неизвестным печатником еще в XVI веке.`
     };
+    hasArrow = true;
 
     constructor() {
         this.tooltipActiveStage = 1;
@@ -129,7 +131,8 @@ export class DemoComponent {
         KbqFormFieldModule,
         KbqCheckboxModule,
         KbqSelectModule,
-        KbqIconModule
+        KbqIconModule,
+        KbqToggleModule
     ],
     bootstrap: [DemoComponent]
 })

--- a/packages/components-dev/tooltip/template.html
+++ b/packages/components-dev/tooltip/template.html
@@ -16,6 +16,10 @@
             </div>
 
             <div class="kbq-form__row">
+                <kbq-toggle [(ngModel)]="hasArrow">Has Arrow</kbq-toggle>
+            </div>
+
+            <div class="kbq-form__row">
                 <label for="element" class="kbq-form__label">Choose color</label>
 
                 <kbq-form-field id="color" class="kbq-form__control">
@@ -228,6 +232,7 @@
                         [kbqPlacementPriority]="multipleSelected"
                         [kbqRelativeToPointer]="true"
                         [kbqTooltip]="inputText"
+                        [kbqTooltipArrow]="hasArrow"
                         [kbqTooltipColor]="selectedColor"
                         [kbqTrigger]="selectedTrigger"
                         (kbqPlacementChange)="onPlacementChange($event)"
@@ -242,7 +247,7 @@
                         [kbqExtendedTooltip]="tooltipContent"
                         [kbqPlacement]="selectedPlacement"
                         [kbqPlacementPriority]="multipleSelected"
-                        [kbqTooltipArrow]="false"
+                        [kbqTooltipArrow]="hasArrow"
                         [kbqTooltipClass]="'tooltip-485'"
                         [kbqTooltipColor]="selectedColor"
                         [kbqTooltipContext]="toolTipContext"
@@ -263,6 +268,7 @@
                             [kbqPlacement]="selectedPlacement"
                             [kbqPlacementPriority]="multipleSelected"
                             [kbqTooltip]="inputText"
+                            [kbqTooltipArrow]="hasArrow"
                             [kbqTooltipColor]="selectedColor"
                             [kbqTrigger]="selectedTrigger"
                             [(ngModel)]="content"
@@ -278,6 +284,7 @@
                             [kbqPlacement]="selectedPlacement"
                             [kbqPlacementPriority]="multipleSelected"
                             [kbqTooltip]="inputText"
+                            [kbqTooltipArrow]="hasArrow"
                             [kbqTooltipColor]="selectedColor"
                             [kbqTrigger]="selectedTrigger"
                             (kbqPlacementChange)="onPlacementChange($event)"

--- a/packages/components/core/pop-up/constants.ts
+++ b/packages/components/core/pop-up/constants.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core';
+import { TooltipSizeArrowSize } from '@koobiq/design-tokens';
 import { Observable } from 'rxjs';
 
 export interface KbqParentPopup {
@@ -51,3 +52,8 @@ export enum PopUpSizes {
  * Tags Input, Timezone, TreeSelect).
  */
 export const defaultOffsetY: number = 4;
+
+/**
+ * Variable used for offsetY(X) calculations when applying Angular Overlay
+ */
+export const ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT = Math.round(parseInt(TooltipSizeArrowSize) * Math.sqrt(2));

--- a/packages/components/core/pop-up/constants.ts
+++ b/packages/components/core/pop-up/constants.ts
@@ -55,5 +55,7 @@ export const defaultOffsetY: number = 4;
 
 /**
  * Variable used for offsetY(X) calculations when applying Angular Overlay
+ *
+ * @docs-private
  */
 export const ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT = Math.round(parseInt(TooltipSizeArrowSize) * Math.sqrt(2));

--- a/packages/components/core/pop-up/pop-up-trigger.ts
+++ b/packages/components/core/pop-up/pop-up-trigger.ts
@@ -34,7 +34,42 @@ import {
     POSITION_PRIORITY_STRATEGY,
     POSITION_TO_CSS_MAP
 } from '../overlay/overlay-position-map';
-import { PopUpPlacements, PopUpTriggers } from './constants';
+import { ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT, PopUpPlacements, PopUpTriggers } from './constants';
+
+const getOffset = ({ originX, overlayX, originY, overlayY }: ConnectionPositionPair, { width, height }: DOMRect) => {
+    const offset: Pick<ConnectionPositionPair, 'offsetX' | 'offsetY'> = {};
+    const elementWidthHalf = width / 2;
+    const elementHeightHalf = height / 2;
+
+    // alignment should be applied only if the element is small
+    if (ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT > elementWidthHalf) {
+        const PADDING = ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT - elementWidthHalf;
+
+        if (originX === overlayX) {
+            if (originX === 'start') {
+                offset.offsetX = -PADDING;
+            }
+            if (originX === 'end') {
+                offset.offsetX = PADDING;
+            }
+        }
+    }
+
+    // alignment should be applied only if the element is small
+    if (ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT > elementHeightHalf) {
+        const PADDING = ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT - elementHeightHalf;
+        if (originY === overlayY) {
+            if (originY === 'top') {
+                offset.offsetY = -PADDING;
+            }
+            if (originY === 'bottom') {
+                offset.offsetY = PADDING;
+            }
+        }
+    }
+
+    return offset;
+};
 
 @Directive()
 export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
@@ -54,6 +89,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     leaveDelay: number = 0;
 
     abstract disabled: boolean;
+    abstract arrow: boolean;
     abstract trigger: string;
     abstract customClass: string;
     abstract content: string | TemplateRef<any>;
@@ -304,12 +340,31 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
         this.subscribeOnClosingActions();
 
         const position = (this.overlayRef.getConfig().positionStrategy as FlexibleConnectedPositionStrategy)
-            .withPositions(this.getPrioritizedPositions())
+            .withPositions(this.getAdjustedPositions())
             .withPush(true);
 
         if (reapplyPosition) {
             setTimeout(() => position.reapplyLastPosition());
         }
+    }
+
+    /**
+     * Returns a list of positions that are aligned with the element's dimensions and offsets.
+     * @protected
+     */
+    protected getAdjustedPositions(): ConnectionPositionPair[] {
+        const res: ConnectionPositionPair[] = [];
+        for (const pos of this.getPrioritizedPositions()) {
+            const offset: Pick<ConnectionPositionPair, 'offsetY' | 'offsetX'> = this.arrow
+                ? getOffset(pos, this.elementRef.nativeElement.getBoundingClientRect())
+                : {};
+
+            res.push({
+                ...pos,
+                ...offset
+            });
+        }
+        return res;
     }
 
     protected getPriorityPlacementStrategy(value: string | string[]): ConnectionPositionPair[] {

--- a/packages/components/core/pop-up/pop-up-trigger.ts
+++ b/packages/components/core/pop-up/pop-up-trigger.ts
@@ -36,8 +36,13 @@ import {
 } from '../overlay/overlay-position-map';
 import { ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT, PopUpPlacements, PopUpTriggers } from './constants';
 
-const getOffset = ({ originX, overlayX, originY, overlayY }: ConnectionPositionPair, { width, height }: DOMRect) => {
-    const offset: Pick<ConnectionPositionPair, 'offsetX' | 'offsetY'> = {};
+type KbqPopupTriggerOffset = Pick<ConnectionPositionPair, 'offsetX' | 'offsetY'>;
+
+const getOffset = (
+    { originX, overlayX, originY, overlayY }: ConnectionPositionPair,
+    { width, height }: DOMRect
+): KbqPopupTriggerOffset => {
+    const offset: KbqPopupTriggerOffset = {};
     const elementWidthHalf = width / 2;
     const elementHeightHalf = height / 2;
 
@@ -355,7 +360,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     protected getAdjustedPositions(): ConnectionPositionPair[] {
         const res: ConnectionPositionPair[] = [];
         for (const pos of this.getPrioritizedPositions()) {
-            const offset: Pick<ConnectionPositionPair, 'offsetY' | 'offsetX'> = this.arrow
+            const offset: KbqPopupTriggerOffset = this.arrow
                 ? getOffset(pos, this.elementRef.nativeElement.getBoundingClientRect())
                 : {};
 

--- a/packages/components/popover/popover.component.ts
+++ b/packages/components/popover/popover.component.ts
@@ -300,6 +300,9 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> impl
 
     @Input() backdropClass: string = 'cdk-overlay-transparent-backdrop';
 
+    // @TODO add realization for arrow (#DS-2514)
+    arrow: boolean = true;
+
     @Output('kbqPopoverPlacementChange') placementChange = new EventEmitter();
 
     @Output('kbqPopoverVisibleChange') visibleChange = new EventEmitter<boolean>();
@@ -351,7 +354,7 @@ export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> impl
         this.overlayRef = this.createOverlay();
 
         const position = (this.overlayRef.getConfig().positionStrategy as FlexibleConnectedPositionStrategy)
-            .withPositions(this.getPrioritizedPositions())
+            .withPositions(this.getAdjustedPositions())
             .withPush(true);
 
         if (reapplyPosition) {

--- a/packages/components/popover/popover.spec.ts
+++ b/packages/components/popover/popover.spec.ts
@@ -1,67 +1,79 @@
-import { OverlayContainer } from '@angular/cdk/overlay';
-import { Component, ElementRef, ViewChild } from '@angular/core';
-import { TestBed, fakeAsync, inject, tick } from '@angular/core/testing';
+import { coerceElement } from '@angular/cdk/coercion';
+import { FlexibleConnectedPositionStrategy, OverlayContainer } from '@angular/cdk/overlay';
+import { Component, DebugElement, ElementRef, Provider, Type, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, inject, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ENTER, ESCAPE, SPACE } from '@koobiq/cdk/keycodes';
 import { dispatchFakeEvent, dispatchKeyboardEvent, dispatchMouseEvent } from '@koobiq/cdk/testing';
+import { ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT } from '@koobiq/components/core';
 import { KBQ_POPOVER_CONFIRM_BUTTON_TEXT, KBQ_POPOVER_CONFIRM_TEXT } from './popover-confirm.component';
+import { KbqPopoverTrigger } from './popover.component';
 import { KbqPopoverModule } from './popover.module';
 
+function openAndAssertPopover<T>(componentFixture: ComponentFixture<T>, triggerElement: ElementRef) {
+    dispatchMouseEvent(coerceElement(triggerElement), 'click');
+    tick();
+    componentFixture.detectChanges();
+
+    const popover = componentFixture.debugElement.query(By.css('.kbq-popover'));
+    expect(popover).toBeTruthy();
+    return popover;
+}
+
+const createComponent = <T>(component: Type<T>, providers: Provider[] = []): ComponentFixture<T> => {
+    TestBed.configureTestingModule({
+        imports: [component, NoopAnimationsModule],
+        providers
+    });
+    const fixture = TestBed.createComponent<T>(component);
+    fixture.autoDetectChanges();
+    return fixture;
+};
+
 describe('KbqPopover', () => {
-    let overlayContainer: OverlayContainer;
-    let overlayContainerElement: HTMLElement;
-    let componentFixture;
-    let component;
-
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            imports: [KbqPopoverModule, NoopAnimationsModule],
-            declarations: [
-                KbqPopoverTestComponent,
-                KbqPopoverConfirmTestComponent,
-                KbqPopoverConfirmWithProvidersTestComponent
-            ]
-        }).compileComponents();
-    });
-
-    beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
-        overlayContainer = oc;
-        overlayContainerElement = oc.getContainerElement();
-    }));
-
-    afterEach(() => {
-        overlayContainer.ngOnDestroy();
-        componentFixture.destroy();
-    });
-
     describe('Check test cases', () => {
+        let fixture: ComponentFixture<KbqPopoverTestComponent>;
+        let componentInstance: KbqPopoverTestComponent;
+        let debugElement: DebugElement;
+        let overlayContainer: OverlayContainer;
+        let overlayContainerElement: HTMLElement;
+
         beforeEach(() => {
-            componentFixture = TestBed.createComponent(KbqPopoverTestComponent);
-            component = componentFixture.componentInstance;
-            componentFixture.detectChanges();
+            fixture = createComponent(KbqPopoverTestComponent);
+            componentInstance = fixture.componentInstance;
+            debugElement = fixture.debugElement;
+        });
+
+        beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
+            overlayContainer = oc;
+            overlayContainerElement = oc.getContainerElement();
+        }));
+
+        afterEach(() => {
+            overlayContainer.ngOnDestroy();
         });
 
         it('kbqTrigger = hover', fakeAsync(() => {
             const expectedValue = '_TEST1';
-            const triggerElement = component.test1.nativeElement;
+            const triggerElement = componentInstance.test1.nativeElement;
 
             expect(overlayContainerElement.textContent).not.toEqual(expectedValue);
 
             dispatchMouseEvent(triggerElement, 'mouseenter');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             expect(overlayContainerElement.textContent).toEqual(expectedValue);
 
             dispatchMouseEvent(triggerElement, 'mouseleave');
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             dispatchMouseEvent(overlayContainerElement, 'mouseenter');
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             expect(overlayContainerElement.textContent).toContain(expectedValue);
             // Move out from the tooltip element to hide it
             dispatchMouseEvent(overlayContainerElement, 'mouseleave');
             tick(100);
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             tick(); // wait for next tick to hide
             expect(overlayContainerElement.textContent).not.toEqual(expectedValue);
             expect(triggerElement.classList).not.toContain('kbq-active');
@@ -69,19 +81,19 @@ describe('KbqPopover', () => {
 
         it('kbqTrigger = manual', fakeAsync(() => {
             const expectedValue = '_TEST2';
-            const triggerElement = component.test1.nativeElement;
+            const triggerElement = componentInstance.test1.nativeElement;
 
             expect(overlayContainerElement.textContent).not.toEqual(expectedValue);
 
-            component.popoverVisibility = true;
+            componentInstance.popoverVisibility = true;
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             expect(overlayContainerElement.textContent).toEqual(expectedValue);
 
-            component.popoverVisibility = false;
-            componentFixture.detectChanges();
+            componentInstance.popoverVisibility = false;
+            fixture.detectChanges();
             tick(500); // wait for next tick to hide
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
             expect(overlayContainerElement.textContent).not.toEqual(expectedValue);
             expect(triggerElement.classList).not.toContain('kbq-active');
@@ -89,15 +101,15 @@ describe('KbqPopover', () => {
 
         it('kbqTrigger = focus', fakeAsync(() => {
             const featureKey = '_TEST3';
-            const triggerElement = component.test3.nativeElement;
+            const triggerElement = componentInstance.test3.nativeElement;
             dispatchFakeEvent(triggerElement, 'focus');
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             expect(overlayContainerElement.textContent).toContain(featureKey);
             dispatchFakeEvent(triggerElement, 'blur');
             tick(100);
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             tick(); // wait for next tick to hide
-            componentFixture.detectChanges();
+            fixture.detectChanges();
             tick(); // wait for next tick to hide
             expect(overlayContainerElement.textContent).not.toContain(featureKey);
             expect(triggerElement.classList).not.toContain('kbq-active');
@@ -105,90 +117,90 @@ describe('KbqPopover', () => {
 
         it('Can set kbqPopoverHeader', fakeAsync(() => {
             const expectedValue = '_TEST4';
-            const triggerElement = component.test4.nativeElement;
+            const triggerElement = componentInstance.test4.nativeElement;
 
             dispatchMouseEvent(triggerElement, 'mouseenter');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const header = componentFixture.debugElement.query(By.css('.kbq-popover__header'));
+            const header = debugElement.query(By.css('.kbq-popover__header'));
             expect(header.nativeElement.textContent).toEqual(expectedValue);
         }));
 
         it('Can set kbqPopoverContent', fakeAsync(() => {
             const expectedValue = '_TEST5';
-            const triggerElement = component.test5.nativeElement;
+            const triggerElement = componentInstance.test5.nativeElement;
 
             dispatchMouseEvent(triggerElement, 'mouseenter');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const content = componentFixture.debugElement.query(By.css('.kbq-popover__content'));
+            const content = debugElement.query(By.css('.kbq-popover__content'));
             expect(content.nativeElement.textContent).toEqual(expectedValue);
         }));
 
         it('Can set kbqPopoverFooter', fakeAsync(() => {
             const expectedValue = '_TEST6';
-            const triggerElement = component.test6.nativeElement;
+            const triggerElement = componentInstance.test6.nativeElement;
 
             dispatchMouseEvent(triggerElement, 'mouseenter');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const footer = componentFixture.debugElement.query(By.css('.kbq-popover__footer'));
+            const footer = debugElement.query(By.css('.kbq-popover__footer'));
             expect(footer.nativeElement.textContent).toEqual(expectedValue);
         }));
 
         it('Can set kbqPopoverClass', fakeAsync(() => {
             const expectedValue = '_TEST7';
-            const triggerElement = component.test7.nativeElement;
+            const triggerElement = componentInstance.test7.nativeElement;
 
             dispatchMouseEvent(triggerElement, 'click');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const popover = componentFixture.debugElement.query(By.css('.kbq-popover'));
+            const popover = debugElement.query(By.css('.kbq-popover'));
             expect(popover.nativeElement.classList.contains(expectedValue)).toBeTruthy();
             expect(triggerElement.classList).toContain('kbq-active');
         }));
 
         it('should open popover with keyboard when kbqTrigger = default', fakeAsync(() => {
-            const triggerElement = component.test7.nativeElement;
+            const triggerElement = componentInstance.test7.nativeElement;
 
             [ENTER, SPACE].forEach((keyCode) => {
                 dispatchKeyboardEvent(triggerElement, 'keydown', keyCode);
                 tick();
-                componentFixture.detectChanges();
+                fixture.detectChanges();
 
-                let popover = componentFixture.debugElement.query(By.css('.kbq-popover'));
+                let popover = debugElement.query(By.css('.kbq-popover'));
                 expect(popover).toBeTruthy();
                 expect(triggerElement.classList).toContain('kbq-active');
 
                 dispatchKeyboardEvent(triggerElement, 'keydown', ESCAPE);
                 tick();
-                componentFixture.detectChanges();
-                popover = componentFixture.debugElement.query(By.css('.kbq-popover'));
+                fixture.detectChanges();
+                popover = debugElement.query(By.css('.kbq-popover'));
                 expect(popover).not.toBeTruthy();
                 expect(triggerElement.classList).not.toContain('kbq-active');
             });
         }));
 
         it('should open popover with keyboard when kbqTrigger = default for elements other than button', fakeAsync(() => {
-            const triggerElement = component.test8.nativeElement;
+            const triggerElement = componentInstance.test8.nativeElement;
 
             [ENTER, SPACE].forEach((keyCode) => {
                 dispatchKeyboardEvent(triggerElement, 'keydown', keyCode);
                 tick();
-                componentFixture.detectChanges();
+                fixture.detectChanges();
 
-                let popover = componentFixture.debugElement.query(By.css('.kbq-popover'));
+                let popover = debugElement.query(By.css('.kbq-popover'));
                 expect(popover).toBeTruthy();
                 expect(triggerElement.classList).toContain('kbq-active');
 
                 dispatchKeyboardEvent(triggerElement, 'keydown', ESCAPE);
                 tick();
-                componentFixture.detectChanges();
-                popover = componentFixture.debugElement.query(By.css('.kbq-popover'));
+                fixture.detectChanges();
+                popover = debugElement.query(By.css('.kbq-popover'));
                 expect(popover).not.toBeTruthy();
                 expect(triggerElement.classList).not.toContain('kbq-active');
             });
@@ -196,94 +208,142 @@ describe('KbqPopover', () => {
     });
 
     describe('Check popover confirm', () => {
-        beforeEach(() => {
-            componentFixture = TestBed.createComponent(KbqPopoverConfirmTestComponent);
-            component = componentFixture.componentInstance;
-            componentFixture.detectChanges();
-        });
-
         it('Default text is correct', fakeAsync(() => {
-            const triggerElement = component.test8.nativeElement;
+            const fixture = createComponent(KbqPopoverConfirmTestComponent);
+            const { componentInstance, debugElement } = fixture;
+            const triggerElement = componentInstance.test8.nativeElement;
             dispatchMouseEvent(triggerElement, 'click');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const button = componentFixture.debugElement.query(By.css('.kbq-popover-confirm button'));
+            const button = debugElement.query(By.css('.kbq-popover-confirm button'));
             expect(button.nativeElement.textContent.trim()).toEqual('Да');
 
-            const confirmText = componentFixture.debugElement.query(
-                By.css('.kbq-popover-confirm .kbq-popover__content div')
-            );
+            const confirmText = debugElement.query(By.css('.kbq-popover-confirm .kbq-popover__content div'));
             expect(confirmText.nativeElement.textContent).toEqual('Вы уверены, что хотите продолжить?');
         }));
 
         it('Can set confirm text through input', fakeAsync(() => {
+            const fixture = createComponent(KbqPopoverConfirmTestComponent);
+            const { componentInstance, debugElement } = fixture;
             const expectedValue = 'new confirm text';
 
-            const triggerElement = component.test9.nativeElement;
+            const triggerElement = componentInstance.test9.nativeElement;
             dispatchMouseEvent(triggerElement, 'click');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const confirmText = componentFixture.debugElement.query(
-                By.css('.kbq-popover-confirm .kbq-popover__content div')
-            );
+            const confirmText = debugElement.query(By.css('.kbq-popover-confirm .kbq-popover__content div'));
             expect(confirmText.nativeElement.textContent).toEqual(expectedValue);
         }));
 
         it('Can set button text through input', fakeAsync(() => {
+            const fixture = createComponent(KbqPopoverConfirmTestComponent);
+            const { componentInstance, debugElement } = fixture;
             const expectedValue = 'new button text';
 
-            const triggerElement = component.test10.nativeElement;
+            const triggerElement = componentInstance.test10.nativeElement;
             dispatchMouseEvent(triggerElement, 'click');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const button = componentFixture.debugElement.query(By.css('.kbq-popover-confirm button'));
+            const button = debugElement.query(By.css('.kbq-popover-confirm button'));
             expect(button.nativeElement.textContent.trim()).toEqual(expectedValue);
         }));
 
         it('Click emits confirm', fakeAsync(() => {
-            const onConfirmSpyFn = jest.spyOn(component, 'onConfirm');
+            const fixture = createComponent(KbqPopoverConfirmTestComponent);
+            const { componentInstance, debugElement } = fixture;
+            const onConfirmSpyFn = jest.spyOn(componentInstance, 'onConfirm');
 
-            const triggerElement = component.test11.nativeElement;
+            const triggerElement = componentInstance.test11.nativeElement;
             dispatchMouseEvent(triggerElement, 'click');
             tick();
 
-            const confirmButton = componentFixture.debugElement.query(By.css('.kbq-popover-confirm button'));
+            const confirmButton = debugElement.query(By.css('.kbq-popover-confirm button'));
             dispatchMouseEvent(confirmButton.nativeElement, 'click');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
             expect(onConfirmSpyFn).toHaveBeenCalled();
         }));
     });
 
     describe('Check popover confirm with providers', () => {
-        beforeEach(() => {
-            componentFixture = TestBed.createComponent(KbqPopoverConfirmWithProvidersTestComponent);
-            component = componentFixture.componentInstance;
-            componentFixture.detectChanges();
-        });
-
         it('Provided text is correct', fakeAsync(() => {
-            const triggerElement = component.test12.nativeElement;
+            const fixture = createComponent(KbqPopoverConfirmWithProvidersTestComponent);
+            const { componentInstance, debugElement } = fixture;
+            const triggerElement = componentInstance.test12.nativeElement;
             dispatchMouseEvent(triggerElement, 'click');
             tick();
-            componentFixture.detectChanges();
+            fixture.detectChanges();
 
-            const button = componentFixture.debugElement.query(By.css('.kbq-popover-confirm button'));
+            const button = debugElement.query(By.css('.kbq-popover-confirm button'));
             expect(button.nativeElement.textContent.trim()).toEqual('provided button text');
 
-            const confirmText = componentFixture.debugElement.query(
-                By.css('.kbq-popover-confirm .kbq-popover__content div')
-            );
+            const confirmText = debugElement.query(By.css('.kbq-popover-confirm .kbq-popover__content div'));
             expect(confirmText.nativeElement.textContent).toEqual('provided confirm text');
+        }));
+    });
+
+    describe('Overlay offset', () => {
+        it('should add offset for some positions if element is less than arrow margin', fakeAsync(() => {
+            const fixture = createComponent(PopoverSimple);
+            const { componentInstance } = fixture;
+
+            const rect = ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT * 2 - 1;
+            componentInstance.triggerElementRef.nativeElement.getBoundingClientRect = () => ({
+                width: rect,
+                height: rect
+            });
+            fixture.detectChanges();
+
+            openAndAssertPopover(fixture, componentInstance.triggerElementRef);
+
+            const strategy: FlexibleConnectedPositionStrategy = componentInstance.popoverTrigger
+                .createOverlay()
+                .getConfig().positionStrategy! as FlexibleConnectedPositionStrategy;
+            expect(strategy.positions.some((pos) => 'offsetX' in pos || 'offsetY' in pos)).toBeTruthy();
+        }));
+
+        it('should not add offset if element is large', fakeAsync(() => {
+            const fixture = createComponent(PopoverSimple);
+            const { componentInstance } = fixture;
+            componentInstance.triggerElementRef.nativeElement.getBoundingClientRect = () => ({
+                width: 100,
+                height: 100
+            });
+            fixture.detectChanges();
+
+            openAndAssertPopover(fixture, componentInstance.triggerElementRef);
+
+            const strategy: FlexibleConnectedPositionStrategy = componentInstance.popoverTrigger
+                .createOverlay()
+                .getConfig().positionStrategy! as FlexibleConnectedPositionStrategy;
+            expect(strategy.positions.some((pos) => 'offsetX' in pos || 'offsetY' in pos)).toBeFalsy();
         }));
     });
 });
 
 @Component({
+    standalone: true,
+    selector: 'popover-simple',
+    template: `
+        <button [kbqPopoverContent]="'test'" kbqPopover>Popover Trigger</button>
+    `,
+    imports: [
+        KbqPopoverModule
+    ]
+})
+export class PopoverSimple {
+    @ViewChild(KbqPopoverTrigger) popoverTrigger: KbqPopoverTrigger;
+    @ViewChild(KbqPopoverTrigger, { read: ElementRef }) triggerElementRef: ElementRef;
+    constructor(public elementRef: ElementRef) {}
+}
+
+@Component({
+    standalone: true,
+    imports: [KbqPopoverModule],
     selector: 'kbq-popover-test-component',
     template: `
         <button #test1 [kbqTrigger]="'hover'" [kbqPopoverContent]="'_TEST1'" kbqPopover>_TEST1asdasd</button>
@@ -320,6 +380,8 @@ class KbqPopoverTestComponent {
 }
 
 @Component({
+    standalone: true,
+    imports: [KbqPopoverModule],
     selector: 'kbq-popover-test-component',
     template: `
         <button #test8 kbqPopoverConfirm>_TEST8</button>
@@ -340,6 +402,8 @@ class KbqPopoverConfirmTestComponent {
 }
 
 @Component({
+    standalone: true,
+    imports: [KbqPopoverModule],
     selector: 'kbq-popover-test-with-providers-component',
     template: `
         <button #test12 kbqPopoverConfirm>_TEST12</button>

--- a/packages/components/tooltip/tooltip.component.ts
+++ b/packages/components/tooltip/tooltip.component.ts
@@ -317,6 +317,7 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
         this.instance.arrow = this.arrow;
         this.instance.offset = this.offset;
         this.instance.detectChanges();
+        this.updatePosition(true);
     }
 
     closingActions() {

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -143,6 +143,9 @@ export enum AnimationCurves {
 // @public (undocumented)
 export const applyPopupMargins: (renderer: Renderer2, element: HTMLElement, name: string, value: string) => void;
 
+// @public
+export const ARROW_BOTTOM_MARGIN_AND_HALF_HEIGHT: number;
+
 // @public (undocumented)
 export class BaseFormatterPipe<D> {
     // (undocumented)
@@ -1677,6 +1680,8 @@ export abstract class KbqPopUp implements OnDestroy {
 // @public (undocumented)
 export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     // (undocumented)
+    abstract arrow: boolean;
+    // (undocumented)
     protected readonly availablePositions: {
         [key: string]: ConnectionPositionPair;
     };
@@ -1709,6 +1714,7 @@ export abstract class KbqPopUpTrigger<T> implements OnInit, OnDestroy {
     protected readonly elementRef: ElementRef;
     // (undocumented)
     enterDelay: number;
+    protected getAdjustedPositions(): ConnectionPositionPair[];
     // (undocumented)
     abstract getOverlayHandleComponentType(): Type<T>;
     // (undocumented)

--- a/tools/public_api_guard/components/popover.api.md
+++ b/tools/public_api_guard/components/popover.api.md
@@ -147,6 +147,8 @@ export function kbqPopoverScrollStrategyFactory(overlay: Overlay): () => ScrollS
 // @public (undocumented)
 export class KbqPopoverTrigger extends KbqPopUpTrigger<KbqPopoverComponent> implements AfterContentInit {
     // (undocumented)
+    arrow: boolean;
+    // (undocumented)
     backdropClass: string;
     get closeOnScroll(): boolean | null;
     set closeOnScroll(value: boolean);


### PR DESCRIPTION
## Summary

- Applied arrow adjusted positioning for small elements.
- Small refactoring of tests in popover for better types usage
- Moved common tasks (open tooltip, open popover) in tests to separate function
- Added arrow property to abstract class to disable offset calculation when tooltip/popover called without arrow
