### PR TITLE
fix(docs): code block language (#DS-3174)

### DIFF
--- a/apps/docs/src/app/components/live-example/docs-live-example.ts
+++ b/apps/docs/src/app/components/live-example/docs-live-example.ts
@@ -40,8 +40,8 @@ import { DocsLiveExampleViewerComponent } from '../live-example-viewer/docs-live
     selector: 'docs-live-example',
     template: `
         {{ isRuLocale() ? 'Загрузка документа...' : 'Loading document...' }}
-        <ng-template cdkPortal let-htmlContent let-contentToCopy="textContent">
-            <kbq-code-block [files]="[{ content: contentToCopy }]" filled lineNumbers />
+        <ng-template cdkPortal let-htmlContent let-contentToCopy="textContent" let-language="language">
+            <kbq-code-block [files]="[{ content: contentToCopy, language }]" filled lineNumbers />
         </ng-template>
         <ng-template #codeSnippet cdkPortal let-htmlContent>
             <span
@@ -177,7 +177,11 @@ export class DocsLiveExampleComponent extends DocsLocaleState implements OnDestr
 
             const portalHost = new DomPortalOutlet(element, this.componentFactoryResolver, this.appRef, this.injector);
 
-            this.codeTemplate.attach(portalHost, { $implicit: outerHTML, textContent });
+            this.codeTemplate.attach(portalHost, {
+                $implicit: outerHTML,
+                textContent,
+                language: element.getAttribute('data-docs-code-language')
+            });
 
             this.portalHosts.push(portalHost);
 

--- a/tools/api-gen/rendering/templates/componentGroup.template.html
+++ b/tools/api-gen/rendering/templates/componentGroup.template.html
@@ -29,7 +29,7 @@
 <!--    </header>-->
 
     <p class="docs-api__module-import">
-        <pre class="kbq-markdown__pre docs-import">import {{$ doc.ngModule.name $}} from '{$ doc.moduleImportPath $}';</pre>
+        <pre data-docs-code-language="typescript" class="kbq-markdown__pre docs-import">import {{$ doc.ngModule.name $}} from '{$ doc.moduleImportPath $}';</pre>
     </p>
 
     {%- if doc.services.length -%}

--- a/tools/api-gen/rendering/templates/constant.template.html
+++ b/tools/api-gen/rendering/templates/constant.template.html
@@ -16,7 +16,7 @@
 {%- endif -%}
 
 <div class="kbq-markdown">
-    <pre class="kbq-markdown__pre docs-import">
+    <pre data-docs-code-language="typescript" class="kbq-markdown__pre docs-import">
         {%- highlight "typescript" -%}
           const {$ constant.name | safe $}: {$ constant.type | safe $};
             {%- end_highlight -%}

--- a/tools/api-gen/rendering/templates/entry-point.template.html
+++ b/tools/api-gen/rendering/templates/entry-point.template.html
@@ -40,7 +40,7 @@
 <!--        API reference for {$ doc.packageDisplayName $} {$ doc.displayName $}-->
 <!--    </header>-->
 
-    <pre class="kbq-markdown__pre docs-import">import { {$ doc.primaryExportName $} } from '{$ doc.moduleImportPath $}';</pre>
+    <pre data-docs-code-language="typescript" class="kbq-markdown__pre docs-import">import { {$ doc.primaryExportName $} } from '{$ doc.moduleImportPath $}';</pre>
 
     {%- if doc.services.length -%}
     <div id="services" class="kbq-markdown__h3 docs-header-link">

--- a/tools/api-gen/rendering/templates/function.template.html
+++ b/tools/api-gen/rendering/templates/function.template.html
@@ -16,7 +16,7 @@
 {%- endif -%}
 
 <div class="kbq-markdown">
-    <pre class="kbq-markdown__pre docs-import">
+    <pre data-docs-code-language="typescript" class="kbq-markdown__pre docs-import">
         {%- highlight "typescript" -%}
           const {$ item.name | safe $}: {$ item.returnType | safe $};
             {%- end_highlight -%}

--- a/tools/api-gen/rendering/templates/type-alias.template.html
+++ b/tools/api-gen/rendering/templates/type-alias.template.html
@@ -16,7 +16,7 @@
 {%- endif -%}
 
 <div class="kbq-markdown">
-    <pre class="kbq-markdown__pre docs-import">
+    <pre data-docs-code-language="typescript" class="kbq-markdown__pre docs-import">
         {%- highlight "typescript" -%}
             type {$ alias.name | safe $} = {$ alias.type | safe $};
         {%- end_highlight -%}

--- a/tools/markdown-to-html/marked/docs-marked-renderer.ts
+++ b/tools/markdown-to-html/marked/docs-marked-renderer.ts
@@ -61,6 +61,12 @@ export class DocsMarkdownRenderer extends Renderer {
         super();
     }
 
+    // Transforms a Markdown code block into the corresponding HTML output. In our case, we
+    // want to add a data-docs-code-language attribute to the code element.
+    code(code: string, infostring: string | undefined, _escaped: boolean): string {
+        return `<pre data-docs-code-language="${infostring}"><code>${code}</code></pre>`;
+    }
+
     /**
      * Transforms a Markdown heading into the corresponding HTML output. In our case, we
      * want to create a header-link for each H2, H3, and H4 heading. This allows users to jump to

--- a/tools/markdown-to-html/marked/docs-marked-renderer.ts
+++ b/tools/markdown-to-html/marked/docs-marked-renderer.ts
@@ -63,8 +63,10 @@ export class DocsMarkdownRenderer extends Renderer {
 
     // Transforms a Markdown code block into the corresponding HTML output. In our case, we
     // want to add a data-docs-code-language attribute to the code element.
-    code(code: string, infostring: string | undefined, _escaped: boolean): string {
-        return `<pre data-docs-code-language="${infostring}"><code>${code}</code></pre>`;
+    code(code: string, infostring: string | undefined, escaped: boolean): string {
+        const result = super.code(code, infostring, escaped);
+
+        return result.replace('<pre>', `<pre data-docs-code-language="${infostring}">`);
     }
 
     /**


### PR DESCRIPTION
for example

before:
![image](https://github.com/user-attachments/assets/6e107427-111b-4464-8093-bde4234ebd58)

after:
![image](https://github.com/user-attachments/assets/8b7e9f1c-1121-4891-a150-1c6c07d5ec41)
