### PR TITLE
fix(button-toggle): added 2px focus line for item (#DS-3136)

### DIFF
--- a/packages/components-dev/button-toggle/module.ts
+++ b/packages/components-dev/button-toggle/module.ts
@@ -6,6 +6,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqTitleModule } from '@koobiq/components/title';
 import { KbqButtonModule } from '../../components/button';
 import { KbqButtonToggleModule } from '../../components/button-toggle';
+import { ButtonToggleExamplesModule } from '../../docs-examples/components/button-toggle';
 
 @Component({
     selector: 'app',
@@ -29,7 +30,8 @@ export class ButtonToggleDemoComponent {
         KbqButtonToggleModule,
         KbqIconModule,
         FormsModule,
-        KbqTitleModule
+        KbqTitleModule,
+        ButtonToggleExamplesModule
     ],
     bootstrap: [
         ButtonToggleDemoComponent

--- a/packages/components-dev/button-toggle/template.html
+++ b/packages/components-dev/button-toggle/template.html
@@ -57,14 +57,9 @@
 
     <label>Group With Overflown text</label>
 
-    <kbq-button-toggle-group>
-        <kbq-button-toggle [value]="1">default 1</kbq-button-toggle>
-        <kbq-button-toggle [disabled]="true" [value]="2">default 2</kbq-button-toggle>
-        <kbq-button-toggle [value]="3">
-            <i kbq-icon="kbq-chevron-down-s_16"></i>
-            Long long long long long Long long long long long Long long long long long text
-        </kbq-button-toggle>
-    </kbq-button-toggle-group>
+    <div style="max-width: 300px" class="dev-container">
+        <button-toggle-tooltip-overview-example />
+    </div>
 
     <br />
 

--- a/packages/components/button-toggle/button-toggle-tokens.scss
+++ b/packages/components/button-toggle/button-toggle-tokens.scss
@@ -3,7 +3,7 @@
     --kbq-button-toggle-size-container-padding-horizontal: var(--kbq-size-xxs);
     --kbq-button-toggle-size-container-padding-vertical: var(--kbq-size-xxs);
     --kbq-button-toggle-size-container-content-gap-horizontal: var(--kbq-size-xxs);
-    --kbq-button-toggle-size-item-height: var(--kbq-size-xxl);
+    --kbq-button-toggle-size-item-height: 22px;
     --kbq-button-toggle-size-item-border-radius: var(--kbq-size-xxs);
     --kbq-button-toggle-size-item-padding-horizontal: var(--kbq-size-s);
     --kbq-button-toggle-size-item-padding-vertical: var(--kbq-size-3xs);

--- a/packages/components/button-toggle/button-toggle.scss
+++ b/packages/components/button-toggle/button-toggle.scss
@@ -27,12 +27,19 @@
         min-height: var(--kbq-button-toggle-size-item-height);
 
         border-radius: var(--kbq-button-toggle-size-item-border-radius);
+        border: var(--kbq-size-border-width) solid transparent;
+
+        &.cdk-keyboard-focused {
+            outline: 1px solid var(--kbq-states-line-focus-theme);
+            border-color: var(--kbq-states-line-focus-theme);
+        }
 
         > .kbq-button,
         > .kbq-button-icon {
             height: inherit;
             min-height: inherit;
             border-radius: var(--kbq-button-toggle-size-item-border-radius);
+            border-width: 0;
 
             padding: kbq-difference-series-css-variables(
                     [ button-toggle-size-item-padding-vertical,
@@ -58,6 +65,10 @@
                 width: 100%;
 
                 gap: var(--kbq-button-toggle-size-item-content-gap-horizontal);
+            }
+
+            &.cdk-keyboard-focused {
+                outline: none;
             }
         }
     }

--- a/packages/docs-examples/components/button-toggle/button-toggle-disabled-all-overview/button-toggle-disabled-all-overview-example.html
+++ b/packages/docs-examples/components/button-toggle/button-toggle-disabled-all-overview/button-toggle-disabled-all-overview-example.html
@@ -1,5 +1,5 @@
 <div class="layout-margin-bottom-m">
-    <kbq-button-toggle-group #group1="kbqButtonToggleGroup" disabled [(ngModel)]="model">
+    <kbq-button-toggle-group #group1="kbqButtonToggleGroup" [disabled]="true" [(ngModel)]="model">
         <kbq-button-toggle [value]="1">
             <i kbq-icon="kbq-info-circle_16"></i>
             Курьером
@@ -16,7 +16,7 @@
 </div>
 
 <div>
-    <kbq-button-toggle-group #group2="kbqButtonToggleGroup" disabled>
+    <kbq-button-toggle-group #group2="kbqButtonToggleGroup" [disabled]="true">
         <kbq-button-toggle [value]="1">
             <i kbq-icon="kbq-info-circle_16"></i>
             Курьером

--- a/packages/docs-examples/components/button-toggle/button-toggle-disabled-partial-overview/button-toggle-disabled-partial-overview-example.html
+++ b/packages/docs-examples/components/button-toggle/button-toggle-disabled-partial-overview/button-toggle-disabled-partial-overview-example.html
@@ -1,6 +1,6 @@
 <div class="layout-margin-bottom-m">
     <kbq-button-toggle-group #group1="kbqButtonToggleGroup">
-        <kbq-button-toggle disabled="true" [checked]="true" [value]="1">
+        <kbq-button-toggle [checked]="true" [disabled]="true" [value]="1">
             <i kbq-icon="kbq-play_16"></i>
             Курьером
         </kbq-button-toggle>
@@ -25,7 +25,7 @@
             <i kbq-icon="kbq-play_16"></i>
             Ослик Экспресс
         </kbq-button-toggle>
-        <kbq-button-toggle disabled [value]="3">
+        <kbq-button-toggle [disabled]="true" [value]="3">
             <i kbq-icon="kbq-play_16"></i>
             Почтой Средиземья
         </kbq-button-toggle>

--- a/packages/docs-examples/components/button-toggle/button-toggle-tooltip-overview/button-toggle-tooltip-overview-example.css
+++ b/packages/docs-examples/components/button-toggle/button-toggle-tooltip-overview/button-toggle-tooltip-overview-example.css
@@ -24,9 +24,3 @@
     > :not(:last-child) {
     margin-right: 4px;
 }
-
-.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button .kbq-button-toggle-wrapper .kbq-icon,
-.kbq-button-toggle-group .kbq-button-toggle > ::ng-deep .kbq-button-icon .kbq-button-toggle-wrapper .kbq-icon {
-    position: relative;
-    top: -1px;
-}


### PR DESCRIPTION
## Summary
Hidden focus line from underlying `kbqButton` and moved to `button-toggle-item`