### PR TITLE
fix(progress-spinner): remove gap if ng-content is not provided (#DS-3568)

### DIFF
--- a/packages/components/progress-spinner/progress-spinner.scss
+++ b/packages/components/progress-spinner/progress-spinner.scss
@@ -13,8 +13,6 @@
 .kbq-progress-spinner {
     display: flex;
     flex-direction: row;
-
-    gap: var(--kbq-progress-spinner-size-compact-content-gap-horizontal);
 }
 
 .kbq-progress-spinner__circle {
@@ -39,11 +37,13 @@
     .kbq-progress-spinner-text {
         margin-bottom: var(--kbq-progress-spinner-size-compact-content-gap-vertical);
     }
+
+    &:not(:empty) {
+        margin-inline-start: var(--kbq-progress-spinner-size-compact-content-gap-horizontal);
+    }
 }
 
 .kbq-progress-spinner_big {
-    gap: var(--kbq-progress-spinner-size-big-content-gap-horizontal);
-
     & .kbq-progress-spinner__inner {
         width: var(--kbq-progress-spinner-size-big-size);
         height: var(--kbq-progress-spinner-size-big-size);
@@ -51,6 +51,12 @@
 
     & .kbq-progress-spinner__circle {
         stroke-width: 6%;
+    }
+
+    & .kbq-progress-spinner__content {
+        &:not(:empty) {
+            margin-inline-start: var(--kbq-progress-spinner-size-big-content-gap-horizontal);
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
-->

## Summary

Remove gap between icon and the content in case no ng-content provided.

Before:
![image](https://github.com/user-attachments/assets/24580320-9f19-46ec-b706-7725afb1db69)

After:
![image](https://github.com/user-attachments/assets/8ff6b73f-59db-4e55-b0da-d1af79d762be)


## List of notable changes:

Handled cases for each `size` variation.

## What should reviewers focus on?

1. Not sure if this is _perfect_ fix, because variable name `--kbq-progress-spinner-size-compact-content-gap-horizontal` is no longer represents actual CSS rule - now it uses `margin` instead of `gap`.

    However this seems like the most straightforward fix that doesn't involve any JavaScript.

2. Tweaked background on components-dev page to make screenshots and verify the fix, but didn't include it in PR. Not sure if example with custom background color will be accepted.
