### PR TITLE
fix(dl): does not switch to vertical on initial render (#DS-3542)

### DIFF
--- a/packages/components-dev/dl/template.html
+++ b/packages/components-dev/dl/template.html
@@ -91,3 +91,10 @@
         authentication. For getting authentication details run the following command
     </kbq-dd>
 </kbq-dl>
+
+<br />
+
+<kbq-dl style="width: 590px" class="docs-border" [minWidth]="600">
+    <kbq-dt>Description</kbq-dt>
+    <kbq-dd>This should be rendered in vertical mode</kbq-dd>
+</kbq-dl>

--- a/packages/components-dev/dl/template.html
+++ b/packages/components-dev/dl/template.html
@@ -1,4 +1,4 @@
-<kbq-dl [minWidth]="600">
+<kbq-dl [minWidth]="590">
     <kbq-dt>Тип инцидента</kbq-dt>
     <kbq-dd>Вредоносное ПО</kbq-dd>
 
@@ -20,7 +20,7 @@
 
 <br />
 
-<kbq-dl [minWidth]="600" [wide]="true">
+<kbq-dl [minWidth]="590" [wide]="true">
     <kbq-dt>File</kbq-dt>
     <kbq-dd>125 КБ</kbq-dd>
 
@@ -77,14 +77,14 @@
 
 <br />
 
-<kbq-dl [minWidth]="600">
+<kbq-dl [minWidth]="590">
     <kbq-dt>Never show GUIDs</kbq-dt>
     <kbq-dd>f3a9583e-346c-4a52-9ddb-252fd34ea9f0</kbq-dd>
 </kbq-dl>
 
 <br />
 
-<kbq-dl [minWidth]="600">
+<kbq-dl [minWidth]="590">
     <kbq-dt>Description</kbq-dt>
     <kbq-dd>
         In order for your npm command line client to work with Artifactory you will firstly need to set the relevant

--- a/packages/components/dl/dl.component.ts
+++ b/packages/components/dl/dl.component.ts
@@ -1,6 +1,15 @@
-import { AfterContentInit, Component, ElementRef, inject, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
+import {
+    AfterContentInit,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    inject,
+    Input,
+    OnDestroy,
+    ViewEncapsulation
+} from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
+import { debounceTime, startWith } from 'rxjs/operators';
 
 @Component({
     selector: 'kbq-dl',
@@ -25,6 +34,7 @@ export class KbqDlComponent implements AfterContentInit, OnDestroy {
     private resizeSubscription = Subscription.EMPTY;
 
     private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+    private readonly changeDetectorRef = inject(ChangeDetectorRef);
 
     ngAfterContentInit(): void {
         if (this.vertical !== null) {
@@ -32,7 +42,7 @@ export class KbqDlComponent implements AfterContentInit, OnDestroy {
         }
 
         this.resizeSubscription = this.resizeStream
-            .pipe(debounceTime(this.resizeDebounceInterval))
+            .pipe(startWith(null), debounceTime(this.resizeDebounceInterval))
             .subscribe(this.updateState);
     }
 
@@ -43,7 +53,10 @@ export class KbqDlComponent implements AfterContentInit, OnDestroy {
     private readonly updateState = (): void => {
         const domRect = this.elementRef.nativeElement.getClientRects()[0];
         const width = domRect?.width || 0;
+
         this.vertical = width <= this.minWidth;
+
+        this.changeDetectorRef.markForCheck();
     };
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
-->

## Summary

On initial render, there can be case when kbq-dl width is already less than `minWidth` property.

## List of notable changes:

Also added example case in components-dev to be able to verify that case.

## What should reviewers focus on?

Could be also fixed by changing `resizeStream` to `BehaviorSubject`, but for me `startWith(null)` better informs the intention of needing the initial event.

**Update**: 
Move to standalone in 8655b5da337506a7ae15fe1846a73a3324e61e69 [introduced](https://github.com/impankratov/angular-components/blob/d6378a7b/packages/components-dev/dl/module.ts#L12) "OnPush" strategy in `DlDev` component, thus initial fix stopped working. Had to add `markForCheck` to trigger change detection run and pick up updated `vertical` value.

Also I've noticed that all examples in `DlDev` will be switched to vertical after this fix. Thus tweaked them so they are horizontal and only new example is vertical.