### PR TITLE
fix(tabs): incomplete underline styles in tab-nav-bar (#DS-3416)

### DIFF
--- a/packages/components/tabs/_tabs-common.scss
+++ b/packages/components/tabs/_tabs-common.scss
@@ -112,6 +112,20 @@
         }
     }
 
+    .kbq-tab-header_underlined:not(.kbq-tab-header_vertical) .kbq-tab-list__content {
+        padding: 8px 0;
+    }
+
+    .kbq-tab-header_underlined:not(.kbq-tab-header_vertical):after {
+        content: '';
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        height: 1px;
+        background: var(--kbq-line-contrast-less);
+    }
+
     .kbq-tab-list__active-tab-underline {
         display: none;
     }

--- a/packages/components/tabs/tab-header.scss
+++ b/packages/components/tabs/tab-header.scss
@@ -26,20 +26,6 @@
     flex-direction: column;
 }
 
-.kbq-tab-header_underlined:not(.kbq-tab-header_vertical) .kbq-tab-list__content {
-    padding: 8px 0;
-}
-
-.kbq-tab-header_underlined:not(.kbq-tab-header_vertical):after {
-    content: '';
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    height: 1px;
-    background: var(--kbq-line-contrast-less);
-}
-
 .kbq-tab-header__container {
     display: flex;
     flex-grow: 1;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
-->

## Summary

Move underline styles under `paginated-tab-header` mixin

## List of notable changes:

\-

## What should reviewers focus on?

\-
