### PR TITLE
chore(deps): updated @koobiq/design-tokens to 3.13.2

### DIFF
--- a/apps/docs/src/assets/stackblitz/package.json
+++ b/apps/docs/src/assets/stackblitz/package.json
@@ -28,7 +28,7 @@
         "@koobiq/components-experimental": "${version}",
         "@koobiq/date-adapter": "^3.2.0",
         "@koobiq/date-formatter": "^3.2.3",
-        "@koobiq/design-tokens": "3.13.0",
+        "@koobiq/design-tokens": "3.13.1",
         "@koobiq/icons": "9.4.0",
         "@koobiq/luxon-date-adapter": "^3.2.3",
         "@koobiq/moment-date-adapter": "^3.2.3",

--- a/apps/docs/src/assets/stackblitz/package.json
+++ b/apps/docs/src/assets/stackblitz/package.json
@@ -28,7 +28,7 @@
         "@koobiq/components-experimental": "${version}",
         "@koobiq/date-adapter": "^3.2.0",
         "@koobiq/date-formatter": "^3.2.3",
-        "@koobiq/design-tokens": "3.12.1",
+        "@koobiq/design-tokens": "3.13.0",
         "@koobiq/icons": "9.4.0",
         "@koobiq/luxon-date-adapter": "^3.2.3",
         "@koobiq/moment-date-adapter": "^3.2.3",

--- a/apps/docs/src/assets/stackblitz/package.json
+++ b/apps/docs/src/assets/stackblitz/package.json
@@ -28,7 +28,7 @@
         "@koobiq/components-experimental": "${version}",
         "@koobiq/date-adapter": "^3.2.0",
         "@koobiq/date-formatter": "^3.2.3",
-        "@koobiq/design-tokens": "3.13.1",
+        "@koobiq/design-tokens": "3.13.2",
         "@koobiq/icons": "9.4.0",
         "@koobiq/luxon-date-adapter": "^3.2.3",
         "@koobiq/moment-date-adapter": "^3.2.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
         "@koobiq/date-formatter": "^3.2.3",
         "@koobiq/icons": "^9.4.0",
         "@koobiq/tokens-builder": "3.11.0",
-        "@koobiq/design-tokens": "3.13.1",
+        "@koobiq/design-tokens": "3.13.2",
         "@radix-ng/primitives": "^0.23.0"
     },
     "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
         "@koobiq/date-formatter": "^3.2.3",
         "@koobiq/icons": "^9.4.0",
         "@koobiq/tokens-builder": "3.11.0",
-        "@koobiq/design-tokens": "3.12.1",
+        "@koobiq/design-tokens": "3.13.0",
         "@radix-ng/primitives": "^0.23.0"
     },
     "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
         "@koobiq/date-formatter": "^3.2.3",
         "@koobiq/icons": "^9.4.0",
         "@koobiq/tokens-builder": "3.11.0",
-        "@koobiq/design-tokens": "3.13.0",
+        "@koobiq/design-tokens": "3.13.1",
         "@radix-ng/primitives": "^0.23.0"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary

No breaking changes: https://github.com/koobiq/design-tokens/compare/3.12.1...3.13.2