### PR TITLE
feat(select,tree-select): moved common logic to separate class

### DIFF
--- a/packages/components/core/select/common.ts
+++ b/packages/components/core/select/common.ts
@@ -107,13 +107,17 @@ export class KbqSelectSearch implements AfterContentInit, OnDestroy {
 export class KbqSelectSearchEmptyResult {}
 
 /**
- * Common Select Behaviour
+ * Abstract class representing a customizable select component with an overlay.
+ *
+ * This class provides base functionality for handling the overlay positioning.
  * @docs-private
  */
 export abstract class KbqAbstractSelect {
     protected abstract overlayDir: CdkConnectedOverlay;
-    protected abstract overlayPanelClass: string;
     protected abstract triggerRect: DOMRect;
+
+    /** Overlay panel class. */
+    protected readonly overlayPanelClass = 'kbq-select-overlay';
 
     protected setOverlayPosition() {
         this.resetOverlay();

--- a/packages/components/core/select/common.ts
+++ b/packages/components/core/select/common.ts
@@ -113,8 +113,8 @@ export class KbqSelectSearchEmptyResult {}
  * @docs-private
  */
 export abstract class KbqAbstractSelect {
-    protected abstract overlayDir: CdkConnectedOverlay;
-    protected abstract triggerRect: DOMRect;
+    protected overlayDir: CdkConnectedOverlay;
+    protected triggerRect: DOMRect;
 
     /** Overlay panel class. */
     protected readonly overlayPanelClass = 'kbq-select-overlay';

--- a/packages/components/select/select.component.ts
+++ b/packages/components/select/select.component.ts
@@ -139,9 +139,6 @@ export class KbqSelectBase extends KbqAbstractSelect {
      */
     readonly stateChanges = new Subject<void>();
 
-    protected overlayDir: CdkConnectedOverlay;
-    protected triggerRect: DOMRect;
-
     constructor(
         public elementRef: ElementRef,
         public defaultErrorStateMatcher: ErrorStateMatcher,

--- a/packages/components/select/select.component.ts
+++ b/packages/components/select/select.component.ts
@@ -71,6 +71,7 @@ import {
     KBQ_OPTION_PARENT_COMPONENT,
     KBQ_PARENT_POPUP,
     KBQ_SELECT_SCROLL_STRATEGY,
+    KbqAbstractSelect,
     KbqLocaleService,
     KbqOptgroup,
     KbqOption,
@@ -81,7 +82,6 @@ import {
     KbqSelectSearch,
     KbqSelectTrigger,
     KbqVirtualOption,
-    SELECT_PANEL_VIEWPORT_PADDING,
     defaultOffsetY,
     getKbqSelectDynamicMultipleError,
     getKbqSelectNonArrayValueError,
@@ -131,7 +131,7 @@ export const kbqSelectOptionsProvider = (options: KbqSelectOptions): Provider =>
 };
 
 /** @docs-private */
-export class KbqSelectBase {
+export class KbqSelectBase extends KbqAbstractSelect {
     /**
      * Emits whenever the component state changes and should cause the parent
      * form-field to update. Implemented as part of `KbqFormFieldControl`.
@@ -139,13 +139,18 @@ export class KbqSelectBase {
      */
     readonly stateChanges = new Subject<void>();
 
+    protected overlayDir: CdkConnectedOverlay;
+    protected triggerRect: DOMRect;
+
     constructor(
         public elementRef: ElementRef,
         public defaultErrorStateMatcher: ErrorStateMatcher,
         public parentForm: NgForm,
         public parentFormGroup: FormGroupDirective,
         public ngControl: NgControl
-    ) {}
+    ) {
+        super();
+    }
 }
 
 /** @docs-private */
@@ -559,9 +564,6 @@ export class KbqSelect
 
     /** Min width of the overlay panel. */
     protected overlayMinWidth: string | number;
-
-    /** Overlay panel class. */
-    protected readonly overlayPanelClass = 'kbq-select-overlay';
 
     /** Origin for the overlay panel. */
     protected overlayOrigin?: CdkOverlayOrigin | ElementRef;
@@ -1334,72 +1336,6 @@ export class KbqSelect
     /** Scrolls the active option into view. */
     private scrollActiveOptionIntoView(): void {
         this.keyManager.activeItem?.focus();
-    }
-
-    /**
-     * Sets the x-offset of the overlay panel in relation to the trigger's top start corner.
-     * This must be adjusted to align the selected option text over the trigger text when
-     * the panel opens. Will change based on LTR or RTL text direction. Note that the offset
-     * can't be calculated until the panel has been attached, because we need to know the
-     * content width in order to constrain the panel within the viewport.
-     */
-    private setOverlayPosition(): void {
-        this.resetOverlay();
-
-        const overlayRect = this.getOverlayRect();
-        // Window width without scrollbar
-        const windowWidth = this.overlayDir.overlayRef?.hostElement.clientWidth;
-        let offsetX: number = 0;
-        let overlayMaxWidth: number;
-
-        // Determine if select overflows on either side.
-        const leftOverflow = -overlayRect.left;
-        const rightOverflow = overlayRect.right - windowWidth;
-
-        // If the element overflows on either side, reduce the offset to allow it to fit.
-        if (leftOverflow > 0 || rightOverflow > 0) {
-            [offsetX, overlayMaxWidth] = this.calculateOverlayXPosition(windowWidth);
-            this.overlayDir.overlayRef.overlayElement.style.maxWidth = `${overlayMaxWidth}px`;
-            // reset the minWidth property
-            this.overlayDir.overlayRef.overlayElement.style.minWidth = '';
-        }
-
-        // Set the offset directly in order to avoid having to go through change detection and
-        // potentially triggering "changed after it was checked" errors. Round the value to avoid
-        // blurry content in some browsers.
-        this.overlayDir.offsetX = Math.round(offsetX);
-        this.overlayDir.overlayRef.updatePosition();
-    }
-
-    private calculateOverlayXPosition(windowWidth: number) {
-        let offsetX = 0;
-        const { left: leftIndent, right: triggerRight, width: triggerWidth } = this.triggerRect;
-        const { width: overlayRectWidth } = this.getOverlayRect();
-        const rightIndent = windowWidth - triggerRight;
-        // Setting direction of dropdown expansion
-        const isRightDirection = leftIndent <= rightIndent;
-
-        const indent = isRightDirection ? rightIndent : leftIndent;
-        const maxDropdownWidth = indent + triggerWidth - SELECT_PANEL_VIEWPORT_PADDING;
-        const overlayMaxWidth = overlayRectWidth < maxDropdownWidth ? overlayRectWidth : maxDropdownWidth;
-
-        if (!isRightDirection) {
-            const leftOffset = triggerRight - overlayMaxWidth;
-            offsetX -= leftIndent - leftOffset;
-        }
-
-        return [offsetX, overlayMaxWidth];
-    }
-
-    private resetOverlay(): void {
-        this.overlayDir.overlayRef.hostElement.classList.add(this.overlayPanelClass);
-        this.overlayDir.offsetX = 0;
-        this.overlayDir.overlayRef.overlayElement.style.maxWidth = 'unset';
-        this.overlayDir.overlayRef.updatePosition();
-    }
-
-    private getOverlayRect(): DOMRect {
-        return this.overlayDir.overlayRef.overlayElement.getBoundingClientRect();
     }
 
     /** Gets how wide the overlay panel should be. */

--- a/packages/components/tree-select/tree-select.component.ts
+++ b/packages/components/tree-select/tree-select.component.ts
@@ -137,9 +137,6 @@ class KbqTreeSelectBase extends KbqAbstractSelect {
      */
     readonly stateChanges = new Subject<void>();
 
-    protected overlayDir: CdkConnectedOverlay;
-    protected triggerRect: DOMRect;
-
     constructor(
         public elementRef: ElementRef,
         public defaultErrorStateMatcher: ErrorStateMatcher,

--- a/packages/components/tree-select/tree-select.component.ts
+++ b/packages/components/tree-select/tree-select.component.ts
@@ -63,12 +63,12 @@ import {
     KBQ_LOCALE_SERVICE,
     KBQ_PARENT_POPUP,
     KBQ_SELECT_SCROLL_STRATEGY,
+    KbqAbstractSelect,
     KbqLocaleService,
     KbqSelectMatcher,
     KbqSelectSearch,
     KbqSelectTrigger,
     MultipleMode,
-    SELECT_PANEL_VIEWPORT_PADDING,
     defaultOffsetY,
     getKbqSelectDynamicMultipleError,
     getKbqSelectNonArrayValueError,
@@ -129,7 +129,7 @@ export class KbqTreeSelectChange {
 }
 
 /** @docs-private */
-class KbqTreeSelectBase {
+class KbqTreeSelectBase extends KbqAbstractSelect {
     /**
      * Emits whenever the component state changes and should cause the parent
      * form-field to update. Implemented as part of `KbqFormFieldControl`.
@@ -137,13 +137,18 @@ class KbqTreeSelectBase {
      */
     readonly stateChanges = new Subject<void>();
 
+    protected overlayDir: CdkConnectedOverlay;
+    protected triggerRect: DOMRect;
+
     constructor(
         public elementRef: ElementRef,
         public defaultErrorStateMatcher: ErrorStateMatcher,
         public parentForm: NgForm,
         public parentFormGroup: FormGroupDirective,
         public ngControl: NgControl
-    ) {}
+    ) {
+        super();
+    }
 }
 
 /** @docs-private */
@@ -464,9 +469,6 @@ export class KbqTreeSelect
 
     /** Min width of the overlay panel. */
     protected overlayMinWidth: string | number;
-
-    /** Overlay panel class. */
-    protected readonly overlayPanelClass = 'kbq-select-overlay';
 
     /** Origin for the overlay panel. */
     protected overlayOrigin?: CdkOverlayOrigin | ElementRef;
@@ -866,7 +868,7 @@ export class KbqTreeSelect
     onAttached() {
         this.overlayDir.positionChange.pipe(take(1)).subscribe(() => {
             this.changeDetectorRef.detectChanges();
-            this.calculateOverlayOffsetX();
+            this.setOverlayPosition();
             this.panel.nativeElement.scrollTop = this.scrollTop;
 
             this.tree.updateScrollSize();
@@ -1206,36 +1208,6 @@ export class KbqTreeSelect
     /** Scrolls the active option into view. */
     private scrollActiveOptionIntoView() {
         this.tree.keyManager.activeItem?.focus();
-    }
-
-    /**
-     * Sets the x-offset of the overlay panel in relation to the trigger's top start corner.
-     * This must be adjusted to align the selected option text over the trigger text when
-     * the panel opens. Will change based on LTR or RTL text direction. Note that the offset
-     * can't be calculated until the panel has been attached, because we need to know the
-     * content width in order to constrain the panel within the viewport.
-     */
-    private calculateOverlayOffsetX() {
-        const overlayRect = this.overlayDir.overlayRef.overlayElement.getBoundingClientRect();
-        const windowWidth = this.overlayDir.overlayRef?.hostElement.clientWidth;
-        let offsetX: number = 0;
-
-        // Determine how much the select overflows on each side.
-        const leftOverflow = -overlayRect.left;
-        const rightOverflow = overlayRect.right - windowWidth;
-
-        // If the element overflows on either side, reduce the offset to allow it to fit.
-        if (leftOverflow > 0) {
-            offsetX += leftOverflow + SELECT_PANEL_VIEWPORT_PADDING;
-        } else if (rightOverflow > 0) {
-            offsetX -= rightOverflow + SELECT_PANEL_VIEWPORT_PADDING;
-        }
-
-        // Set the offset directly in order to avoid having to go through change detection and
-        // potentially triggering "changed after it was checked" errors. Round the value to avoid
-        // blurry content in some browsers.
-        this.overlayDir.offsetX = Math.round(offsetX);
-        this.overlayDir.overlayRef.updatePosition();
     }
 
     private subscribeOnSearchChanges() {

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -11,6 +11,7 @@ import { AfterViewInit } from '@angular/core';
 import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
 import { AnimationTriggerMetadata } from '@angular/animations';
 import { BehaviorSubject } from 'rxjs';
+import { CdkConnectedOverlay } from '@angular/cdk/overlay';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ConnectedOverlayPositionChange } from '@angular/cdk/overlay';
@@ -1186,6 +1187,23 @@ export const KBQ_TITLE_TEXT_REF: InjectionToken<KbqTitleTextRef>;
 
 // @public @deprecated (undocumented)
 export const KBQ_VALIDATION: InjectionToken<KbqValidationOptions>;
+
+// @public
+export abstract class KbqAbstractSelect {
+    // (undocumented)
+    protected calculateOverlayOffsetX(baseOffsetX: number): number[];
+    // (undocumented)
+    protected getOverlayRect(): DOMRect;
+    // (undocumented)
+    protected abstract overlayDir: CdkConnectedOverlay;
+    protected readonly overlayPanelClass = "kbq-select-overlay";
+    // (undocumented)
+    protected resetOverlay(): void;
+    // (undocumented)
+    protected setOverlayPosition(): void;
+    // (undocumented)
+    protected abstract triggerRect: DOMRect;
+}
 
 // @public
 export type KbqCodeBlockLocaleConfiguration = {

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -1195,14 +1195,14 @@ export abstract class KbqAbstractSelect {
     // (undocumented)
     protected getOverlayRect(): DOMRect;
     // (undocumented)
-    protected abstract overlayDir: CdkConnectedOverlay;
+    protected overlayDir: CdkConnectedOverlay;
     protected readonly overlayPanelClass = "kbq-select-overlay";
     // (undocumented)
     protected resetOverlay(): void;
     // (undocumented)
     protected setOverlayPosition(): void;
     // (undocumented)
-    protected abstract triggerRect: DOMRect;
+    protected triggerRect: DOMRect;
 }
 
 // @public

--- a/tools/public_api_guard/components/select.api.md
+++ b/tools/public_api_guard/components/select.api.md
@@ -33,6 +33,7 @@ import * as i6 from '@koobiq/components/tags';
 import * as i7 from '@koobiq/components/tooltip';
 import * as i8 from '@angular/common';
 import { InjectionToken } from '@angular/core';
+import { KbqAbstractSelect } from '@koobiq/components/core';
 import { KbqCleaner } from '@koobiq/components/form-field';
 import { KbqFormField } from '@koobiq/components/form-field';
 import { KbqFormFieldControl } from '@koobiq/components/form-field';
@@ -206,7 +207,6 @@ export class KbqSelect extends KbqSelectMixinBase implements AfterContentInit, A
     overlayDir: CdkConnectedOverlay;
     protected overlayMinWidth: string | number;
     protected overlayOrigin?: CdkOverlayOrigin | ElementRef;
-    protected readonly overlayPanelClass = "kbq-select-overlay";
     protected overlayWidth: string | number;
     // (undocumented)
     panel: ElementRef;
@@ -262,7 +262,7 @@ export class KbqSelect extends KbqSelectMixinBase implements AfterContentInit, A
 }
 
 // @public
-export class KbqSelectBase {
+export class KbqSelectBase extends KbqAbstractSelect {
     constructor(elementRef: ElementRef, defaultErrorStateMatcher: ErrorStateMatcher, parentForm: NgForm, parentFormGroup: FormGroupDirective, ngControl: NgControl);
     // (undocumented)
     defaultErrorStateMatcher: ErrorStateMatcher;
@@ -271,10 +271,14 @@ export class KbqSelectBase {
     // (undocumented)
     ngControl: NgControl;
     // (undocumented)
+    protected overlayDir: CdkConnectedOverlay;
+    // (undocumented)
     parentForm: NgForm;
     // (undocumented)
     parentFormGroup: FormGroupDirective;
     readonly stateChanges: Subject<void>;
+    // (undocumented)
+    protected triggerRect: DOMRect;
 }
 
 // @public

--- a/tools/public_api_guard/components/select.api.md
+++ b/tools/public_api_guard/components/select.api.md
@@ -271,14 +271,10 @@ export class KbqSelectBase extends KbqAbstractSelect {
     // (undocumented)
     ngControl: NgControl;
     // (undocumented)
-    protected overlayDir: CdkConnectedOverlay;
-    // (undocumented)
     parentForm: NgForm;
     // (undocumented)
     parentFormGroup: FormGroupDirective;
     readonly stateChanges: Subject<void>;
-    // (undocumented)
-    protected triggerRect: DOMRect;
 }
 
 // @public

--- a/tools/public_api_guard/components/tree-select.api.md
+++ b/tools/public_api_guard/components/tree-select.api.md
@@ -31,6 +31,7 @@ import * as i5 from '@koobiq/components/tags';
 import * as i6 from '@koobiq/components/core';
 import * as i7 from '@angular/common';
 import { InjectionToken } from '@angular/core';
+import { KbqAbstractSelect } from '@koobiq/components/core';
 import { KbqCleaner } from '@koobiq/components/form-field';
 import { KbqFormField } from '@koobiq/components/form-field';
 import { KbqFormFieldControl } from '@koobiq/components/form-field';
@@ -161,7 +162,6 @@ export class KbqTreeSelect extends KbqTreeSelectMixinBase implements AfterConten
     overlayDir: CdkConnectedOverlay;
     protected overlayMinWidth: string | number;
     protected overlayOrigin?: CdkOverlayOrigin | ElementRef;
-    protected readonly overlayPanelClass = "kbq-select-overlay";
     protected overlayWidth: string | number;
     // (undocumented)
     panel: ElementRef;


### PR DESCRIPTION
## Summary

Вынес логику позиционирования оверлея в отдельный класс. 

Взял за основу `KbqSelect`. В нем при выходе оверлея за границы видимой области, оверлей сжимается, чтобы был виден контент селекта.

Select:

https://github.com/user-attachments/assets/f8a348f7-2f66-42e8-be7f-ab714aab15e1

Tree Select:

https://github.com/user-attachments/assets/713f3a81-45b9-4330-900b-bae469bd28fb
