### PR TITLE
fix(navbar): async item alignment in vertical navbar for second navbar-container with OnPush (#DS-3645)

### DIFF
--- a/packages/components-dev/navbar/module.ts
+++ b/packages/components-dev/navbar/module.ts
@@ -1,4 +1,4 @@
-import { Component, NgModule, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, NgModule, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -21,7 +21,8 @@ import { map, timer } from 'rxjs';
     selector: 'app',
     templateUrl: './template.html',
     styleUrls: ['./styles.scss'],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NavbarDemoComponent {
     popUpPlacements = PopUpPlacements;

--- a/packages/components-dev/navbar/template.html
+++ b/packages/components-dev/navbar/template.html
@@ -201,7 +201,7 @@
 
             <!-- Asynchronous navbar-item -->
             @if (permission$ | async) {
-                <button #navbarItemAdmin kbq-navbar-item>
+                <button kbq-navbar-item>
                     <i kbq-icon="kbq-bsd_16"></i>
                     <span kbq-navbar-title>Настройки</span>
                 </button>
@@ -209,6 +209,14 @@
         </kbq-navbar-container>
 
         <kbq-navbar-container>
+            <!-- Second asynchronous navbar-item -->
+            @if (permission$ | async) {
+                <button kbq-navbar-item>
+                    <i kbq-icon="kbq-bsd_16"></i>
+                    <span kbq-navbar-title>Настройки</span>
+                </button>
+            }
+
             <kbq-navbar-item
                 #verticalPopover="kbqPopover"
                 kbqPopover

--- a/packages/components/navbar/vertical-navbar.component.ts
+++ b/packages/components/navbar/vertical-navbar.component.ts
@@ -6,7 +6,9 @@ import {
     ChangeDetectorRef,
     Component,
     ContentChild,
+    contentChildren,
     ContentChildren,
+    effect,
     ElementRef,
     forwardRef,
     Input,
@@ -14,7 +16,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { DOWN_ARROW, isHorizontalMovement, isVerticalMovement, TAB, UP_ARROW } from '@koobiq/cdk/keycodes';
-import { startWith, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { KbqNavbarBento, KbqNavbarItem, KbqNavbarRectangleElement } from './navbar-item.component';
 import { KbqFocusableComponent } from './navbar.component';
 
@@ -48,8 +50,10 @@ import { KbqFocusableComponent } from './navbar.component';
     encapsulation: ViewEncapsulation.None
 })
 export class KbqVerticalNavbar extends KbqFocusableComponent implements AfterContentInit {
-    @ContentChildren(forwardRef(() => KbqNavbarRectangleElement), { descendants: true })
-    rectangleElements: QueryList<KbqNavbarRectangleElement>;
+    rectangleElements = contentChildren(
+        forwardRef(() => KbqNavbarRectangleElement),
+        { descendants: true }
+    );
 
     @ContentChildren(forwardRef(() => KbqNavbarItem), { descendants: true }) items: QueryList<KbqNavbarItem>;
 
@@ -80,14 +84,12 @@ export class KbqVerticalNavbar extends KbqFocusableComponent implements AfterCon
         super(changeDetectorRef, elementRef, focusMonitor);
 
         this.animationDone.subscribe(this.updateTooltipForItems);
+
+        effect(() => this.setItemsVerticalStateAndUpdateExpandedState(this.rectangleElements()));
     }
 
     ngAfterContentInit(): void {
         this.updateTooltipForItems();
-
-        this.rectangleElements.changes
-            .pipe(startWith(null))
-            .subscribe(this.setItemsVerticalStateAndUpdateExpandedState);
 
         super.ngAfterContentInit();
 
@@ -123,12 +125,12 @@ export class KbqVerticalNavbar extends KbqFocusableComponent implements AfterCon
         }
     }
 
-    private updateExpandedStateForItems = () => this.rectangleElements?.forEach(this.updateItemExpandedState);
+    private updateExpandedStateForItems = () => this.rectangleElements().forEach(this.updateItemExpandedState);
 
     private updateTooltipForItems = () => this.items.forEach((item) => item.updateTooltip());
 
-    private setItemsVerticalStateAndUpdateExpandedState = () =>
-        this.rectangleElements.forEach(this.setItemVerticalStateAndUpdateExpandedState);
+    private setItemsVerticalStateAndUpdateExpandedState = (rectangleElements: Readonly<KbqNavbarRectangleElement[]>) =>
+        rectangleElements.forEach(this.setItemVerticalStateAndUpdateExpandedState);
 
     private setItemVerticalStateAndUpdateExpandedState = (item: KbqNavbarRectangleElement): void => {
         queueMicrotask(() => this.setItemVerticalState(item));

--- a/tools/public_api_guard/components/navbar.api.md
+++ b/tools/public_api_guard/components/navbar.api.md
@@ -27,6 +27,7 @@ import { NgZone } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
 import { QueryList } from '@angular/core';
+import { Signal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TooltipModifier } from '@koobiq/components/tooltip';
@@ -91,7 +92,7 @@ export class KbqNavbar extends KbqFocusableComponent implements AfterViewInit, A
     // (undocumented)
     onKeyDown(event: KeyboardEvent): void;
     // (undocumented)
-    rectangleElements: QueryList<KbqNavbarRectangleElement>;
+    rectangleElements: Signal<readonly any[]>;
     // (undocumented)
     readonly resizeStream: Subject<Event>;
     // (undocumented)
@@ -382,11 +383,11 @@ export class KbqVerticalNavbar extends KbqFocusableComponent implements AfterCon
     // (undocumented)
     openOver: boolean;
     // (undocumented)
-    rectangleElements: QueryList<KbqNavbarRectangleElement>;
+    rectangleElements: Signal<readonly any[]>;
     // (undocumented)
     toggle(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqVerticalNavbar, "kbq-vertical-navbar", ["KbqVerticalNavbar"], { "openOver": { "alias": "openOver"; "required": false; }; "expanded": { "alias": "expanded"; "required": false; }; }, {}, ["bento", "rectangleElements", "items"], ["[kbq-navbar-container], kbq-navbar-container", "[kbq-navbar-toggle], kbq-navbar-toggle"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqVerticalNavbar, "kbq-vertical-navbar", ["KbqVerticalNavbar"], { "openOver": { "alias": "openOver"; "required": false; }; "expanded": { "alias": "expanded"; "required": false; }; }, {}, ["rectangleElements", "bento", "items"], ["[kbq-navbar-container], kbq-navbar-container", "[kbq-navbar-toggle], kbq-navbar-toggle"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqVerticalNavbar, never>;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
-->

## Summary

Довольно специфичный кейс, почему-то проблема именно в случае использования второго navbar-container + OnPush стратегии и асинхронной kbq-navbar-item

## List of notable changes:

- обновил пример в components-dev чтобы проблема воспроизводилась
- решил попробовать signal-based content query в качестве простого решения
- в обычном navbar повторил переход на signal-based content query для консистентности

## What should reviewers focus on?

Теоретически возможно убирть предыдущий кейс из components-dev примера (сейчас там 2 async kbq-nabar-item), т.к. текущий пример более специфичный