### PR TITLE
fix(file-upload): resolved types

### DIFF
--- a/packages/components/file-upload/file-drop.ts
+++ b/packages/components/file-upload/file-drop.ts
@@ -52,7 +52,7 @@ export class KbqFileDropDirective {
             // @ts-ignore
             const fileEntries: FileSystemEntry[] = [...event.dataTransfer.items]
                 .filter((item: DataTransferItem) => item.kind === 'file')
-                .map((item) => item.webkitGetAsEntry() satisfies FileSystemEntry);
+                .map((item: DataTransferItem) => item.webkitGetAsEntry()!);
 
             Promise.all(fileEntries.map(unwrapDirectory))
                 .then((fileList) => fileList.reduce((res, next) => res.concat(next), []))


### PR DESCRIPTION
## Summary

Fixed redundant casting because of check in `filter`

![image](https://github.com/user-attachments/assets/6a11f5e0-e340-409d-bef3-4eadc4d46c9c)
