### PR TITLE
fix(form-field): password-hint colors (#DS-3796)

### DIFF
--- a/packages/components-dev/input/module.ts
+++ b/packages/components-dev/input/module.ts
@@ -31,6 +31,7 @@ import { InputExamplesModule } from '../../docs-examples/components/input';
     template: `
         <input-number-overview-example />
         <hr />
+        <input-password-overview-example />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/components/form-field/password-hint.ts
+++ b/packages/components/form-field/password-hint.ts
@@ -10,7 +10,7 @@ import {
     QueryList,
     ViewEncapsulation
 } from '@angular/core';
-import { KBQ_FORM_FIELD_REF } from '@koobiq/components/core';
+import { KBQ_FORM_FIELD_REF, KbqComponentColors } from '@koobiq/components/core';
 import { Subject } from 'rxjs';
 import { KbqFormField } from './form-field';
 import { KbqHint } from './hint';
@@ -40,7 +40,7 @@ export const hasPasswordStrengthError = (passwordHints: QueryList<KbqPasswordHin
 @Component({
     selector: 'kbq-password-hint',
     template: `
-        <i class="kbq-password-hint__icon" [ngClass]="icon" color="contrast-fade" kbq-icon=""></i>
+        <i class="kbq-password-hint__icon" [ngClass]="icon" kbq-icon=""></i>
 
         <span class="kbq-hint__text">
             <ng-content />
@@ -92,6 +92,8 @@ export class KbqPasswordHint extends KbqHint implements AfterContentInit {
         @Optional() @Inject(forwardRef(() => KBQ_FORM_FIELD_REF)) private formField: any
     ) {
         super();
+        this.color = KbqComponentColors.ContrastFade;
+        this.setDefaultColor(KbqComponentColors.ContrastFade);
     }
 
     ngAfterContentInit(): void {


### PR DESCRIPTION
## Summary

Potentially `kbq-cleaner`, `kbq-stepper`, and icon colors with `[autoColor]="true"` in suffix/prefix should be fixed. But it seems to be another case.
