### PR TITLE
chore(file-upload): jsdocs & dev examples

### DIFF
--- a/packages/components-dev/file-upload/main.ts
+++ b/packages/components-dev/file-upload/main.ts
@@ -1,6 +1,9 @@
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { DemoModule } from './module';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { FileUploadDev } from './module';
 
-platformBrowserDynamic()
-    .bootstrapModule(DemoModule)
-    .catch((error) => console.error(error));
+bootstrapApplication(FileUploadDev, {
+    providers: [
+        provideAnimations()
+    ]
+}).catch((error) => console.error(error));

--- a/packages/components-dev/file-upload/template.html
+++ b/packages/components-dev/file-upload/template.html
@@ -5,26 +5,11 @@
     Indeterminate Loading imitation for single and multiple
 </button>
 
-<button kbq-button (click)="checkValidation()">Call validation from outside</button>
+<button kbq-button class="layout-margin-bottom-l" (click)="checkValidation()">Call validation from outside</button>
 
-<br />
-<br />
+<dev-locale-selector class="layout-margin-bottom-l" />
 
-<kbq-radio-group class="example-radio-group" (change)="setFormat($event)">
-    @for (language of languageList; track language) {
-        <kbq-radio-button
-            class="example-radio-button"
-            [checked]="language.id === selectedLanguage.id"
-            [value]="language"
-        >
-            {{ language.id }}
-        </kbq-radio-button>
-    }
-    <br />
-</kbq-radio-group>
-
-<br />
-<br />
+<file-upload-examples class="layout-margin-bottom-l" />
 
 <div class="layout-row layout-align-space-between">
     <div>
@@ -82,14 +67,11 @@
         <div class="dev-container">
             <div class="kbq-subheading">Single file upload</div>
             <br />
-            <div class="kbq-text-big-strong">with pdf/png files accepted, validation outside</div>
+            <div class="kbq-text-big-strong">with pdf/png files accepted</div>
             <br />
-            <kbq-file-upload [accept]="accept" [disabled]="disabled" [file]="file" (fileQueueChange)="addFile($event)">
+            <kbq-file-upload [accept]="accept" [disabled]="disabled">
                 <i kbq-icon="kbq-info-circle_16"></i>
                 <kbq-hint>{{ hintMessage }}</kbq-hint>
-                @for (error of errorMessagesForSingle; track error) {
-                    <kbq-hint color="error">{{ error }}</kbq-hint>
-                }
             </kbq-file-upload>
         </div>
     </div>

--- a/packages/components/file-upload/examples.file-upload.en.md
+++ b/packages/components/file-upload/examples.file-upload.en.md
@@ -13,11 +13,9 @@ After uploading, the file is highlighted as having an issue — this is a simula
 
 <!-- example(file-upload-single-with-signal) -->
 
-## Simple Usage of Control Value Accessor for File Upload
+## Reactive Forms
 
