### PR TITLE
chore(docs): removed filter of redundant class members (#DS-3657)

### DIFF
--- a/tools/api-gen/extraction/helpers.ts
+++ b/tools/api-gen/extraction/helpers.ts
@@ -2,26 +2,9 @@ import fs from 'fs';
 import { relative } from 'path';
 import ts from 'typescript';
 import { isPublic } from '../manifest/helpers';
-import { ClassEntry, DocEntry, MemberEntry, MemberTags } from '../rendering/entities';
+import { ClassEntry, DocEntry } from '../rendering/entities';
 import { isClassEntry } from '../rendering/entities/categorization';
 import { ClassEntryMetadata, PackageMetadata } from '../types';
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-type FunctionProps = keyof Function | string;
-const fProps: FunctionProps[] = [
-    'call',
-    'caller',
-    'apply',
-    '[Symbol.hasInstance]',
-    'toString',
-    'arguments',
-    'bind',
-    '[Symbol.metadata]',
-    'name',
-    'length'
-];
-const metadataMembers = ({ name, memberTags }: MemberEntry) =>
-    !fProps.includes(name) && !memberTags.includes(MemberTags.Inherited);
 
 /**
  * Updates the entries in the documentation with additional information based on class metadata.
@@ -43,7 +26,7 @@ export function updateEntries(entries: DocEntry[], classMetadata: Record<string,
 
         res.push({
             ...entry,
-            members: (entry as ClassEntry).members?.filter(metadataMembers),
+            members: (entry as ClassEntry).members,
             isService: classMetadata[entry.name]?.decorators?.includes('Injectable'),
             extendedDoc: !!baseClassEntry &&
                 isPublic(baseClassEntry) && {


### PR DESCRIPTION
## Summary
Мы переехали с одного подхода генерации доки на другой, после чего в генерируемом api классов, расширяемых через миксин-функцию, стали добавляться свойства объекта `Function`.

После выполнения #638 эта проверка неактуальна