### PR TITLE
fix(file-upload): sync events order on files changes (#DS-3451)

### DIFF
--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -246,6 +246,10 @@ export class KbqMultipleFileUploadComponent
 
         const filesToAdd = this.mapToFileItem((target as HTMLInputElement).files);
 
+        /* even if the user selects the same file,
+                 the onchange event will be triggered every time user clicks on the control.*/
+        this.renderer.setProperty(this.input.nativeElement, 'value', null);
+
         this.files = [
             ...this.files,
             ...filesToAdd
@@ -253,9 +257,6 @@ export class KbqMultipleFileUploadComponent
         this.filesAdded.emit(filesToAdd);
         this.filesChange.emit(this.files);
         this.onTouched();
-        /* even if the user selects the same file,
-                 the onchange event will be triggered every time user clicks on the control.*/
-        this.renderer.setProperty(this.input.nativeElement, 'value', null);
     }
 
     /** @docs-private */
@@ -282,9 +283,10 @@ export class KbqMultipleFileUploadComponent
         }
 
         event?.stopPropagation();
-        this.fileRemoved.emit([this.files[index], index]);
-        this.files.splice(index, 1);
+        const removedFile = this.files.splice(index, 1)[0];
+
         this.files = [...this.files];
+        this.fileRemoved.emit([removedFile, index]);
         this.filesChange.emit(this.files);
         this.onTouched();
     }

--- a/packages/components/file-upload/single-file-upload.component.ts
+++ b/packages/components/file-upload/single-file-upload.component.ts
@@ -206,6 +206,10 @@ export class KbqSingleFileUploadComponent
             return;
         }
 
+        /* even if the user selects the same file,
+         the onchange event will be triggered every time user clicks on the control.*/
+        this.renderer.setProperty(this.input.nativeElement, 'value', null);
+
         const files: FileList | null = (target as HTMLInputElement).files;
 
         if (files?.length) {
@@ -214,9 +218,6 @@ export class KbqSingleFileUploadComponent
         }
 
         this.onTouched();
-        /* even if the user selects the same file,
-         the onchange event will be triggered every time user clicks on the control.*/
-        this.renderer.setProperty(this.input.nativeElement, 'value', null);
     }
 
     /** @docs-private */


### PR DESCRIPTION
## Summary

The problem was that the event was triggered **before** accessing `this.input`.  
As a result, by the time `detectChanges` was called, `this.input` had already become `undefined` (hidden after file selection).

To fix this, the handling was restructured in the following order:
- process the current state
- emit outputs
- call `onTouch`