### PR TITLE
fix(file-upload): disabled state colors (#DS-3824)

### DIFF
--- a/packages/components/file-upload/_file-upload-theme.scss
+++ b/packages/components/file-upload/_file-upload-theme.scss
@@ -16,6 +16,20 @@
             background-color: var(--kbq-file-upload-single-default-container-background);
             border-color: var(--kbq-file-upload-single-default-container-border) !important;
 
+            &:not(.kbq-disabled, .kbq-error) {
+                .kbq-file-upload__action {
+                    color: var(--kbq-file-upload-single-default-icon-button-color);
+                }
+
+                .kbq-dropzone__icon {
+                    color: var(--kbq-file-upload-single-default-upload-icon-color);
+                }
+
+                .file-item__text-wrapper .kbq-icon.kbq-empty {
+                    color: var(--kbq-file-upload-single-default-left-icon-color);
+                }
+            }
+
             &.dragover {
                 background-color: var(--kbq-file-upload-single-states-on-drag-container-background);
                 border-color: var(--kbq-file-upload-single-states-on-drag-container-border) !important;
@@ -27,9 +41,21 @@
                     border-color: var(--kbq-file-upload-single-states-error-container-border) !important;
                 }
 
-                :not(.kbq-link),
-                .kbq-icon.kbq-empty {
+                .kbq-dropzone__icon {
+                    color: var(--kbq-file-upload-single-states-error-upload-icon-color);
+                }
+
+                .file-item__text-wrapper .kbq-icon.kbq-empty {
+                    color: var(--kbq-file-upload-single-states-error-left-icon-color);
+                }
+
+                .file-item__text,
+                .dropzone__text:not(.kbq-link) {
                     color: var(--kbq-file-upload-single-states-error-text-block-color);
+                }
+
+                .kbq-file-upload__action {
+                    color: var(--kbq-file-upload-single-states-error-icon-button-color);
                 }
             }
 
@@ -37,10 +63,21 @@
                 background-color: var(--kbq-file-upload-single-states-disabled-container-background);
                 border-color: var(--kbq-file-upload-single-states-disabled-container-border) !important;
 
-                &,
-                .kbq-icon.kbq-empty,
-                .kbq-link {
-                    color: var(--kbq-file-upload-single-states-disabled-container-border);
+                .kbq-dropzone__icon {
+                    color: var(--kbq-file-upload-single-states-disabled-upload-icon-color);
+                }
+
+                .file-item__text-wrapper .kbq-icon.kbq-empty {
+                    color: var(--kbq-file-upload-single-states-disabled-left-icon-color);
+                }
+
+                .dropzone__text,
+                .file-item__text {
+                    color: var(--kbq-file-upload-single-states-disabled-text-block-color);
+                }
+
+                .kbq-file-upload__action {
+                    color: var(--kbq-file-upload-single-states-disabled-icon-button-color);
                 }
             }
         }
@@ -59,12 +96,22 @@
                 border-bottom-color: var(--kbq-file-upload-multiple-default-grid-divider-color);
             }
 
