### PR TITLE
fix(tags): sync placeholder padding with design (#DS-3484)

### DIFF
--- a/packages/components/tags/tag-list.scss
+++ b/packages/components/tags/tag-list.scss
@@ -37,10 +37,15 @@
 
     gap: var(--kbq-tag-list-size-content-gap);
 
-    & .kbq-tag-input {
+    .kbq-tag-input {
         max-width: 100%;
 
         flex: 1 1 auto;
+
+        // indicating tag list is empty
+        &:first-child {
+            padding-left: var(--kbq-size-s);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Update `padding-left` when no more `kbq-tag` items left.
Maybe calculating `padding-left` would be more descriptive, but I think it's complicated.