### PR TITLE
fix(docs): manual installation guide rewritten (#DS-3415)

### DIFF
--- a/docs/guides/installation.en.md
+++ b/docs/guides/installation.en.md
@@ -10,14 +10,15 @@ If you prefer not to use **schematics** or want to add `@koobiq/components` to a
 you need to install the following dependencies:
 
 ```bash
-npm install
-npm install @koobiq/cdk
-npm install @koobiq/components
-npm install @koobiq/icons
-npm install @koobiq/design-tokens
-npm install @koobiq/angular-luxon-adapter
-npm install @koobiq/date-adapter
-npm install @koobiq/date-formatter
-npm install luxon
-npm install @messageformat/core
+npm install \
+    @koobiq/cdk \
+    @koobiq/components \
+    @koobiq/icons \
+    @koobiq/design-tokens \
+    @koobiq/angular-luxon-adapter \
+    @koobiq/date-adapter \
+    @koobiq/date-formatter \
+    luxon \
+    @messageformat/core \
+    @radix-ng/primitives@^0.14.0
 ```

--- a/docs/guides/installation.en.md
+++ b/docs/guides/installation.en.md
@@ -11,14 +11,13 @@ you need to install the following dependencies:
 
 ```bash
 npm install
-    @koobiq/cdk
-    @koobiq/components
-    @koobiq/icons
-    @koobiq/design-tokens
-    @koobiq/angular-luxon-adapter
-    @koobiq/date-adapter
-    @koobiq/date-formatter
-    luxon
-    @messageformat/core
-    @radix-ng/primitives
+npm install @koobiq/cdk
+npm install @koobiq/components
+npm install @koobiq/icons
+npm install @koobiq/design-tokens
+npm install @koobiq/angular-luxon-adapter
+npm install @koobiq/date-adapter
+npm install @koobiq/date-formatter
+npm install luxon
+npm install @messageformat/core
 ```

--- a/docs/guides/installation.en.md
+++ b/docs/guides/installation.en.md
@@ -10,15 +10,14 @@ If you prefer not to use **schematics** or want to add `@koobiq/components` to a
 you need to install the following dependencies:
 
 ```bash
-npm install \
-    @koobiq/cdk \
-    @koobiq/components \
-    @koobiq/icons \
-    @koobiq/design-tokens \
-    @koobiq/angular-luxon-adapter \
-    @koobiq/date-adapter \
-    @koobiq/date-formatter \
-    luxon \
-    @messageformat/core \
-    @radix-ng/primitives@^0.14.0
+npm install @koobiq/cdk
+npm install @koobiq/components
+npm install @koobiq/icons
+npm install @koobiq/design-tokens
+npm install @koobiq/angular-luxon-adapter
+npm install @koobiq/date-adapter
+npm install @koobiq/date-formatter
+npm install luxon
+npm install @messageformat/core
+npm install @radix-ng/primitives@^0.14.0
 ```

--- a/docs/guides/installation.ru.md
+++ b/docs/guides/installation.ru.md
@@ -10,14 +10,15 @@ ng add @koobiq/components
 вам необходимо установить следующие зависимости:
 
 ```bash
-npm install
-npm install @koobiq/cdk
-npm install @koobiq/components
-npm install @koobiq/icons
-npm install @koobiq/design-tokens
-npm install @koobiq/angular-luxon-adapter
-npm install @koobiq/date-adapter
-npm install @koobiq/date-formatter
-npm install luxon
-npm install @messageformat/core
+npm install \
+    @koobiq/cdk \
+    @koobiq/components \
+    @koobiq/icons \
+    @koobiq/design-tokens \
+    @koobiq/angular-luxon-adapter \
+    @koobiq/date-adapter \
+    @koobiq/date-formatter \
+    luxon \
+    @messageformat/core \
+    @radix-ng/primitives@^0.14.0
 ```

--- a/docs/guides/installation.ru.md
+++ b/docs/guides/installation.ru.md
@@ -11,14 +11,13 @@ ng add @koobiq/components
 
 ```bash
 npm install
-    @koobiq/cdk
-    @koobiq/components
-    @koobiq/icons
-    @koobiq/design-tokens
-    @koobiq/angular-luxon-adapter
-    @koobiq/date-adapter
-    @koobiq/date-formatter
-    luxon
-    @messageformat/core
-    @radix-ng/primitives
+npm install @koobiq/cdk
+npm install @koobiq/components
+npm install @koobiq/icons
+npm install @koobiq/design-tokens
+npm install @koobiq/angular-luxon-adapter
+npm install @koobiq/date-adapter
+npm install @koobiq/date-formatter
+npm install luxon
+npm install @messageformat/core
 ```

--- a/docs/guides/installation.ru.md
+++ b/docs/guides/installation.ru.md
@@ -10,15 +10,14 @@ ng add @koobiq/components
 вам необходимо установить следующие зависимости:
 
 ```bash
-npm install \
-    @koobiq/cdk \
-    @koobiq/components \
-    @koobiq/icons \
-    @koobiq/design-tokens \
-    @koobiq/angular-luxon-adapter \
-    @koobiq/date-adapter \
-    @koobiq/date-formatter \
-    luxon \
-    @messageformat/core \
-    @radix-ng/primitives@^0.14.0
+npm install @koobiq/cdk
+npm install @koobiq/components
+npm install @koobiq/icons
+npm install @koobiq/design-tokens
+npm install @koobiq/angular-luxon-adapter
+npm install @koobiq/date-adapter
+npm install @koobiq/date-formatter
+npm install luxon
+npm install @messageformat/core
+npm install @radix-ng/primitives@^0.14.0
 ```


### PR DESCRIPTION
## Summary
Исправил инструкцию по установке.

Удалил `@radix-ng/primitives` из гайда по ручной установке, т.к. сыпятся ошибки ( в последней версии библиотеки - angular 19, а у нас пока 18).

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: untitled@0.0.0
npm error Found: @angular/cdk@18.2.14
npm error node_modules/@angular/cdk
npm error   @angular/cdk@"^18.2.6" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @angular/cdk@"^19.1.0" from @radix-ng/primitives@0.32.2
npm error node_modules/@radix-ng/primitives
npm error   @radix-ng/primitives@"*" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.

```
