### PR TITLE
fix(navbar): async item alignment in vertical navbar (#DS-3519)

### DIFF
--- a/packages/components-dev/navbar/module.ts
+++ b/packages/components-dev/navbar/module.ts
@@ -15,6 +15,7 @@ import { KbqModalModule, KbqModalRef, KbqModalService } from '@koobiq/components
 import { KbqNavbar, KbqNavbarModule } from '@koobiq/components/navbar';
 import { KbqPopoverModule } from '@koobiq/components/popover';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
+import { map, timer } from 'rxjs';
 
 @Component({
     selector: 'app',
@@ -44,6 +45,8 @@ export class NavbarDemoComponent {
     componentModal: KbqModalRef;
 
     private _collapsedNavbarWidth: number = 1280;
+
+    permission$ = timer(500).pipe(map(() => true));
 
     constructor(private modalService: KbqModalService) {}
 

--- a/packages/components-dev/navbar/template.html
+++ b/packages/components-dev/navbar/template.html
@@ -198,6 +198,14 @@
                     }
                 </button>
             </kbq-navbar-item>
+
+            <!-- Asynchronous navbar-item -->
+            @if (permission$ | async) {
+                <button #navbarItemAdmin kbq-navbar-item>
+                    <i kbq-icon="kbq-bsd_16"></i>
+                    <span kbq-navbar-title>Настройки</span>
+                </button>
+            }
         </kbq-navbar-container>
 
         <kbq-navbar-container>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
-->

## Summary

Hello!

When using `vertical-navbar` & asynchronously added `kbq-navbar-item`, that item's `extended` state goes out of sync. Thus `kbq-navbar-item` is misaligned (at least until expanded state in navbar is changed).

Fix is to add "expanded state update" operation on every `rectangleElements` change.

## List of notable changes:

Also added example case in components-dev to be able to verify that case 419e356b42fd16776576c5949a6650e4ad904e0a

## What should reviewers focus on?

Made sure that there's only one `.forEach(...)` for both "expanded state update" & "set item vertical state" operations.

Also replaced `Promise.resolve().then(() => ...)` with `queuMicrotask(() => ...)`. Example still works without `NG0100` error.