### PR TITLE
fix(alert): align info variant with design (#DS-3602)

### DIFF
--- a/packages/components/alert/_alert-theme.scss
+++ b/packages/components/alert/_alert-theme.scss
@@ -18,6 +18,7 @@
     }
 
     .kbq-alert.kbq-alert_default {
+        // Will be replaced with `kbq-alert_info` in next major release (#DS-3651)
         &.kbq-alert_contrast {
             @include kbq-alert-style(default, contrast);
         }
@@ -34,12 +35,14 @@
             @include kbq-alert-style(default, success);
         }
 
+        // Will be removed and replaced with `kbq-alert_info` in next major release (#DS-3651)
         &.kbq-alert_theme {
             @include kbq-alert-style(default, theme);
         }
     }
 
     .kbq-alert.kbq-alert_colored {
+        // Will be removed in next major release (#DS-3651)
         &.kbq-alert_contrast {
             @include kbq-alert-style(colored, contrast);
         }
@@ -56,6 +59,7 @@
             @include kbq-alert-style(colored, success);
         }
 
+        // Will be replaced with `kbq-alert_info` in next major release (#DS-3651)
         &.kbq-alert_theme {
             @include kbq-alert-style(colored, theme);
         }

--- a/packages/components/alert/alert-tokens.scss
+++ b/packages/components/alert/alert-tokens.scss
@@ -1,4 +1,4 @@
-.kbq-alert {
+:where(.kbq-alert) {
     --kbq-alert-size-normal-container-border-radius: var(--kbq-size-m);
     --kbq-alert-size-normal-container-padding-top: 0;
     --kbq-alert-size-normal-container-padding-right: var(--kbq-size-s);

--- a/packages/components/alert/alert.component.ts
+++ b/packages/components/alert/alert.component.ts
@@ -16,13 +16,17 @@ export enum KbqAlertStyles {
 }
 
 export enum KbqAlertColors {
-    Contrast = 'contrast',
     Error = 'error',
     Warning = 'warning',
     Success = 'success',
-    /** @deprecated This color key doesn't correlate with design, use `Info` instead. */
+    /** Used the same value as `Theme` to not introduce breaking changes */
+    Info = 'theme',
+    /** @deprecated This color key doesn't correlate with design, use `Info` instead.
+     * Will be removed in next major release (#DS-3602) */
     Theme = 'theme',
-    Info = 'theme'
+    /** @deprecated This color key doesn't correlate with design.
+     * Will be removed and replaced with `Info` in next major release (#DS-3602) */
+    Contrast = 'contrast'
 }
 
 @Directive({

--- a/packages/components/alert/alert.component.ts
+++ b/packages/components/alert/alert.component.ts
@@ -20,7 +20,9 @@ export enum KbqAlertColors {
     Error = 'error',
     Warning = 'warning',
     Success = 'success',
-    Theme = 'theme'
+    /** @deprecated This color key doesn't correlate with design, use `Info` instead. */
+    Theme = 'theme',
+    Info = 'theme'
 }
 
 @Directive({
@@ -93,7 +95,7 @@ export class KbqAlert implements AfterContentInit {
         const icon = this.icon || this.iconItem;
 
         if (icon) {
-            icon.color = this._alertColor;
+            icon.color = this._alertColor === KbqAlertColors.Info ? KbqAlertColors.Contrast : this._alertColor;
         }
     }
 }

--- a/packages/docs-examples/components/alert/alert-status/alert-status-example.html
+++ b/packages/docs-examples/components/alert/alert-status/alert-status-example.html
@@ -1,6 +1,6 @@
 <div class="layout-row layout-gap-l flex-100">
     <div class="layout-column layout-gap-l">
-        <kbq-alert class="kbq-alert_theme" [alertStyle]="alertStyles.Colored" [compact]="true">
+        <kbq-alert [alertColor]="alertColors.Info" [alertStyle]="alertStyles.Colored" [compact]="true">
             <i kbq-icon="kbq-info-circle_16" [color]="colors.Contrast"></i>
             {{ text }}
         </kbq-alert>


### PR DESCRIPTION
## Summary

Поправил, чтобы выглядело в соответствии с дизайном. 

Переработка алерт , чтобы сделать его более кастомизируемым требует больших изменений , это будет явно не фикс.

Добавил свойство `Info` в `enum` и депрекейтнул `Theme`. Кажется, что удобнее если именования совпадают с дизайном