### PR TITLE
fix(filter-bar): align icon in filters (#DS-3561)

### DIFF
--- a/packages/components/filter-bar/filters.scss
+++ b/packages/components/filter-bar/filters.scss
@@ -18,6 +18,10 @@
 
     & .kbq-filters__filter-name {
         @include common.kbq-truncate-line();
+
+        & .kbq-icon {
+            margin-bottom: var(--kbq-size-3xs);
+        }
     }
 
     & .kbq-filter-bar__separator {


### PR DESCRIPTION
Выравнивание с помощью `vertical-align` не помогает, все равно происходит сдвиг вверх или вниз.

Пришлось поднять на 2 пикселя отступом.