### PR TITLE
fix(timezone): rounded timezone options (#DS-3429)

### DIFF
--- a/packages/components/core/option/option-tokens.scss
+++ b/packages/components/core/option/option-tokens.scss
@@ -1,10 +1,14 @@
 @use '../../list/list-tokens';
 
-.kbq-option {
+%kbq-option-geometry-tokens {
     --kbq-option-size-horizontal-padding: var(--kbq-size-m);
     --kbq-option-size-height: var(--kbq-size-3xl);
     --kbq-option-size-border-width: 2px;
     --kbq-option-border-radius: var(--kbq-size-xs);
+}
+
+.kbq-option {
+    @extend %kbq-option-geometry-tokens;
     /* LIST THEME TOKENS */
     @include list-tokens.list-theme-tokens;
 }

--- a/packages/components/timezone/timezone-option-tokens.scss
+++ b/packages/components/timezone/timezone-option-tokens.scss
@@ -1,4 +1,5 @@
 @use '../list/list-tokens';
+@use '../core/option/option-tokens';
 
 .kbq-timezone-select__panel {
     --kbq-select-size-single-padding-left: var(--kbq-size-m);
@@ -20,5 +21,5 @@
     --kbq-timezone-option-caption: var(--kbq-foreground-contrast-secondary);
     --kbq-timezone-option-optgroup-label: var(--kbq-foreground-contrast-secondary);
     /* LIST THEME TOKENS */
-    @include list-tokens.list-theme-tokens;
+    @extend %kbq-option-geometry-tokens;
 }

--- a/packages/components/timezone/timezone-option-tokens.scss
+++ b/packages/components/timezone/timezone-option-tokens.scss
@@ -9,7 +9,7 @@
     --kbq-select-size-multiple-padding-left: var(--kbq-size-xxs);
     --kbq-select-size-multiple-padding-right: var(--kbq-size-xxs);
     --kbq-select-size-multiple-content-gap: var(--kbq-size-xxs);
-    --kbq-timezone-option-size-padding: 6px 10px;
+    --kbq-timezone-option-size-padding: var(--kbq-size-xxs) 10px;
     --kbq-timezone-option-size-column-gap: 16px;
     --kbq-timezone-option-size-height: auto;
     --kbq-timezone-option-size-max-height: 5em;


### PR DESCRIPTION
## Summary

To make option tokens as a single source of truth, moved geometry tokens to placeholder class and extended in timezone option

<details>
    <summary>ru-RU</summary>
    
Чтобы использовать токены option как единый источник правды, переместил токены в плейсхолдер-класс и расширил в `timezone-option`
</details>