-This section provides an example implementation of a file uploader that supports uploading a single file using `Control Value Accessor`.
-
-<!-- example(file-upload-cva-overview) -->
+An example of a file uploader using [`FormControl`](https://angular.dev/api/forms/FormControl).
 
 ### Validation: Additional Examples
 

--- a/packages/components/file-upload/examples.file-upload.ru.md
+++ b/packages/components/file-upload/examples.file-upload.ru.md
@@ -13,9 +13,9 @@
 
 <!-- example(file-upload-single-with-signal) -->
 
-## Простое использование Control Value Accessor для загрузчика файлов
+### Реактивные формы
 
-В этом разделе представлен пример реализации загрузчика файлов, поддерживающего загрузку одного файла, с использованием `Control Value Accessor`.
+Пример загрузчика файлов с использованием [`FormControl`](https://angular.dev/api/forms/FormControl).
 
 <!-- example(file-upload-cva-overview) -->
 

--- a/packages/components/file-upload/file-drop.ts
+++ b/packages/components/file-upload/file-drop.ts
@@ -16,22 +16,27 @@ const entryIsFile = (entry?: FileSystemEntry): entry is FileSystemFileEntry => !
     }
 })
 export class KbqFileDropDirective {
+    /** Flag that controls css-class modifications on drag events. */
     dragover: boolean;
 
+    /** Emits an event when file items were dropped. */
     @Output() filesDropped: EventEmitter<FileList | KbqFile[]> = new EventEmitter<FileList | KbqFile[]>();
 
+    /** @docs-private */
     onDragOver(event: DragEvent) {
         event.preventDefault();
         event.stopPropagation();
         this.dragover = true;
     }
 
+    /** @docs-private */
     onDragLeave(event: DragEvent) {
         event.preventDefault();
         event.stopPropagation();
         this.dragover = false;
     }
 
+    /** @docs-private */
     onDrop(event: DragEvent) {
         if (!isFolderCanBeDragged()) {
             console.warn('Drag-and-drop functionality for folders is not supported by this browser.');
@@ -47,7 +52,7 @@ export class KbqFileDropDirective {
             // @ts-ignore
             const fileEntries: FileSystemEntry[] = [...event.dataTransfer.items]
                 .filter((item: DataTransferItem) => item.kind === 'file')
-                .map((item) => item.webkitGetAsEntry() as FileSystemEntry);
+                .map((item) => item.webkitGetAsEntry() satisfies FileSystemEntry);
 
             Promise.all(fileEntries.map(unwrapDirectory))
                 .then((fileList) => fileList.reduce((res, next) => res.concat(next), []))

--- a/packages/components/file-upload/file-upload.karma-spec.ts
+++ b/packages/components/file-upload/file-upload.karma-spec.ts
@@ -16,8 +16,8 @@ const fileItemRowCssClass = 'multiple__uploaded-item';
 const fileItemCssClass = 'file-item';
 
 describe(KbqMultipleFileUploadComponent.name, () => {
-    let component: any;
-    let fixture: ComponentFixture<any>;
+    let component: BasicMultipleFileUpload;
+    let fixture: ComponentFixture<BasicMultipleFileUpload>;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -44,7 +44,7 @@ describe(KbqMultipleFileUploadComponent.name, () => {
             dispatchEvent(component.fileUpload.input.nativeElement, event);
             fixture.detectChanges();
 
-            const subscription = component.fileUpload.fileQueueChanged.subscribe((value) => {
+            const subscription = component.fileUpload.filesChange.subscribe((value) => {
                 expect(value.length).toBeFalsy();
             });
 
@@ -59,8 +59,8 @@ describe(KbqMultipleFileUploadComponent.name, () => {
 });
 
 describe(KbqSingleFileUploadComponent.name, () => {
-    let component: any;
-    let fixture: ComponentFixture<any>;
+    let component: BasicSingleFileUpload;
+    let fixture: ComponentFixture<BasicSingleFileUpload>;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -84,7 +84,7 @@ describe(KbqSingleFileUploadComponent.name, () => {
             dispatchEvent(component.fileUpload.input.nativeElement, event);
             fixture.detectChanges();
 
-            const subscription = component.fileUpload.fileQueueChange.subscribe((value) => {
+            const subscription = component.fileUpload.fileChange.subscribe((value) => {
                 expect(value).toBeFalsy();
             });
 

--- a/packages/components/file-upload/file-upload.ts
+++ b/packages/components/file-upload/file-upload.ts
@@ -72,17 +72,27 @@ export abstract class KbqFileUploadBase implements CanUpdateErrorState {
      */
     readonly stateChanges = new Subject<void>();
 
+    /** @docs-private */
     protected readonly cdr = inject(ChangeDetectorRef);
+    /** @docs-private */
     protected readonly renderer = inject(Renderer2);
+    /** @docs-private */
     protected readonly destroyRef = inject(DestroyRef);
+    /** @docs-private */
     protected readonly localeService = inject(KBQ_LOCALE_SERVICE, { optional: true });
+    /** @docs-private */
     protected readonly ngControl = inject(NgControl, { optional: true, self: true });
+    /** @docs-private */
     protected readonly parentForm = inject(NgForm, { optional: true });
+    /** @docs-private */
     protected readonly parentFormGroup = inject(FormGroupDirective, { optional: true });
+    /** @docs-private */
     protected readonly defaultErrorStateMatcher = inject(ErrorStateMatcher);
+    /** @docs-private */
     protected readonly elementRef = inject(ElementRef);
 
-    /** implemented as part of base class. Decided not use mixinErrorState, not to overcomplicate */
+    /** implemented as part of base class. Decided not use mixinErrorState, not to overcomplicate
+     * @docs-private */
     updateErrorState() {
         const oldState = this.errorState;
         const parent = this.parentFormGroup || this.parentForm;

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -98,30 +98,40 @@ export class KbqMultipleFileUploadComponent
         this.cdr.markForCheck();
     }
 
-    @Output() fileQueueChanged: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
-
+    /** Emits an event containing updated file list. */
+    @Output('fileQueueChanged') filesChange: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
     /**
      * Emits an event containing a chunk of files added to the file list.
+     * Useful when handling added files, skipping filtering file list.
      */
     @Output() filesAdded: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
     /**
-     * Emits an event containing a file and file's index when removed from the file list.
+     * Emits an event containing a tuple of file and file's index when removed from the file list.
+     * Useful when handle removed files, skipping filtering file list.
      */
     @Output() fileRemoved: EventEmitter<[KbqFileItem, number]> = new EventEmitter<[KbqFileItem, number]>();
 
+    /** File Icon Template */
     @ContentChild('kbqFileIcon', { static: false, read: TemplateRef }) customFileIcon: TemplateRef<HTMLElement>;
 
+    /** @docs-private */
     @ViewChild('input') input: ElementRef<HTMLInputElement>;
 
+    /** @docs-private */
     @ContentChildren(KbqHint) protected readonly hint: QueryList<TemplateRef<any>>;
 
+    /** @docs-private */
     hasFocus = false;
+    /** @docs-private */
     columnDefs: { header: string; cssClass: string }[];
-
+    /** @docs-private */
     config: KbqInputFileMultipleLabel;
 
+    /** @docs-private */
     separatedCaptionText: string[];
+    /** @docs-private */
     separatedCaptionTextWhenSelected: string[];
+    /** @docs-private */
     separatedCaptionTextForCompactSize: string[];
 
     /** cvaOnChange function registered via registerOnChange (ControlValueAccessor).
@@ -133,6 +143,7 @@ export class KbqMultipleFileUploadComponent
      * @docs-private */
     onTouched = () => {};
 
+    /** @docs-private */
     get acceptedFiles(): string {
         return this.accept?.join(',') || '*/*';
     }
@@ -144,6 +155,7 @@ export class KbqMultipleFileUploadComponent
         return this.errors && !!this.errors.length;
     }
 
+    /** @docs-private */
     get hasHint(): boolean {
         return this.hint.length > 0;
     }
@@ -151,11 +163,13 @@ export class KbqMultipleFileUploadComponent
     /**
      * Indicates an invalid state based on `errorState`,
      * applying a CSS class in HTML for visual feedback.
+     * @docs-private
      */
     get invalid(): boolean {
         return this.errorState;
     }
 
+    /** @docs-private */
     readonly configuration = inject<KbqInputFileMultipleLabel>(KBQ_FILE_UPLOAD_CONFIGURATION, {
         optional: true
     });
@@ -198,7 +212,7 @@ export class KbqMultipleFileUploadComponent
      * @docs-private */
     writeValue(files: FileList | KbqFileItem[] | null): void {
         this.files = files instanceof FileList || !files ? this.mapToFileItem(files) : files;
-        this.fileQueueChanged.emit(this.files);
+        this.filesChange.emit(this.files);
     }
 
     /** Implemented as part of ControlValueAccessor.
@@ -212,7 +226,6 @@ export class KbqMultipleFileUploadComponent
     registerOnTouched(fn: any): void {
         this.onTouched = fn;
     }
-
     /**
      * Sets the disabled state of the control. Implemented as a part of ControlValueAccessor.
      * @param isDisabled Whether the control should be disabled.
@@ -223,6 +236,7 @@ export class KbqMultipleFileUploadComponent
         this.cdr.markForCheck();
     }
 
+    /** @docs-private */
     onFileSelectedViaClick({ target }: Event) {
         if (this.disabled) {
             return;
@@ -235,13 +249,14 @@ export class KbqMultipleFileUploadComponent
             ...filesToAdd
         ];
         this.filesAdded.emit(filesToAdd);
-        this.fileQueueChanged.emit(this.files);
+        this.filesChange.emit(this.files);
         this.onTouched();
         /* even if the user selects the same file,
                  the onchange event will be triggered every time user clicks on the control.*/
         this.renderer.setProperty(this.input.nativeElement, 'value', null);
     }
 
+    /** @docs-private */
     onFileDropped(files: FileList | KbqFile[]) {
         if (this.disabled) {
             return;
@@ -254,10 +269,11 @@ export class KbqMultipleFileUploadComponent
             ...filesToAdd
         ];
         this.filesAdded.emit(filesToAdd);
-        this.fileQueueChanged.emit(this.files);
+        this.filesChange.emit(this.files);
         this.onTouched();
     }
 
+    /** @docs-private */
     deleteFile(index: number, event?: MouseEvent) {
         if (this.disabled) {
             return;
@@ -267,12 +283,8 @@ export class KbqMultipleFileUploadComponent
         this.fileRemoved.emit([this.files[index], index]);
         this.files.splice(index, 1);
         this.files = [...this.files];
-        this.fileQueueChanged.emit(this.files);
+        this.filesChange.emit(this.files);
         this.onTouched();
-    }
-
-    onFileListChange(): void {
-        this.fileQueueChanged.emit(this.files);
     }
 
     private updateLocaleParams = () => {

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -98,7 +98,8 @@ export class KbqMultipleFileUploadComponent
         this.cdr.markForCheck();
     }
 
-    /** Emits an event containing updated file list. */
+    /** Emits an event containing updated file list.
+     * @TODO public output will be renamed to filesChange in next major release (#DS-3700) */
     @Output('fileQueueChanged') filesChange: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
     /**
      * Emits an event containing a chunk of files added to the file list.

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -66,6 +66,7 @@ export class KbqMultipleFileUploadComponent
      * A value responsible for progress spinner type.
      * Loading logic depends on selected mode */
     @Input() progressMode: ProgressSpinnerMode = 'determinate';
+    /** Array of file type specifiers */
     @Input() accept?: string[];
     @Input() disabled: boolean;
     /**
@@ -99,7 +100,7 @@ export class KbqMultipleFileUploadComponent
     }
 
     /** Emits an event containing updated file list.
-     * @TODO public output will be renamed to filesChange in next major release (#DS-3700) */
+     * public output will be renamed to filesChange in next major release (#DS-3700) */
     @Output('fileQueueChanged') filesChange: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
     /**
      * Emits an event containing a chunk of files added to the file list.

--- a/packages/components/file-upload/single-file-upload.component.ts
+++ b/packages/components/file-upload/single-file-upload.component.ts
@@ -81,7 +81,8 @@ export class KbqSingleFileUploadComponent
         this.cdr.markForCheck();
     }
 
-    /** Emits an event containing updated file. */
+    /** Emits an event containing updated file.
+     * @TODO public output will be renamed to fileChange in next major release (#DS-3700) */
     @Output('fileQueueChange') fileChange: EventEmitter<KbqFileItem | null> = new EventEmitter<KbqFileItem | null>();
 
     /** @docs-private */

--- a/packages/components/file-upload/single-file-upload.component.ts
+++ b/packages/components/file-upload/single-file-upload.component.ts
@@ -81,14 +81,18 @@ export class KbqSingleFileUploadComponent
         this.cdr.markForCheck();
     }
 
-    @Output() fileQueueChange: EventEmitter<KbqFileItem | null> = new EventEmitter<KbqFileItem | null>();
+    /** Emits an event containing updated file. */
+    @Output('fileQueueChange') fileChange: EventEmitter<KbqFileItem | null> = new EventEmitter<KbqFileItem | null>();
 
+    /** @docs-private */
     @ViewChild('input') input: ElementRef<HTMLInputElement>;
 
+    /** @docs-private */
     @ContentChildren(KbqHint) private readonly hint: QueryList<KbqHint>;
 
+    /** @docs-private */
     config: KbqInputFileLabel;
-
+    /** @docs-private */
     separatedCaptionText: string[];
 
     /** cvaOnChange function registered via registerOnChange (ControlValueAccessor).
@@ -101,10 +105,12 @@ export class KbqSingleFileUploadComponent
      */
     onTouched = () => {};
 
+    /** @docs-private */
     get acceptedFiles(): string {
         return this.accept?.join(',') || '*/*';
     }
 
+    /** @docs-private */
     get hasHint(): boolean {
         return this.hint.length > 0;
     }
@@ -112,11 +118,13 @@ export class KbqSingleFileUploadComponent
     /**
      * Indicates an invalid state based on file errors or `errorState`,
      * applying a CSS class in HTML for visual feedback.
+     * @docs-private
      */
     get invalid(): boolean {
         return !!this.file?.hasError || this.errorState;
     }
 
+    /** @docs-private */
     readonly configuration: KbqInputFileLabel | null = inject(KBQ_FILE_UPLOAD_CONFIGURATION, {
         optional: true
     });
@@ -165,7 +173,7 @@ export class KbqSingleFileUploadComponent
      * @docs-private */
     writeValue(file: File | KbqFileItem | null): void {
         this.file = file instanceof File ? this.mapToFileItem(file) : file;
-        this.fileQueueChange.emit(this.file);
+        this.fileChange.emit(this.file);
     }
 
     /** Implemented as part of ControlValueAccessor.
@@ -190,6 +198,7 @@ export class KbqSingleFileUploadComponent
         this.cdr.markForCheck();
     }
 
+    /** @docs-private */
     onFileSelectedViaClick({ target }: Event): void {
         if (this.disabled) {
             return;
@@ -199,7 +208,7 @@ export class KbqSingleFileUploadComponent
 
         if (files?.length) {
             this.file = this.mapToFileItem(files[0]);
-            this.fileQueueChange.emit(this.file);
+            this.fileChange.emit(this.file);
         }
 
         this.onTouched();
@@ -208,17 +217,19 @@ export class KbqSingleFileUploadComponent
         this.renderer.setProperty(this.input.nativeElement, 'value', null);
     }
 
+    /** @docs-private */
     deleteItem(event?: MouseEvent): void {
         if (this.disabled) return;
 
         event?.stopPropagation();
         this.file = null;
-        this.fileQueueChange.emit(this.file);
+        this.fileChange.emit(this.file);
         this.errors = [];
         // mark as touched after file drop even if file wasn't correct
         this.onTouched();
     }
 
+    /** @docs-private */
     onFileDropped(files: FileList | KbqFile[]): void {
         if (this.disabled) {
             return;
@@ -226,7 +237,7 @@ export class KbqSingleFileUploadComponent
 
         if (files?.length && isCorrectExtension(files[0], this.accept)) {
             this.file = this.mapToFileItem(files[0]);
-            this.fileQueueChange.emit(this.file);
+            this.fileChange.emit(this.file);
         }
 
         // mark as touched after file drop even if file wasn't correct

--- a/packages/components/file-upload/single-file-upload.component.ts
+++ b/packages/components/file-upload/single-file-upload.component.ts
@@ -53,6 +53,7 @@ export class KbqSingleFileUploadComponent
      * A value responsible for progress spinner type.
      * Loading logic depends on selected mode */
     @Input() progressMode: ProgressSpinnerMode = 'determinate';
+    /** Array of file type specifiers */
     @Input() accept?: string[];
     @Input() disabled: boolean = false;
     /**
@@ -82,7 +83,7 @@ export class KbqSingleFileUploadComponent
     }
 
     /** Emits an event containing updated file.
-     * @TODO public output will be renamed to fileChange in next major release (#DS-3700) */
+     * public output will be renamed to fileChange in next major release (#DS-3700) */
     @Output('fileQueueChange') fileChange: EventEmitter<KbqFileItem | null> = new EventEmitter<KbqFileItem | null>();
 
     /** @docs-private */

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -1391,6 +1391,18 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "primaryFile": "file-upload-single-validation-reactive-forms-overview-example.ts",
     "importPath": "components/file-upload"
   },
+  "file-upload-single-with-signal": {
+    "packagePath": "components/file-upload/file-upload-single-with-signal",
+    "title": "File-upload single",
+    "componentName": "FileUploadSingleWithSignalExample",
+    "files": [
+      "file-upload-single-with-signal-example.ts"
+    ],
+    "selector": "file-upload-single-with-signal-example",
+    "additionalComponents": [],
+    "primaryFile": "file-upload-single-with-signal-example.ts",
+    "importPath": "components/file-upload"
+  },
   "filter-bar-cleanable": {
     "packagePath": "components/filter-bar/filter-bar-cleanable",
     "title": "filter-bar-cleanable",
@@ -4284,6 +4296,8 @@ return import('@koobiq/docs-examples/components/file-upload');
   case 'file-upload-single-required-reactive-validation':
 return import('@koobiq/docs-examples/components/file-upload');
   case 'file-upload-single-validation-reactive-forms-overview':
+return import('@koobiq/docs-examples/components/file-upload');
+  case 'file-upload-single-with-signal':
 return import('@koobiq/docs-examples/components/file-upload');
   case 'filter-bar-cleanable':
 return import('@koobiq/docs-examples/components/filter-bar');

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -212,7 +212,6 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
 // @public (undocumented)
 export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements AfterViewInit, KbqInputFile, ControlValueAccessor, DoCheck {
     constructor();
-    // (undocumented)
     accept?: string[];
     get acceptedFiles(): string;
     config: KbqInputFileLabel;

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -170,45 +170,34 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     constructor();
     // (undocumented)
     accept?: string[];
-    // (undocumented)
     get acceptedFiles(): string;
-    // (undocumented)
     columnDefs: {
         header: string;
         cssClass: string;
     }[];
-    // (undocumented)
     config: KbqInputFileMultipleLabel;
-    // (undocumented)
     readonly configuration: KbqInputFileMultipleLabel | null;
-    // (undocumented)
     customFileIcon: TemplateRef<HTMLElement>;
     // @deprecated (undocumented)
     customValidation?: KbqFileValidatorFn[];
     cvaOnChange: (_: KbqFileItem[]) => void;
-    // (undocumented)
     deleteFile(index: number, event?: MouseEvent): void;
     // (undocumented)
     disabled: boolean;
     // @deprecated (undocumented)
     errors: string[];
     errorStateMatcher: ErrorStateMatcher;
-    // (undocumented)
-    fileQueueChanged: EventEmitter<KbqFileItem[]>;
     fileRemoved: EventEmitter<[KbqFileItem, number]>;
     // (undocumented)
     get files(): KbqFileItem[];
     set files(currentFileList: KbqFileItem[]);
     filesAdded: EventEmitter<KbqFileItem[]>;
+    filesChange: EventEmitter<KbqFileItem[]>;
     // @deprecated (undocumented)
     get hasErrors(): boolean;
-    // (undocumented)
     hasFocus: boolean;
-    // (undocumented)
     get hasHint(): boolean;
-    // (undocumented)
     protected readonly hint: QueryList<TemplateRef<any>>;
-    // (undocumented)
     input: ElementRef<HTMLInputElement>;
     inputId: string;
     get invalid(): boolean;
@@ -216,28 +205,21 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     ngAfterViewInit(): void;
     // (undocumented)
     ngDoCheck(): void;
-    // (undocumented)
     onFileDropped(files: FileList | KbqFile[]): void;
-    // (undocumented)
-    onFileListChange(): void;
-    // (undocumented)
     onFileSelectedViaClick({ target }: Event): void;
     onTouched: () => void;
     progressMode: ProgressSpinnerMode;
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
-    // (undocumented)
     separatedCaptionText: string[];
-    // (undocumented)
     separatedCaptionTextForCompactSize: string[];
-    // (undocumented)
     separatedCaptionTextWhenSelected: string[];
     setDisabledState(isDisabled: boolean): void;
     // (undocumented)
     size: 'compact' | 'default';
     writeValue(files: FileList | KbqFileItem[] | null): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqMultipleFileUploadComponent, "kbq-multiple-file-upload,kbq-file-upload[multiple]", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "size": { "alias": "size"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "files": { "alias": "files"; "required": false; }; }, { "fileQueueChanged": "fileQueueChanged"; "filesAdded": "filesAdded"; "fileRemoved": "fileRemoved"; }, ["customFileIcon", "hint"], ["kbq-hint"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqMultipleFileUploadComponent, "kbq-multiple-file-upload,kbq-file-upload[multiple]", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "size": { "alias": "size"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "files": { "alias": "files"; "required": false; }; }, { "filesChange": "fileQueueChanged"; "filesAdded": "filesAdded"; "fileRemoved": "fileRemoved"; }, ["customFileIcon", "hint"], ["kbq-hint"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqMultipleFileUploadComponent, never>;
 }
@@ -247,16 +229,12 @@ export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements A
     constructor();
     // (undocumented)
     accept?: string[];
-    // (undocumented)
     get acceptedFiles(): string;
-    // (undocumented)
     config: KbqInputFileLabel;
-    // (undocumented)
     readonly configuration: KbqInputFileLabel | null;
     // @deprecated (undocumented)
     customValidation?: KbqFileValidatorFn[];
     cvaOnChange: (_: KbqFileItem | null) => void;
-    // (undocumented)
     deleteItem(event?: MouseEvent): void;
     // (undocumented)
     disabled: boolean;
@@ -266,11 +244,8 @@ export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements A
     // (undocumented)
     get file(): KbqFileItem | null;
     set file(currentFile: KbqFileItem | null);
-    // (undocumented)
-    fileQueueChange: EventEmitter<KbqFileItem | null>;
-    // (undocumented)
+    fileChange: EventEmitter<KbqFileItem | null>;
     get hasHint(): boolean;
-    // (undocumented)
     input: ElementRef<HTMLInputElement>;
     // (undocumented)
     inputId: string;
@@ -279,20 +254,17 @@ export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements A
     ngAfterViewInit(): void;
     // (undocumented)
     ngDoCheck(): void;
-    // (undocumented)
     onFileDropped(files: FileList | KbqFile[]): void;
-    // (undocumented)
     onFileSelectedViaClick({ target }: Event): void;
     onTouched: () => void;
     progressMode: ProgressSpinnerMode;
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
-    // (undocumented)
     separatedCaptionText: string[];
     setDisabledState(isDisabled: boolean): void;
     writeValue(file: File | KbqFileItem | null): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSingleFileUploadComponent, "kbq-single-file-upload,kbq-file-upload:not([multiple])", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "file": { "alias": "file"; "required": false; }; }, { "fileQueueChange": "fileQueueChange"; }, ["hint"], ["[kbq-icon]", "kbq-hint"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSingleFileUploadComponent, "kbq-single-file-upload,kbq-file-upload:not([multiple])", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "file": { "alias": "file"; "required": false; }; }, { "fileChange": "fileQueueChange"; }, ["hint"], ["[kbq-icon]", "kbq-hint"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqSingleFileUploadComponent, never>;
 }

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -57,15 +57,10 @@ export interface KbqFile extends File {
 
 // @public (undocumented)
 export class KbqFileDropDirective {
-    // (undocumented)
     dragover: boolean;
-    // (undocumented)
     filesDropped: EventEmitter<FileList | KbqFile[]>;
-    // (undocumented)
     onDragLeave(event: DragEvent): void;
-    // (undocumented)
     onDragOver(event: DragEvent): void;
-    // (undocumented)
     onDrop(event: DragEvent): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<KbqFileDropDirective, "[kbqFileDrop]", ["kbqFileDrop"], {}, { "filesDropped": "filesDropped"; }, never, never, false, never>;
@@ -87,25 +82,16 @@ export interface KbqFileItem {
 
 // @public
 export abstract class KbqFileUploadBase implements CanUpdateErrorState {
-    // (undocumented)
     protected readonly cdr: ChangeDetectorRef;
-    // (undocumented)
     protected readonly defaultErrorStateMatcher: ErrorStateMatcher;
-    // (undocumented)
     protected readonly destroyRef: DestroyRef;
-    // (undocumented)
     protected readonly elementRef: ElementRef<any>;
     errorState: boolean;
     abstract errorStateMatcher: ErrorStateMatcher;
-    // (undocumented)
     protected readonly localeService: KbqLocaleService | null;
-    // (undocumented)
     protected readonly ngControl: NgControl | null;
-    // (undocumented)
     protected readonly parentForm: NgForm | null;
-    // (undocumented)
     protected readonly parentFormGroup: FormGroupDirective | null;
-    // (undocumented)
     protected readonly renderer: Renderer2;
     readonly stateChanges: Subject<void>;
     updateErrorState(): void;
@@ -168,7 +154,6 @@ export interface KbqInputFileMultipleLabel extends KbqInputFileLabel {
 // @public (undocumented)
 export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements AfterViewInit, KbqInputFile, ControlValueAccessor, DoCheck {
     constructor();
-    // (undocumented)
     accept?: string[];
     get acceptedFiles(): string;
     columnDefs: {


### PR DESCRIPTION
## Summary

- Спрятал свойства и методы, которые не должны быть доступны извне с помощью `@docs-private`
- Переименовал `fileQueueChange` и `fileQueueChanged` в `fileChange` и `filesChange` для двухстороннего биндинга в дальнейшем. Не брейкинг, потому что извне изменения не видны, только внутри класса.
- Переделал дев пример на standalone по аналогии с другими и удалил неиспользуемый код
- Упростил описание во вкладке примеры для одного из примеров

