### PR TITLE
fix(form-field, select, tree-select): legacy validate directive selector (#DS-3515)

### DIFF
--- a/packages/components/form-field/_form-field-theme.scss
+++ b/packages/components/form-field/_form-field-theme.scss
@@ -41,7 +41,7 @@
         }
 
         &.kbq-form-field_invalid,
-        &.ng-invalid {
+        &.kbq-form-field_has-validate-directive.ng-invalid {
             @include kbq-form-field-state(states-error);
         }
 
@@ -61,7 +61,7 @@
             }
 
             &.kbq-form-field_invalid,
-            &.ng-invalid {
+            &.kbq-form-field_has-validate-directive.ng-invalid {
                 @include kbq-form-field-state(states-error);
 
                 &.cdk-focused .kbq-form-field__container {

--- a/packages/components/form-field/_form-field-theme.scss
+++ b/packages/components/form-field/_form-field-theme.scss
@@ -40,7 +40,9 @@
             }
         }
 
+        // Invalid by control `ErrorStateMatcher`
         &.kbq-form-field_invalid,
+        // Invalid by `KbqValidateDirective`
         &.kbq-form-field_has-validate-directive.ng-invalid {
             @include kbq-form-field-state(states-error);
         }
@@ -60,7 +62,9 @@
                 }
             }
 
+            // Invalid by control `ErrorStateMatcher`
             &.kbq-form-field_invalid,
