### PR TITLE
fix(docs,toast): close button alignment (#DS-3693)

### DIFF
--- a/apps/docs/src/assets/stackblitz/src/styles.scss
+++ b/apps/docs/src/assets/stackblitz/src/styles.scss
@@ -5,6 +5,9 @@
 @use '@koobiq/design-tokens/web/css-tokens-light.css';
 @use '@koobiq/ag-grid-angular-theme';
 @use '@koobiq/components/core/styles/common/tokens';
+@use '@koobiq/components/core/styles/visual';
+
+@include visual.layouts-for-breakpoint();
 
 body {
     @include tokens.kbq-typography-level-to-styles-css-variables(typography, text-normal);


### PR DESCRIPTION
## Summary

Close button inside toast is using `layout-row layout-align` styles , so using layout styles is required for it.
