### PR TITLE
fix(tabs): missing underline in tab-nav-bar (#DS-3405)

### DIFF
--- a/packages/components-dev/tabs/template.html
+++ b/packages/components-dev/tabs/template.html
@@ -11,6 +11,19 @@
 
 <hr />
 
+<h3>Nav-bar tabs underlined</h3>
+<nav kbqTabNavBar underlined [tabNavPanel]="kbqTabNavPanel1">
+    @for (link of links; track link; let index = $index) {
+        @let disabled = index === 1;
+        <a kbqTabLink [active]="activeLink === link" [disabled]="disabled" (click)="activeLink = link">
+            {{ link }}
+        </a>
+    }
+</nav>
+<div #kbqTabNavPanel1="kbqTabNavPanel" kbqTabNavPanel>activeLink: {{ activeLink }}</div>
+
+<hr />
+
 <h3>Nav-bar tabs vertical</h3>
 <div class="layout-row">
     <nav kbqTabNavBar vertical [style.height.px]="160" [style.width.px]="120" [tabNavPanel]="kbqTabNavPanel2">

--- a/packages/components/tabs/_tabs-common.scss
+++ b/packages/components/tabs/_tabs-common.scss
@@ -111,4 +111,18 @@
             display: flex;
         }
     }
+
+    .kbq-tab-list__active-tab-underline {
+        display: none;
+    }
+
+    .kbq-tab-header_underlined:not(.kbq-tab-header_vertical) .kbq-tab-list__active-tab-underline {
+        display: block;
+        position: absolute;
+        bottom: 0;
+        height: 3px;
+        border-radius: 2px 2px 0 0;
+        background: var(--kbq-line-contrast);
+        transition: all 0.2s ease-in-out;
+    }
 }

--- a/packages/components/tabs/tab-header.scss
+++ b/packages/components/tabs/tab-header.scss
@@ -40,20 +40,6 @@
     background: var(--kbq-line-contrast-less);
 }
 
-.kbq-tab-list__active-tab-underline {
-    display: none;
-}
-
-.kbq-tab-header_underlined:not(.kbq-tab-header_vertical) .kbq-tab-list__active-tab-underline {
-    display: block;
-    position: absolute;
-    bottom: 0;
-    height: 3px;
-    border-radius: 2px 2px 0 0;
-    background: var(--kbq-line-contrast);
-    transition: all 0.2s ease-in-out;
-}
-
 .kbq-tab-header__container {
     display: flex;
     flex-grow: 1;


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!
-->

## Summary

tab-nav-bar renders same tab underline indicator (`.kbq-tab-list__active-tab-underline`) as in tab-header, but it misses specific CSS rules which should style & position indicator properly.


## List of notable changes:

Fix is to move styles related to tab underline indicator under `paginated-tab-header` mixin.

closes DS-3405


## What should reviewers focus on?