+            // Invalid by `KbqValidateDirective`
             &.kbq-form-field_has-validate-directive.ng-invalid {
                 @include kbq-form-field-state(states-error);
 

--- a/packages/components/form-field/form-field.ts
+++ b/packages/components/form-field/form-field.ts
@@ -39,7 +39,6 @@ import { KbqPasswordToggle } from './password-toggle';
 import { KbqPrefix } from './prefix';
 import { KbqStepper } from './stepper';
 import { KbqSuffix } from './suffix';
-import { KbqValidateDirective } from './validate.directive';
 
 let nextUniqueId = 0;
 
@@ -76,7 +75,6 @@ export const KbqFormFieldMixinBase: CanColorCtor & typeof KbqFormFieldBase = mix
         '[class.kbq-form-field_has-password-toggle]': 'hasPasswordToggle',
         '[class.kbq-form-field_has-cleaner]': 'canShowCleaner',
         '[class.kbq-form-field_has-stepper]': 'canShowStepper',
-        '[class.kbq-form-field_has-validate-directive]': 'hasValidateDirective',
 
         '[class.kbq-disabled]': 'control.disabled',
 
@@ -106,8 +104,6 @@ export class KbqFormField
     @ContentChild(KbqStepper, { static: false }) stepper: KbqStepper;
     @ContentChild(KbqCleaner, { static: false }) cleaner: KbqCleaner | null;
     @ContentChild(KbqPasswordToggle, { static: false }) passwordToggle: KbqPasswordToggle | null;
-    @ContentChild(KbqValidateDirective, { static: true })
-    private readonly validateDirective: KbqValidateDirective | null;
 
     @ContentChildren(KbqHint) hint: QueryList<KbqHint>;
     @ContentChildren(KbqPasswordHint) passwordHints: QueryList<KbqPasswordHint>;
@@ -124,15 +120,6 @@ export class KbqFormField
     canCleanerClearByEsc: boolean = true;
 
     private readonly destroyRef = inject(DestroyRef);
-
-    /**
-     * Whether the form field has the deprecated `KbqValidateDirective`.
-     *
-     * @docs-private
-     */
-    get hasValidateDirective(): boolean {
-        return !!this.validateDirective;
-    }
 
     get focusOrigin(): FocusOrigin {
         return this._focusOrigin;

--- a/packages/components/form-field/form-field.ts
+++ b/packages/components/form-field/form-field.ts
@@ -39,6 +39,7 @@ import { KbqPasswordToggle } from './password-toggle';
 import { KbqPrefix } from './prefix';
 import { KbqStepper } from './stepper';
 import { KbqSuffix } from './suffix';
+import { KbqValidateDirective } from './validate.directive';
 
 let nextUniqueId = 0;
 
@@ -75,6 +76,7 @@ export const KbqFormFieldMixinBase: CanColorCtor & typeof KbqFormFieldBase = mix
         '[class.kbq-form-field_has-password-toggle]': 'hasPasswordToggle',
         '[class.kbq-form-field_has-cleaner]': 'canShowCleaner',
         '[class.kbq-form-field_has-stepper]': 'canShowStepper',
+        '[class.kbq-form-field_has-validate-directive]': 'hasValidateDirective',
 
         '[class.kbq-disabled]': 'control.disabled',
 
@@ -104,6 +106,8 @@ export class KbqFormField
     @ContentChild(KbqStepper, { static: false }) stepper: KbqStepper;
     @ContentChild(KbqCleaner, { static: false }) cleaner: KbqCleaner | null;
     @ContentChild(KbqPasswordToggle, { static: false }) passwordToggle: KbqPasswordToggle | null;
+    @ContentChild(KbqValidateDirective, { static: true })
+    private readonly validateDirective: KbqValidateDirective | null;
 
     @ContentChildren(KbqHint) hint: QueryList<KbqHint>;
     @ContentChildren(KbqPasswordHint) passwordHints: QueryList<KbqPasswordHint>;
@@ -120,6 +124,15 @@ export class KbqFormField
     canCleanerClearByEsc: boolean = true;
 
     private readonly destroyRef = inject(DestroyRef);
+
+    /**
+     * Whether the form field has the deprecated `KbqValidateDirective`.
+     *
+     * @docs-private
+     */
+    get hasValidateDirective(): boolean {
+        return !!this.validateDirective;
+    }
 
     get focusOrigin(): FocusOrigin {
         return this._focusOrigin;

--- a/packages/components/form-field/validate.directive.ts
+++ b/packages/components/form-field/validate.directive.ts
@@ -48,7 +48,10 @@ import { KbqFormFieldControl } from './form-field-control';
         kbq-tree-select,
         kbq-tag-list
     `,
-    exportAs: 'KbqValidate'
+    exportAs: 'KbqValidate',
+    host: {
+        class: 'kbq-validate-directive'
+    }
 })
 export class KbqValidateDirective implements AfterContentInit {
     get isNgModel(): boolean {

--- a/packages/components/form-field/validate.directive.ts
+++ b/packages/components/form-field/validate.directive.ts
@@ -1,4 +1,13 @@
-import { AfterContentInit, ChangeDetectorRef, Directive, forwardRef, Inject, Optional, Self } from '@angular/core';
+import {
+    AfterContentInit,
+    ChangeDetectorRef,
+    Directive,
+    forwardRef,
+    Host,
+    Inject,
+    Optional,
+    Self
+} from '@angular/core';
 import {
     AbstractControl,
     FormControlDirective,
@@ -14,6 +23,7 @@ import {
     ValidatorFn
 } from '@angular/forms';
 import { KBQ_VALIDATION, KbqValidationOptions } from '@koobiq/components/core';
+import { KbqFormField } from './form-field';
 import { KbqFormFieldControl } from './form-field-control';
 
 /**
@@ -50,7 +60,7 @@ import { KbqFormFieldControl } from './form-field-control';
     `,
     exportAs: 'KbqValidate',
     host: {
-        class: 'kbq-validate-directive'
+        class: 'kbq-control_has-validate-directive'
     }
 })
 export class KbqValidateDirective implements AfterContentInit {
@@ -85,8 +95,11 @@ export class KbqValidateDirective implements AfterContentInit {
         @Optional() private parentForm: NgForm,
         @Optional() private parentFormGroup: FormGroupDirective,
         @Optional() @Inject(KBQ_VALIDATION) private mcValidation: KbqValidationOptions,
-        private cdr: ChangeDetectorRef
-    ) {}
+        private cdr: ChangeDetectorRef,
+        @Optional() @Host() private readonly parentFormField: KbqFormField | null
+    ) {
+        this.parentFormField?.elementRef.nativeElement.classList.add('kbq-form-field_has-validate-directive');
+    }
 
     ngAfterContentInit() {
         if (this.mcValidation.useValidation) {

--- a/packages/components/select/_select-theme.scss
+++ b/packages/components/select/_select-theme.scss
@@ -6,7 +6,9 @@
     .kbq-select {
         color: var(--kbq-foreground-contrast);
 
-        &.kbq-validate-directive.ng-invalid,
+        // Invalid by `KbqValidateDirective`
+        &.kbq-control_has-validate-directive.ng-invalid,
+        // Invalid by control `ErrorStateMatcher`
         &.kbq-invalid {
             color: var(--kbq-error-default);
 

--- a/packages/components/select/_select-theme.scss
+++ b/packages/components/select/_select-theme.scss
@@ -6,7 +6,8 @@
     .kbq-select {
         color: var(--kbq-foreground-contrast);
 
-        &.ng-invalid {
+        &.kbq-validate-directive.ng-invalid,
+        &.kbq-invalid {
             color: var(--kbq-error-default);
 
             .kbq-select__placeholder {

--- a/packages/components/tree-select/_tree-select-theme.scss
+++ b/packages/components/tree-select/_tree-select-theme.scss
@@ -4,7 +4,8 @@
     .kbq-tree-select {
         color: var(--kbq-foreground-contrast);
 
-        &.ng-invalid {
+        &.kbq-validate-directive.ng-invalid,
+        &.kbq-invalid {
             color: var(--kbq-error-default);
 
             .kbq-select__placeholder {

--- a/packages/components/tree-select/_tree-select-theme.scss
+++ b/packages/components/tree-select/_tree-select-theme.scss
@@ -4,7 +4,9 @@
     .kbq-tree-select {
         color: var(--kbq-foreground-contrast);
 
-        &.kbq-validate-directive.ng-invalid,
+        // Invalid by `KbqValidateDirective`
+        &.kbq-control_has-validate-directive.ng-invalid,
+        // Invalid by control `ErrorStateMatcher`
         &.kbq-invalid {
             color: var(--kbq-error-default);
 

--- a/tools/public_api_guard/components/form-field.api.md
+++ b/tools/public_api_guard/components/form-field.api.md
@@ -90,6 +90,7 @@ export class KbqFormField extends KbqFormFieldMixinBase implements AfterContentI
     get hasStepper(): boolean;
     // (undocumented)
     get hasSuffix(): boolean;
+    get hasValidateDirective(): boolean;
     // (undocumented)
     hint: QueryList<KbqHint>;
     // (undocumented)
@@ -127,7 +128,7 @@ export class KbqFormField extends KbqFormFieldMixinBase implements AfterContentI
     suffix: QueryList<KbqSuffix>;
     protected validateControlChild(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqFormField, "kbq-form-field", ["kbqFormField"], { "color": { "alias": "color"; "required": false; }; }, {}, ["control", "stepper", "cleaner", "passwordToggle", "hint", "passwordHints", "suffix", "prefix"], ["[kbqPrefix]", "*", "[kbqSuffix]", "kbq-cleaner", "kbq-password-toggle", "kbq-stepper", "kbq-hint, kbq-password-hint"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqFormField, "kbq-form-field", ["kbqFormField"], { "color": { "alias": "color"; "required": false; }; }, {}, ["control", "stepper", "cleaner", "passwordToggle", "validateDirective", "hint", "passwordHints", "suffix", "prefix"], ["[kbqPrefix]", "*", "[kbqSuffix]", "kbq-cleaner", "kbq-password-toggle", "kbq-stepper", "kbq-hint, kbq-password-hint"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqFormField, never>;
 }

--- a/tools/public_api_guard/components/form-field.api.md
+++ b/tools/public_api_guard/components/form-field.api.md
@@ -90,7 +90,6 @@ export class KbqFormField extends KbqFormFieldMixinBase implements AfterContentI
     get hasStepper(): boolean;
     // (undocumented)
     get hasSuffix(): boolean;
-    get hasValidateDirective(): boolean;
     // (undocumented)
     hint: QueryList<KbqHint>;
     // (undocumented)
@@ -128,7 +127,7 @@ export class KbqFormField extends KbqFormFieldMixinBase implements AfterContentI
     suffix: QueryList<KbqSuffix>;
     protected validateControlChild(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqFormField, "kbq-form-field", ["kbqFormField"], { "color": { "alias": "color"; "required": false; }; }, {}, ["control", "stepper", "cleaner", "passwordToggle", "validateDirective", "hint", "passwordHints", "suffix", "prefix"], ["[kbqPrefix]", "*", "[kbqSuffix]", "kbq-cleaner", "kbq-password-toggle", "kbq-stepper", "kbq-hint, kbq-password-hint"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqFormField, "kbq-form-field", ["kbqFormField"], { "color": { "alias": "color"; "required": false; }; }, {}, ["control", "stepper", "cleaner", "passwordToggle", "hint", "passwordHints", "suffix", "prefix"], ["[kbqPrefix]", "*", "[kbqSuffix]", "kbq-cleaner", "kbq-password-toggle", "kbq-stepper", "kbq-hint, kbq-password-hint"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqFormField, never>;
 }
@@ -323,7 +322,7 @@ export class KbqTrim {
 
 // @public @deprecated (undocumented)
 export class KbqValidateDirective implements AfterContentInit {
-    constructor(formFieldControl: KbqFormFieldControl<any>, rawValidators: Validator[], ngControl: NgControl, parentForm: NgForm, parentFormGroup: FormGroupDirective, mcValidation: KbqValidationOptions, cdr: ChangeDetectorRef);
+    constructor(formFieldControl: KbqFormFieldControl<any>, rawValidators: Validator[], ngControl: NgControl, parentForm: NgForm, parentFormGroup: FormGroupDirective, mcValidation: KbqValidationOptions, cdr: ChangeDetectorRef, parentFormField: KbqFormField | null);
     // (undocumented)
     get hasNotSubmittedParent(): boolean;
     // (undocumented)
@@ -350,7 +349,7 @@ export class KbqValidateDirective implements AfterContentInit {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqValidateDirective, "        input[kbqInput],        input[kbqNumberInput],        input[kbqInputPassword],        input[kbqTimepicker],        input[kbqDatepicker],        textarea[kbqTextarea],        kbq-select,        kbq-tree-select,        kbq-tag-list    ", ["KbqValidate"], {}, {}, never, never, false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<KbqValidateDirective, [null, { optional: true; self: true; }, { optional: true; self: true; }, { optional: true; }, { optional: true; }, { optional: true; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<KbqValidateDirective, [null, { optional: true; self: true; }, { optional: true; self: true; }, { optional: true; }, { optional: true; }, { optional: true; }, null, { optional: true; host: true; }]>;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
we should apply the `.ng-invalid` selector only for fields which contains the deprecated `KbqValidateDirective`, otherwise use `.kbq-invalid` (for select base fields) and `.kbq-form-field_invalid` selectors. 