### PR TITLE
feat(docs): default icon color in modal (#DS-3747)

### DIFF
--- a/apps/docs/src/app/components/icons-viewer/icon-preview-modal/icon-preview-modal.component.ts
+++ b/apps/docs/src/app/components/icons-viewer/icon-preview-modal/icon-preview-modal.component.ts
@@ -61,7 +61,7 @@ export class DocsIconPreviewModalComponent extends DocsLocaleState implements Af
         KbqComponentColors.Warning
     ];
 
-    selectedColorTheme: KbqComponentColors | string = KbqComponentColors.Theme;
+    selectedColorTheme: KbqComponentColors | string = KbqComponentColors.Contrast;
 
     readonly componentColors = KbqComponentColors;
 


### PR DESCRIPTION
## Summary

Simplified initial modal view, so icon layout can be copied with default color param.