+            &:not(.kbq-disabled, .kbq-error) {
+                .kbq-dropzone__icon {
+                    color: var(--kbq-file-upload-multiple-default-upload-icon-color);
+                }
+            }
+
             &.dragover {
                 background-color: var(--kbq-file-upload-multiple-states-on-drag-container-background);
                 border-color: var(--kbq-file-upload-multiple-states-on-drag-container-border) !important;
 
                 .kbq-file-multiple-uploaded__header {
                     border-bottom-color: var(--kbq-file-upload-multiple-states-on-drag-container-background) !important;
+                }
+
+                .kbq-dropzone__icon {
+                    color: var(--kbq-file-upload-multiple-states-on-drag-upload-icon-color);
                 }
 
                 &.selected {
@@ -78,10 +125,28 @@
                 background-color: var(--kbq-file-upload-multiple-states-disabled-container-background);
                 border-color: var(--kbq-file-upload-multiple-states-disabled-container-border) !important;
 
-                &,
-                .kbq-icon.kbq-empty,
-                .kbq-link {
-                    color: var(--kbq-file-upload-multiple-states-disabled-container-border);
+                .kbq-dropzone__icon {
+                    color: var(--kbq-file-upload-multiple-states-disabled-upload-icon-color);
+                }
+
+                .dropzone__text,
+                .kbq-file-multiple-uploaded__header {
+                    color: var(--kbq-file-upload-multiple-states-disabled-text-block-color);
+                }
+
+                .multiple__uploaded-item {
+                    .kbq-file-upload__file .kbq-icon.kbq-empty {
+                        color: var(--kbq-file-upload-multiple-states-disabled-left-icon-color);
+                    }
+
+                    .file-item__text,
+                    .kbq-file-upload__size {
+                        color: var(--kbq-file-upload-multiple-states-disabled-text-block-color);
+                    }
+
+                    .kbq-file-upload__action .kbq-icon.kbq-empty {
+                        color: var(--kbq-file-upload-multiple-states-disabled-icon-button-color);
+                    }
                 }
 
                 &.selected {
@@ -96,9 +161,13 @@
                     background-color: var(--kbq-background-error-less);
                     border-color: var(--kbq-line-error) !important;
 
-                    :not(.kbq-link),
-                    .kbq-icon.kbq-empty {
-                        color: var(--kbq-foreground-error);
+                    .kbq-dropzone__icon {
+                        color: var(--kbq-file-upload-single-states-error-upload-icon-color);
+                    }
+
+                    .dropzone__text:not(.kbq-link),
+                    .kbq-file-multiple-uploaded__header {
+                        color: var(--kbq-file-upload-single-states-error-text-block-color);
                     }
                 }
 
@@ -106,20 +175,28 @@
                     &:has(.kbq-file-upload__row.error) {
                         background-color: var(--kbq-background-error-less);
 
-                        :not(.kbq-link),
-                        .kbq-icon.kbq-empty {
+                        .file-item__text,
+                        .kbq-file-upload__size {
                             color: var(--kbq-foreground-error);
+                        }
+
+                        .kbq-file-upload__file .kbq-icon.kbq-empty {
+                            color: var(--kbq-file-upload-multiple-states-error-left-icon-color);
+                        }
+
+                        .kbq-file-upload__action .kbq-icon.kbq-empty {
+                            color: var(--kbq-file-upload-multiple-states-error-icon-button-color);
                         }
                     }
                 }
             }
 
             .multiple__uploaded-item {
-                & .kbq-file-upload__file .kbq-icon.kbq-empty {
+                .kbq-file-upload__file .kbq-icon.kbq-empty {
                     color: var(--kbq-file-upload-multiple-default-left-icon-color);
                 }
 
-                & .kbq-file-upload__action .kbq-icon.kbq-empty {
+                .kbq-file-upload__action .kbq-icon.kbq-empty {
                     color: var(--kbq-file-upload-multiple-default-icon-button-color);
                 }
             }

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -33,12 +33,15 @@
     --kbq-file-upload-single-states-on-drag-text-block-color: var(--kbq-foreground-contrast);
     --kbq-file-upload-single-states-error-container-border: var(--kbq-line-error);
     --kbq-file-upload-single-states-error-container-background: var(--kbq-background-error-less);
+    --kbq-file-upload-single-states-error-upload-icon-color: var(--kbq-icon-error);
     --kbq-file-upload-single-states-error-left-icon-color: var(--kbq-icon-error);
     --kbq-file-upload-single-states-error-text-block-color: var(--kbq-foreground-error);
+    --kbq-file-upload-single-states-error-icon-button-color: var(--kbq-icon-error);
     --kbq-file-upload-single-states-disabled-container-border: var(--kbq-states-line-disabled);
     --kbq-file-upload-single-states-disabled-container-background: var(--kbq-states-background-disabled);
     --kbq-file-upload-single-states-disabled-upload-icon-color: var(--kbq-states-icon-disabled);
     --kbq-file-upload-single-states-disabled-left-icon-color: var(--kbq-states-icon-disabled);
+    --kbq-file-upload-single-states-disabled-icon-button-color: var(--kbq-states-icon-disabled);
     --kbq-file-upload-single-states-disabled-text-block-color: var(--kbq-states-foreground-disabled);
     --kbq-file-upload-single-states-focused-focus-outline-color: var(--kbq-states-line-focus-theme);
     --kbq-file-upload-multiple-default-container-border: var(--kbq-line-contrast-fade);
@@ -63,6 +66,7 @@
     --kbq-file-upload-multiple-states-disabled-container-background: var(--kbq-states-background-disabled);
     --kbq-file-upload-multiple-states-disabled-upload-icon-color: var(--kbq-states-icon-disabled);
     --kbq-file-upload-multiple-states-disabled-left-icon-color: var(--kbq-states-icon-disabled);
+    --kbq-file-upload-multiple-states-disabled-icon-button-color: var(--kbq-states-icon-disabled);
     --kbq-file-upload-multiple-states-disabled-text-block-color: var(--kbq-states-foreground-disabled);
     --kbq-file-upload-multiple-states-disabled-grid-divider-color: var(--kbq-states-line-disabled);
     --kbq-form-field-hint-text: var(--kbq-foreground-contrast-secondary);

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -10,7 +10,7 @@
     @if (!files.length) {
         <div class="dropzone">
             @if (size === 'default') {
-                <i color="contrast-fade" kbq-icon="kbq-cloud-arrow-up-o_32"></i>
+                <i kbq-icon="kbq-cloud-arrow-up-o_32" class="kbq-dropzone__icon"></i>
                 <div class="dropzone__text">
                     <span class="multiple__header">{{ config.title }}</span>
                     <div>
@@ -19,7 +19,7 @@
                     </div>
                 </div>
             } @else {
-                <i color="contrast-fade" kbq-icon="kbq-cloud-arrow-up-o_24"></i>
+                <i kbq-icon="kbq-cloud-arrow-up-o_24" class="kbq-dropzone__icon"></i>
                 <span class="dropzone__text multiple__caption">
                     {{ separatedCaptionTextForCompactSize[0] }}
                     <label kbq-link pseudo [disabled]="disabled" [for]="inputId" [tabIndex]="-1">
@@ -87,7 +87,7 @@
             </div>
             <div class="btn-upload">
                 <div class="dropzone">
-                    <i kbq-icon="kbq-cloud-arrow-up-o_24"></i>
+                    <i kbq-icon="kbq-cloud-arrow-up-o_24" class="kbq-dropzone__icon"></i>
                     <span class="dropzone__text multiple__caption">
                         {{ separatedCaptionTextWhenSelected[0] }}
                         <label kbq-link pseudo [disabled]="disabled" [for]="inputId" [tabIndex]="-1">

--- a/packages/components/file-upload/single-file-upload.component.html
+++ b/packages/components/file-upload/single-file-upload.component.html
@@ -7,7 +7,7 @@
 >
     @if (!file) {
         <div class="dropzone">
-            <i color="contrast-fade" kbq-icon="kbq-cloud-arrow-up-o_24"></i>
+            <i kbq-icon="kbq-cloud-arrow-up-o_24" class="kbq-dropzone__icon"></i>
             <!-- prettier-ignore -->
             <span class="dropzone__text">{{ separatedCaptionText[0] }}<label kbq-link pseudo [disabled]="disabled" [tabIndex]="-1" [for]="inputId">{{ config.browseLink }}<input #input type="file" class="cdk-visually-hidden" [id]="inputId" [accept]="acceptedFiles" [disabled]="disabled" (change)="onFileSelectedViaClick($event)"></label>{{ separatedCaptionText[1] }}</span>
         </div>
@@ -27,6 +27,7 @@
                 </div>
                 <i
                     kbq-icon-button="kbq-xmark-circle_16"
+                    class="kbq-file-upload__action"
                     [disabled]="disabled"
                     (click)="deleteItem($event)"
                     (keydown.backspace)="deleteItem()"


### PR DESCRIPTION
## Summary

- added dev example for all states of file-upload (for future e2e tests)
- fixed icons colors

### before
<img width="1305" alt="Screenshot 2025-06-02 at 22 21 02" src="https://github.com/user-attachments/assets/d38edc00-8bd4-4c74-834b-99c361957d99" />

<hr/>

### after
<img width="1304" alt="Screenshot 2025-06-02 at 22 19 34" src="https://github.com/user-attachments/assets/fdee64d7-349a-4c8e-b4c2-35b821294a07" />
