### PR TITLE
fix(textarea): aligned paddings with design (#DS-3720)

### DIFF
--- a/packages/components/textarea/textarea-tokens.scss
+++ b/packages/components/textarea/textarea-tokens.scss
@@ -1,6 +1,6 @@
 .kbq-textarea {
     --kbq-textarea-size-min-height: 64px;
     --kbq-textarea-size-max-height: 96px;
-    --kbq-textarea-size-padding-vertical: var(--kbq-size-xs);
+    --kbq-textarea-size-padding-vertical: 5px;
     --kbq-textarea-size-padding-horizontal: var(--kbq-size-m);
 }


### PR DESCRIPTION
## Summary

After fix

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/b07f7222-a73a-4b71-b076-e531e400dc00" />
