### PR TITLE
fix(breadcrumbs): fixed error on component import (#DS-3523)

### DIFF
--- a/docs/guides/installation.en.md
+++ b/docs/guides/installation.en.md
@@ -19,5 +19,5 @@ npm install @koobiq/date-adapter
 npm install @koobiq/date-formatter
 npm install luxon
 npm install @messageformat/core
-npm install @radix-ng/primitives@^0.14.0
+npm install @radix-ng/primitives@^0.23.0
 ```

--- a/docs/guides/installation.ru.md
+++ b/docs/guides/installation.ru.md
@@ -19,5 +19,5 @@ npm install @koobiq/date-adapter
 npm install @koobiq/date-formatter
 npm install luxon
 npm install @messageformat/core
-npm install @radix-ng/primitives@^0.14.0
+npm install @radix-ng/primitives@^0.23.0
 ```

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@koobiq/date-adapter": "^3.2.3",
         "@koobiq/date-formatter": "^3.2.3",
         "@koobiq/icons": "9.4.0",
-        "@radix-ng/primitives": "^0.20.2",
+        "@radix-ng/primitives": "^0.23.0",
         "ag-grid-angular": "^30.2.1",
         "ag-grid-community": "^30.2.1",
         "highlight.js": "^11.10.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,7 +31,7 @@
         "@koobiq/icons": "^9.4.0",
         "@koobiq/tokens-builder": "3.11.0",
         "@koobiq/design-tokens": "3.12.1",
-        "@radix-ng/primitives": "^0.14.0"
+        "@radix-ng/primitives": "^0.23.0"
     },
     "dependencies": {
         "tslib": "^2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5455,7 +5455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ng/primitives@npm:0.23.0":
+"@radix-ng/primitives@npm:^0.23.0":
   version: 0.23.0
   resolution: "@radix-ng/primitives@npm:0.23.0"
   dependencies:
@@ -14681,7 +14681,7 @@ __metadata:
     "@microsoft/api-extractor": "npm:7.40.2"
     "@octokit/rest": "npm:^18.9.1"
     "@prettier/plugin-xml": "npm:^3.4.1"
-    "@radix-ng/primitives": "npm:0.23.0"
+    "@radix-ng/primitives": "npm:^0.23.0"
     "@rollup/plugin-commonjs": "npm:^24.0.0"
     "@rollup/plugin-json": "npm:^6.0.0"
     "@rollup/plugin-node-resolve": "npm:^15.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5455,15 +5455,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ng/primitives@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "@radix-ng/primitives@npm:0.20.2"
+"@radix-ng/primitives@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@radix-ng/primitives@npm:0.23.0"
   dependencies:
     tslib: "npm:^2.3.0"
   peerDependencies:
     "@angular/cdk": ^18.0.0
     "@angular/core": ^18.0.0
-  checksum: 10c0/34ce746eb30317f971d5b9f1eb0e4fea0bf127d65fc6d15a67579f3e9e51ef8027b6afe1dc7ba18bea371feba3f9b4aefcaf1185098e4059b9938af5d5ad7938
+  checksum: 10c0/c90946928b02f0eadfee58d1910362f039181d28c6f447e29021b958e8f6404192a62cdb12dbc16e5c661bcdf6bfdf8db62cb1826b8822e3765299d9a3f1ffe7
   languageName: node
   linkType: hard
 
@@ -14681,7 +14681,7 @@ __metadata:
     "@microsoft/api-extractor": "npm:7.40.2"
     "@octokit/rest": "npm:^18.9.1"
     "@prettier/plugin-xml": "npm:^3.4.1"
-    "@radix-ng/primitives": "npm:^0.20.2"
+    "@radix-ng/primitives": "npm:0.23.0"
     "@rollup/plugin-commonjs": "npm:^24.0.0"
     "@rollup/plugin-json": "npm:^6.0.0"
     "@rollup/plugin-node-resolve": "npm:^15.0.2"


### PR DESCRIPTION
## Summary

Здесь будет фикс бага, связанный с недоступностью `RdxRovingFocusGroupDirective` и `RdxRovingFocusItemDirective` из пакета `@radix-ng/primitives`.

Имплементацию `FocusKeyManager` внутри предлагаю сделать в следующем спринте
