### PR TITLE
fix(radio): removed duplicated input styles

### DIFF
--- a/packages/components/radio/radio.scss
+++ b/packages/components/radio/radio.scss
@@ -96,12 +96,6 @@
     }
 }
 
-.kbq-radio-input {
-    position: absolute;
-    outline: none;
-    opacity: 0;
-}
-
 .kbq-radio-button.kbq-radio-button_big {
     .kbq-radio-label-content {
         padding-left: kbq-sum-series-css-variables(


### PR DESCRIPTION
input already contains [`cdk-visually-hidden`](https://github.com/koobiq/angular-components/blob/333f8bf5cc3cf7a00efa29c0e8e376671de75fd5/packages/components/radio/radio.component.html#L5) selector