### PR TITLE
fix(file-upload): layout improvements (#DS-3714)

### DIFF
--- a/packages/components-dev/file-upload/module.ts
+++ b/packages/components-dev/file-upload/module.ts
@@ -219,6 +219,36 @@ export class DevCustomTextDirective {}
             </tr>
             <tr>
                 <td>
+                    <kbq-multiple-file-upload size="compact">
+                        <ng-template #kbqFileIcon>
+                            <i kbq-icon="kbq-file-o_16"></i>
+                        </ng-template>
+                    </kbq-multiple-file-upload>
+                </td>
+                <td>
+                    <kbq-multiple-file-upload [disabled]="true" size="compact">
+                        <ng-template #kbqFileIcon>
+                            <i kbq-icon="kbq-file-o_16"></i>
+                        </ng-template>
+                    </kbq-multiple-file-upload>
+                </td>
+                <td>
+                    <kbq-multiple-file-upload class="dev-with-error" size="compact">
+                        <ng-template #kbqFileIcon>
+                            <i kbq-icon="kbq-file-o_16"></i>
+                        </ng-template>
+                    </kbq-multiple-file-upload>
+                </td>
+                <td>
+                    <kbq-multiple-file-upload class="dev-dragover" size="compact">
+                        <ng-template #kbqFileIcon>
+                            <i kbq-icon="kbq-file-o_16"></i>
+                        </ng-template>
+                    </kbq-multiple-file-upload>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="4">
                     <kbq-multiple-file-upload
                         class="dev-dragover"
                         #multipleWithErrorState
@@ -239,8 +269,6 @@ export class DevFileUploadStateAndStyle {
 
     protected readonly singleWithEmptyErrorState = viewChild<KbqSingleFileUploadComponent>('withEmptyErrorState');
     protected readonly singleWithErrorState = viewChild<KbqSingleFileUploadComponent>('withErrorState');
-    protected readonly multipleEmptyWithErrorState =
-        viewChild<KbqMultipleFileUploadComponent>('multipleEmptyWithErrorState');
     protected readonly multipleWithErrorState = viewChildren<KbqMultipleFileUploadComponent>('multipleWithErrorState');
 
     protected readonly file = new FormControl(this.testFile);
@@ -259,9 +287,11 @@ export class DevFileUploadStateAndStyle {
         afterNextRender(() => {
             this.singleWithEmptyErrorState()!.errorState = true;
             this.singleWithErrorState()!.errorState = true;
-            this.multipleEmptyWithErrorState()!.errorState = true;
             this.document.querySelectorAll('.dev-dragover .kbq-file-upload').forEach((el) => {
                 this.renderer.addClass(el, 'dragover');
+            });
+            this.document.querySelectorAll('.dev-with-error .kbq-file-upload').forEach((el) => {
+                this.renderer.addClass(el, 'kbq-error');
             });
             this.fileControlInvalid.updateValueAndValidity();
             this.multipleFileControlInvalid.updateValueAndValidity();

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -1,5 +1,6 @@
 import {
     AfterViewInit,
+    ChangeDetectorRef,
     Directive,
     inject,
     Input,
@@ -24,10 +25,13 @@ const MIN_VISIBLE_LENGTH = 50;
 })
 export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnInit, AfterViewInit, OnDestroy {
     private renderer: Renderer2 = inject(Renderer2);
+    private cdr: ChangeDetectorRef = inject(ChangeDetectorRef);
 
     @Input() set kbqEllipsisCenter(value: string) {
         this._kbqEllipsisCenter = value;
         this.refresh();
+        // check the view to properly calculate text-start and text-end on text initialized
+        this.cdr.detectChanges();
     }
 
     @Input() minVisibleLength: number = MIN_VISIBLE_LENGTH;

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -24,13 +24,13 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
 
     @Input() charWidth = 7;
 
+    @Input() debounceInterval: number = 50;
+
     readonly resizeStream = new Subject<Event>();
 
     private _kbqEllipsisCenter: string;
 
     private resizeSubscription = Subscription.EMPTY;
-
-    private readonly debounceInterval: number = 50;
 
     override ngOnInit(): void {
         super.ngOnInit();

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -1,4 +1,14 @@
-import { AfterViewInit, Directive, inject, Input, NgModule, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import {
+    AfterViewInit,
+    Directive,
+    inject,
+    Input,
+    NgModule,
+    numberAttribute,
+    OnDestroy,
+    OnInit,
+    Renderer2
+} from '@angular/core';
 import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
@@ -24,7 +34,7 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
 
     @Input() charWidth = 7;
 
-    @Input() debounceInterval: number = 50;
+    @Input({ transform: numberAttribute }) debounceInterval: number = 50;
 
     readonly resizeStream = new Subject<Event>();
 

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -34,6 +34,10 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
 
     @Input() charWidth = 7;
 
+    /**
+     * Debounce time (ms) for resize events before recalculating ellipsis position.
+     * @default 50
+     */
     @Input({ transform: numberAttribute }) debounceInterval: number = 50;
 
     readonly resizeStream = new Subject<Event>();

--- a/packages/components/file-upload/_file-upload-theme.scss
+++ b/packages/components/file-upload/_file-upload-theme.scss
@@ -93,6 +93,7 @@
             }
 
             .kbq-file-multiple-uploaded__header {
+                color: var(--kbq-foreground-contrast-secondary);
                 border-bottom-color: var(--kbq-file-upload-multiple-default-grid-divider-color);
             }
 
@@ -106,18 +107,16 @@
                 background-color: var(--kbq-file-upload-multiple-states-on-drag-container-background);
                 border-color: var(--kbq-file-upload-multiple-states-on-drag-container-border) !important;
 
+                .btn-upload {
+                    border-top-color: var(--kbq-file-upload-multiple-states-on-drag-container-border);
+                }
+
                 .kbq-file-multiple-uploaded__header {
-                    border-bottom-color: var(--kbq-file-upload-multiple-states-on-drag-container-background) !important;
+                    border-bottom-color: var(--kbq-file-upload-multiple-states-on-drag-grid-divider-color) !important;
                 }
 
                 .kbq-dropzone__icon {
                     color: var(--kbq-file-upload-multiple-states-on-drag-upload-icon-color);
-                }
-
-                &.selected {
-                    .dropzone {
-                        border-top-color: var(--kbq-file-upload-multiple-states-on-drag-container-border);
-                    }
                 }
             }
 
@@ -134,6 +133,10 @@
                     color: var(--kbq-file-upload-multiple-states-disabled-text-block-color);
                 }
 
+                .kbq-file-multiple-uploaded__header {
+                    border-bottom-color: var(--kbq-file-upload-multiple-states-disabled-grid-divider-color) !important;
+                }
+
                 .multiple__uploaded-item {
                     .kbq-file-upload__file .kbq-icon.kbq-empty {
                         color: var(--kbq-file-upload-multiple-states-disabled-left-icon-color);
@@ -148,12 +151,6 @@
                         color: var(--kbq-file-upload-multiple-states-disabled-icon-button-color);
                     }
                 }
-
-                &.selected {
-                    .dropzone {
-                        border-top-color: var(--kbq-file-upload-multiple-states-disabled-container-border);
-                    }
-                }
             }
 
             &:not(.kbq-disabled) {
@@ -162,12 +159,12 @@
                     border-color: var(--kbq-line-error) !important;
 
                     .kbq-dropzone__icon {
-                        color: var(--kbq-file-upload-single-states-error-upload-icon-color);
+                        color: var(--kbq-file-upload-multiple-states-error-upload-icon-color);
                     }
 
                     .dropzone__text:not(.kbq-link),
                     .kbq-file-multiple-uploaded__header {
-                        color: var(--kbq-file-upload-single-states-error-text-block-color);
+                        color: var(--kbq-file-upload-multiple-states-error-text-block-color);
                     }
                 }
 

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -59,6 +59,7 @@
     --kbq-file-upload-multiple-states-on-drag-text-block-color: var(--kbq-foreground-contrast);
     --kbq-file-upload-multiple-states-on-drag-grid-divider-color: var(--kbq-line-contrast-less);
     --kbq-file-upload-multiple-states-error-grid-cell-background: var(--kbq-background-error-less);
+    --kbq-file-upload-multiple-states-error-upload-icon-color: var(--kbq-icon-error);
     --kbq-file-upload-multiple-states-error-left-icon-color: var(--kbq-icon-error);
     --kbq-file-upload-multiple-states-error-text-block-color: var(--kbq-foreground-error);
     --kbq-file-upload-multiple-states-error-icon-button-color: var(--kbq-icon-error);

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-class-pattern */
 :where(.kbq-file-upload) {
     --kbq-file-upload-size-single-container-border-radius: var(--kbq-size-s);
     --kbq-file-upload-size-single-container-border-width: 1px;
@@ -76,6 +75,7 @@
     --kbq-form-field-hint-text: var(--kbq-foreground-contrast-secondary);
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 :where(.kbq-file-upload.compact) {
     --kbq-file-upload-multiple-compact-container-content-gap-horizontal: var(--kbq-size-s);
     --kbq-file-upload-multiple-compact-text-block-padding-vertical: var(--kbq-size-3xs);

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -7,18 +7,20 @@
     --kbq-file-upload-size-single-text-block-padding-vertical: var(--kbq-size-3xs);
     --kbq-file-upload-size-single-text-block-content-gap-horizontal: var(--kbq-size-xxs);
     --kbq-file-upload-single-min-height: var(--kbq-size-5xl);
-    --kbq-file-upload-size-multiple-big-container-min-height: 160px;
+    --kbq-file-upload-size-multiple-big-container-min-height: 192px;
     --kbq-file-upload-size-multiple-big-container-min-width: 320px;
     --kbq-file-upload-size-multiple-big-container-border-radius: var(--kbq-size-s);
     --kbq-file-upload-size-multiple-big-container-border-width: 1px;
     --kbq-file-upload-size-multiple-big-container-content-gap-horizontal: var(--kbq-size-m);
     --kbq-file-upload-size-multiple-big-container-padding-vertical: var(--kbq-size-xxl);
     --kbq-file-upload-size-multiple-big-container-padding-horizontal: var(--kbq-size-xxl);
+    --kbq-file-upload-size-multiple-big-dropzone-content-gap-horizontal: var(--kbq-size-s);
     --kbq-file-upload-size-multiple-big-text-block-content-gap-vertical: 0px;
     --kbq-file-upload-size-multiple-big-text-block-content-gap-horizontal: var(--kbq-size-xxs);
     --kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal: var(--kbq-size-s);
     --kbq-file-upload-size-multiple-big-grid-cell-padding-vertical: var(--kbq-size-s);
     --kbq-file-upload-size-multiple-big-grid-cell-content-gap-horizontal: var(--kbq-size-xxs);
+    --kbq-file-upload-size-multiple-big-grid-cell-file-size-width: var(--kbq-size-7xl);
     /* THEME TOKENS */
     --kbq-file-upload-single-default-container-border: var(--kbq-line-contrast-fade);
     --kbq-file-upload-single-default-container-background: var(--kbq-background-bg);

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -1,4 +1,5 @@
-.kbq-file-upload {
+/* stylelint-disable selector-class-pattern */
+:where(.kbq-file-upload) {
     --kbq-file-upload-size-single-container-border-radius: var(--kbq-size-s);
     --kbq-file-upload-size-single-container-border-width: 1px;
     --kbq-file-upload-size-single-container-content-gap-horizontal: var(--kbq-size-s);
@@ -73,4 +74,11 @@
     --kbq-file-upload-multiple-states-disabled-text-block-color: var(--kbq-states-foreground-disabled);
     --kbq-file-upload-multiple-states-disabled-grid-divider-color: var(--kbq-states-line-disabled);
     --kbq-form-field-hint-text: var(--kbq-foreground-contrast-secondary);
+}
+
+:where(.kbq-file-upload.compact) {
+    --kbq-file-upload-multiple-compact-container-content-gap-horizontal: var(--kbq-size-s);
+    --kbq-file-upload-multiple-compact-text-block-padding-vertical: var(--kbq-size-3xs);
+    --kbq-file-upload-multiple-compact-container-padding-vertical: 11px;
+    --kbq-file-upload-multiple-compact-container-padding-horizontal: 11px;
 }

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -51,7 +51,7 @@
                             (keydown.delete)="deleteFile(index)"
                         >
                             <div class="kbq-file-upload__row" [class.error]="file.hasError">
-                                <div class="kbq-file-upload__file">
+                                <div class="kbq-file-upload__file kbq-file-upload__grid-cell">
                                     @if (
                                         { loading: file.loading | async, progress: file.progress | async };
                                         as asyncData
@@ -76,9 +76,14 @@
                                         [minVisibleLength]="10"
                                     ></span>
                                 </div>
-                                <div class="kbq-file-upload__size">{{ file.file.size | kbqDataSize }}</div>
-                                <div class="kbq-file-upload__action">
-                                    <i kbq-icon-button="kbq-xmark-circle_16" (click)="deleteFile(index, $event)"></i>
+                                <div class="kbq-file-upload__size kbq-file-upload__grid-cell">
+                                    {{ file.file.size | kbqDataSize }}
+                                </div>
+                                <div
+                                    class="kbq-file-upload__action layout-row layout-align-center-center kbq-file-upload__grid-cell"
+                                    (click)="deleteFile(index, $event)"
+                                >
+                                    <i kbq-icon-button="kbq-xmark-circle_16" [disabled]="disabled"></i>
                                 </div>
                             </div>
                         </kbq-list-option>

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -122,6 +122,7 @@
     <input
         #input
         multiple
+        tabindex="0"
         type="file"
         class="cdk-visually-hidden"
         [accept]="acceptedFiles"

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -35,7 +35,7 @@
             <div class="kbq-file-upload__grid">
                 <div class="kbq-file-multiple-uploaded__header">
                     <div class="kbq-file-multiple-uploaded__header-inner">
-                        <div class="kbq-file-upload__file kbq-file-upload__grid-cell">
+                        <div #fileSizeHeaderCell class="kbq-file-upload__file kbq-file-upload__grid-cell">
                             {{ config.gridHeaders.file }}
                         </div>
                         <div class="kbq-file-upload__size kbq-file-upload__grid-cell">
@@ -53,7 +53,10 @@
                             (keydown.delete)="deleteFile(index)"
                         >
                             <div class="kbq-file-upload__row" [class.error]="file.hasError">
-                                <div class="kbq-file-upload__file kbq-file-upload__grid-cell">
+                                <div
+                                    class="kbq-file-upload__file kbq-file-upload__grid-cell"
+                                    [style.max-width.px]="calculateFileSizeCellMaxWidth()"
+                                >
                                     @if (
                                         { loading: file.loading | async, progress: file.progress | async };
                                         as asyncData
@@ -74,8 +77,8 @@
                                     }
                                     <span
                                         class="file-item__text"
+                                        [debounceInterval]="0"
                                         [kbqEllipsisCenter]="file.file.name"
-                                        [minVisibleLength]="10"
                                     ></span>
                                 </div>
                                 <div class="kbq-file-upload__size kbq-file-upload__grid-cell">
@@ -85,7 +88,7 @@
                                     class="kbq-file-upload__action kbq-file-upload__grid-cell"
                                     (click)="deleteFile(index, $event)"
                                 >
-                                    <i kbq-icon-button="kbq-xmark-circle_16" [disabled]="disabled"></i>
+                                    <i kbq-icon-button="kbq-xmark-circle_16" tabindex="-1" [disabled]="disabled"></i>
                                 </div>
                             </div>
                         </kbq-list-option>

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -12,10 +12,10 @@
             @if (size === 'default') {
                 <i kbq-icon="kbq-cloud-arrow-up-o_32" class="kbq-dropzone__icon"></i>
                 <div class="dropzone__text">
-                    <span class="multiple__header">{{ config.title }}</span>
+                    <div class="multiple__header">{{ config.title }}</div>
                     <div>
                         <!-- prettier-ignore -->
-                        <span class="multiple__caption">{{ separatedCaptionText[0] }}<label kbq-link pseudo [disabled]="disabled" [tabIndex]="-1" [for]="inputId">{{ config.browseLink }}<ng-container *ngTemplateOutlet="inputTemplate" /></label>{{ separatedCaptionText[1] }}</span>
+                        <div class="multiple__caption">{{ separatedCaptionText[0] }}<label kbq-link pseudo [disabled]="disabled" [tabIndex]="-1" [for]="inputId">{{ config.browseLink }}<ng-container *ngTemplateOutlet="inputTemplate" /></label>{{ separatedCaptionText[1] }}</div>
                     </div>
                 </div>
             } @else {
@@ -35,11 +35,13 @@
             <div class="kbq-file-upload__grid">
                 <div class="kbq-file-multiple-uploaded__header">
                     <div class="kbq-file-multiple-uploaded__header-inner">
-                        @for (column of columnDefs; track column) {
-                            <div [class]="'kbq-file-upload__' + column.cssClass">
-                                {{ column.header }}
-                            </div>
-                        }
+                        <div class="kbq-file-upload__file kbq-file-upload__grid-cell">
+                            {{ config.gridHeaders.file }}
+                        </div>
+                        <div class="kbq-file-upload__size kbq-file-upload__grid-cell">
+                            {{ config.gridHeaders.size }}
+                        </div>
+                        <div class="kbq-file-upload__action kbq-file-upload__grid-cell"></div>
                     </div>
                 </div>
                 <kbq-list-selection [autoSelect]="false" [disabled]="disabled">
@@ -80,7 +82,7 @@
                                     {{ file.file.size | kbqDataSize }}
                                 </div>
                                 <div
-                                    class="kbq-file-upload__action layout-row layout-align-center-center kbq-file-upload__grid-cell"
+                                    class="kbq-file-upload__action kbq-file-upload__grid-cell"
                                     (click)="deleteFile(index, $event)"
                                 >
                                     <i kbq-icon-button="kbq-xmark-circle_16" [disabled]="disabled"></i>

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -55,7 +55,7 @@
                             <div class="kbq-file-upload__row" [class.error]="file.hasError">
                                 <div
                                     class="kbq-file-upload__file kbq-file-upload__grid-cell"
-                                    [style.max-width.px]="calculateFileSizeCellMaxWidth()"
+                                    [style.max-width.px]="fileSizeCellMaxWidth"
                                 >
                                     @if (
                                         { loading: file.loading | async, progress: file.progress | async };

--- a/packages/components/file-upload/multiple-file-upload.component.scss
+++ b/packages/components/file-upload/multiple-file-upload.component.scss
@@ -46,8 +46,7 @@
 
     .kbq-list-option.multiple__uploaded-item {
         border-radius: 0;
-        // size-3xs subtract border-width
-        padding: 0 1px;
+        padding: 0 calc(var(--kbq-size-3xs) - var(--kbq-file-upload-size-multiple-big-container-border-width));
 
         .kbq-icon {
             margin-right: 0;
@@ -93,39 +92,50 @@
         }
 
         .kbq-file-upload__action {
+            $list-option-border-width: var(--kbq-size-3xs);
             display: flex;
             justify-content: center;
             align-items: center;
-            // grid-cell-padding-vertical subtract list-option-border-width
-            padding-top: 6px;
-            padding-bottom: 6px;
+            padding-top: calc(
+                var(--kbq-file-upload-size-multiple-big-grid-cell-padding-vertical) - $list-option-border-width
+            );
+            padding-bottom: calc(
+                var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal) - $list-option-border-width
+            );
             min-height: var(--kbq-size-xxl);
             min-width: var(--kbq-size-xxl);
         }
     }
 
     .kbq-file-multiple-uploaded__header {
+        margin: -1px;
         border-bottom-width: var(--kbq-file-upload-size-multiple-big-container-border-width);
         border-bottom-style: solid;
 
-        padding: 0 3px;
+        padding: 0 var(--kbq-size-xxs);
 
         .kbq-file-upload__grid-cell {
-            padding: 9px var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal);
+            padding: 10px var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal) 9px
+                var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal);
         }
 
         .kbq-file-upload__action {
             min-height: var(--kbq-size-xxl);
             min-width: var(--kbq-size-xxl);
-            // grid-cell-padding-vertical subtract border-width
-            padding: 7px var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal);
+            padding: var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal)
+                var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal)
+                calc(
+                    var(--kbq-file-upload-size-multiple-big-grid-cell-padding-vertical) - var(
+                            --kbq-file-upload-size-multiple-big-container-border-width
+                        )
+                );
         }
     }
 
     .btn-upload {
         margin: -1px;
-        // size-m subtract border-width
-        padding: 11px var(--kbq-size-m) var(--kbq-size-m) var(--kbq-size-m);
+        padding: calc(var(--kbq-size-m) - var(--kbq-file-upload-size-multiple-big-container-border-width))
+            var(--kbq-size-m) var(--kbq-size-m) var(--kbq-size-m);
 
         border-top-width: var(--kbq-file-upload-size-multiple-big-container-border-width);
         border-top-style: dashed;

--- a/packages/components/file-upload/multiple-file-upload.component.scss
+++ b/packages/components/file-upload/multiple-file-upload.component.scss
@@ -115,7 +115,9 @@
         padding: 0 var(--kbq-size-xxs);
 
         .kbq-file-upload__grid-cell {
-            padding: 10px var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal) 9px
+            $header-cell-vertical-padding: 10px;
+            padding: $header-cell-vertical-padding var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal)
+                calc($header-cell-vertical-padding - var(--kbq-file-upload-size-multiple-big-container-border-width))
                 var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal);
         }
 

--- a/packages/components/file-upload/multiple-file-upload.component.scss
+++ b/packages/components/file-upload/multiple-file-upload.component.scss
@@ -18,58 +18,36 @@
 
         min-width: var(--kbq-file-upload-size-multiple-big-container-min-width);
 
-        & .dropzone {
+        .dropzone {
             gap: var(--kbq-file-upload-size-multiple-big-container-content-gap-horizontal);
         }
 
-        & .dropzone__text {
-            & .multiple__header {
-                display: block;
-            }
-
-            & .multiple__caption {
-                display: block;
+        .dropzone__text {
+            .multiple__caption {
                 padding-top: var(--kbq-file-upload-size-multiple-big-text-block-content-gap-vertical);
-                // гап не применяется тк не флекс. в целом гап не нужен, тк по логике дизайна ссылка от текста отделяется пробелом
-                gap: var(--kbq-file-upload-size-multiple-big-text-block-content-gap-horizontal);
             }
         }
     }
 
     &.compact:not(.selected) {
+        // todo replace with vars related to multiple file upload
         padding: var(--kbq-file-upload-size-single-container-padding-vertical)
             var(--kbq-file-upload-size-single-container-padding-horizontal);
 
-        & .dropzone {
+        .dropzone {
             gap: var(--kbq-file-upload-size-single-container-content-gap-horizontal);
 
-            & .dropzone__text.multiple__caption {
+            .dropzone__text.multiple__caption {
                 padding-top: var(--kbq-file-upload-size-single-text-block-padding-vertical);
 
                 padding-bottom: var(--kbq-file-upload-size-single-text-block-padding-vertical);
-
-                gap: var(--kbq-file-upload-size-single-text-block-content-gap-horizontal);
             }
         }
     }
 
-    & .kbq-list-option.multiple__uploaded-item {
-        padding: 0;
-
-        & .kbq-list-text {
-            padding: calc(
-                    var(--kbq-file-upload-size-multiple-big-grid-cell-padding-vertical) - var(
-                            --kbq-list-size-container-focus-outline-width,
-                            var(--kbq-size-3xs)
-                        )
-                )
-                calc(
-                    var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal) - var(
-                            --kbq-list-size-container-focus-outline-width,
-                            var(--kbq-size-3xs)
-                        )
-                );
-        }
+    .kbq-list-option.multiple__uploaded-item {
+        border-radius: 0;
+        padding: 0 1px;
 
         .kbq-icon {
             margin-right: 0;
@@ -86,29 +64,44 @@
         align-items: center;
 
         .kbq-file-upload__file {
-            width: 65%;
-            max-width: 65%;
-
-            gap: var(--kbq-file-upload-size-multiple-big-grid-cell-content-gap-horizontal);
+            flex-grow: 1;
         }
 
         .kbq-file-upload__size {
-            width: var(--kbq-size-7xl);
-            min-width: var(--kbq-size-7xl);
+            width: var(--kbq-file-upload-size-multiple-big-grid-cell-file-size-width);
+            min-width: var(--kbq-file-upload-size-multiple-big-grid-cell-file-size-width);
+            max-width: var(--kbq-file-upload-size-multiple-big-grid-cell-file-size-width);
             text-align: left;
             flex-grow: 1;
+            flex-shrink: 1;
         }
     }
 
     .kbq-file-upload__row {
+        .kbq-file-upload__grid-cell {
+            padding: 0 8px;
+        }
+
         .kbq-file-upload__file {
             display: flex;
             align-items: center;
+            gap: var(--kbq-file-upload-size-multiple-big-grid-cell-content-gap-horizontal);
 
             .file-item__text {
                 margin-left: 0;
                 width: 90%;
             }
+        }
+
+        .kbq-file-upload__action {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            // todo replace with vars
+            padding-top: 6px;
+            padding-bottom: 6px;
+            min-height: 24px;
+            min-width: 24px;
         }
     }
 
@@ -116,37 +109,30 @@
         border-bottom-width: 1px;
         border-bottom-style: solid;
 
-        .kbq-file-multiple-uploaded__header-inner {
-            padding: kbq-sum-series-css-variables([file-upload-size-multiple-big-grid-cell-padding-vertical, 2px])
-                kbq-sum-series-css-variables([file-upload-size-multiple-big-grid-cell-padding-horizontal 2px]);
+        padding: 0 3px;
+
+        .kbq-file-upload__grid-cell {
+            // todo replace with vars
+            padding: 9px 8px;
+        }
+
+        .kbq-file-upload__action {
+            min-height: 24px;
+            min-width: 24px;
+            padding: 7px 8px;
         }
     }
 
     .btn-upload {
-        padding: kbq-difference-series-css-variables(
-                [ file-upload-size-single-container-padding-vertical,
-                file-upload-size-single-container-border-width]
-            )
-            kbq-difference-series-css-variables(
-                [ file-upload-size-single-container-padding-horizontal,
-                file-upload-size-single-container-border-width]
-            );
-        border-top-left-radius: var(--kbq-file-upload-size-single-container-border-radius);
+        margin: -1px;
+        // todo replace with vars
+        padding: 11px var(--kbq-size-m) var(--kbq-size-m) var(--kbq-size-m);
 
-        border-top-right-radius: var(--kbq-file-upload-size-single-container-border-radius);
-        border-top-width: var(--kbq-file-upload-size-single-container-border-width);
+        border-top-width: var(--kbq-file-upload-size-multiple-big-container-border-width);
         border-top-style: dashed;
 
-        & .dropzone {
-            gap: var(--kbq-file-upload-size-single-container-content-gap-horizontal);
-
-            & .dropzone__text.multiple__caption {
-                padding-top: var(--kbq-file-upload-size-single-text-block-padding-vertical);
-
-                padding-bottom: var(--kbq-file-upload-size-single-text-block-padding-vertical);
-
-                gap: var(--kbq-file-upload-size-single-text-block-content-gap-horizontal);
-            }
+        .dropzone {
+            gap: var(--kbq-file-upload-size-multiple-big-dropzone-content-gap-horizontal);
         }
     }
 

--- a/packages/components/file-upload/multiple-file-upload.component.scss
+++ b/packages/components/file-upload/multiple-file-upload.component.scss
@@ -30,23 +30,23 @@
     }
 
     &.compact:not(.selected) {
-        // todo replace with vars related to multiple file upload
-        padding: var(--kbq-file-upload-size-single-container-padding-vertical)
-            var(--kbq-file-upload-size-single-container-padding-horizontal);
+        padding: var(--kbq-file-upload-multiple-compact-container-padding-vertical)
+            var(--kbq-file-upload-multiple-compact-container-padding-horizontal);
 
         .dropzone {
-            gap: var(--kbq-file-upload-size-single-container-content-gap-horizontal);
+            gap: var(--kbq-file-upload-multiple-compact-container-content-gap-horizontal);
 
             .dropzone__text.multiple__caption {
-                padding-top: var(--kbq-file-upload-size-single-text-block-padding-vertical);
+                padding-top: var(--kbq-file-upload-multiple-compact-text-block-padding-vertical);
 
-                padding-bottom: var(--kbq-file-upload-size-single-text-block-padding-vertical);
+                padding-bottom: var(--kbq-file-upload-multiple-compact-text-block-padding-vertical);
             }
         }
     }
 
     .kbq-list-option.multiple__uploaded-item {
         border-radius: 0;
+        // size-3xs subtract border-width
         padding: 0 1px;
 
         .kbq-icon {
@@ -71,15 +71,15 @@
             width: var(--kbq-file-upload-size-multiple-big-grid-cell-file-size-width);
             min-width: var(--kbq-file-upload-size-multiple-big-grid-cell-file-size-width);
             max-width: var(--kbq-file-upload-size-multiple-big-grid-cell-file-size-width);
-            text-align: left;
             flex-grow: 1;
             flex-shrink: 1;
+            text-align: left;
         }
     }
 
     .kbq-file-upload__row {
         .kbq-file-upload__grid-cell {
-            padding: 0 8px;
+            padding: 0 var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal);
         }
 
         .kbq-file-upload__file {
@@ -88,7 +88,6 @@
             gap: var(--kbq-file-upload-size-multiple-big-grid-cell-content-gap-horizontal);
 
             .file-item__text {
-                margin-left: 0;
                 width: 90%;
             }
         }
@@ -97,35 +96,35 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            // todo replace with vars
+            // grid-cell-padding-vertical subtract list-option-border-width
             padding-top: 6px;
             padding-bottom: 6px;
-            min-height: 24px;
-            min-width: 24px;
+            min-height: var(--kbq-size-xxl);
+            min-width: var(--kbq-size-xxl);
         }
     }
 
     .kbq-file-multiple-uploaded__header {
-        border-bottom-width: 1px;
+        border-bottom-width: var(--kbq-file-upload-size-multiple-big-container-border-width);
         border-bottom-style: solid;
 
         padding: 0 3px;
 
         .kbq-file-upload__grid-cell {
-            // todo replace with vars
-            padding: 9px 8px;
+            padding: 9px var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal);
         }
 
         .kbq-file-upload__action {
-            min-height: 24px;
-            min-width: 24px;
-            padding: 7px 8px;
+            min-height: var(--kbq-size-xxl);
+            min-width: var(--kbq-size-xxl);
+            // grid-cell-padding-vertical subtract border-width
+            padding: 7px var(--kbq-file-upload-size-multiple-big-grid-cell-padding-horizontal);
         }
     }
 
     .btn-upload {
         margin: -1px;
-        // todo replace with vars
+        // size-m subtract border-width
         padding: 11px var(--kbq-size-m) var(--kbq-size-m) var(--kbq-size-m);
 
         border-top-width: var(--kbq-file-upload-size-multiple-big-container-border-width);

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -19,6 +19,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor } from '@angular/forms';
 import { ErrorStateMatcher, ruRULocaleData } from '@koobiq/components/core';
 import { KbqHint } from '@koobiq/components/form-field';
+import { KbqListSelection } from '@koobiq/components/list';
 import { ProgressSpinnerMode } from '@koobiq/components/progress-spinner';
 import { BehaviorSubject } from 'rxjs';
 import {
@@ -118,6 +119,9 @@ export class KbqMultipleFileUploadComponent
 
     /** @docs-private */
     @ViewChild('input') input: ElementRef<HTMLInputElement>;
+
+    /** @docs-private */
+    @ViewChild(KbqListSelection) listSelection: KbqListSelection;
 
     /** @docs-private */
     @ContentChildren(KbqHint) protected readonly hint: QueryList<TemplateRef<any>>;
@@ -287,6 +291,8 @@ export class KbqMultipleFileUploadComponent
         this.fileRemoved.emit([removedFile, index]);
         this.filesChange.emit(this.files);
         this.onTouched();
+
+        this.listSelection.keyManager.setActiveItem(-1);
     }
 
     private updateLocaleParams = () => {

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -123,10 +123,10 @@ export class KbqMultipleFileUploadComponent
     @ViewChild('input') input: ElementRef<HTMLInputElement>;
 
     /** @docs-private */
-    @ViewChild('fileSizeHeaderCell') fileSizeHeaderCell: ElementRef<HTMLElement>;
+    @ViewChild(KbqListSelection) listSelection: KbqListSelection;
 
     /** @docs-private */
-    @ViewChild(KbqListSelection) listSelection: KbqListSelection;
+    @ViewChild('fileSizeHeaderCell') private fileSizeHeaderCell: ElementRef<HTMLElement>;
 
     /** @docs-private */
     @ContentChildren(KbqHint) protected readonly hint: QueryList<TemplateRef<any>>;
@@ -178,6 +178,14 @@ export class KbqMultipleFileUploadComponent
      */
     get invalid(): boolean {
         return this.errorState;
+    }
+
+    /**
+     * Set maxWidth for filesize cell to enable proper ellipsis center,
+     * @docs-private
+     */
+    protected get fileSizeCellMaxWidth() {
+        return this.fileSizeHeaderCell?.nativeElement.offsetWidth - fileSizeCellPadding;
     }
 
     /** @docs-private */
@@ -298,14 +306,6 @@ export class KbqMultipleFileUploadComponent
         this.onTouched();
 
         this.listSelection.keyManager.setActiveItem(-1);
-    }
-
-    /**
-     * Set maxWidth for filesize cell to enable proper ellipsis center
-     * @docs-private
-     */
-    protected calculateFileSizeCellMaxWidth() {
-        return this.fileSizeHeaderCell?.nativeElement.offsetWidth - fileSizeCellPadding;
     }
 
     private updateLocaleParams = () => {

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -49,6 +49,8 @@ export interface KbqInputFileMultipleLabel extends KbqInputFileLabel {
 export const KBQ_MULTIPLE_FILE_UPLOAD_DEFAULT_CONFIGURATION: KbqInputFileMultipleLabel =
     ruRULocaleData.fileUpload.multiple;
 
+const fileSizeCellPadding = 16;
+
 @Component({
     selector: 'kbq-multiple-file-upload,kbq-file-upload[multiple]',
     templateUrl: './multiple-file-upload.component.html',
@@ -119,6 +121,9 @@ export class KbqMultipleFileUploadComponent
 
     /** @docs-private */
     @ViewChild('input') input: ElementRef<HTMLInputElement>;
+
+    /** @docs-private */
+    @ViewChild('fileSizeHeaderCell') fileSizeHeaderCell: ElementRef<HTMLElement>;
 
     /** @docs-private */
     @ViewChild(KbqListSelection) listSelection: KbqListSelection;
@@ -293,6 +298,14 @@ export class KbqMultipleFileUploadComponent
         this.onTouched();
 
         this.listSelection.keyManager.setActiveItem(-1);
+    }
+
+    /**
+     * Set maxWidth for filesize cell to enable proper ellipsis center
+     * @docs-private
+     */
+    protected calculateFileSizeCellMaxWidth() {
+        return this.fileSizeHeaderCell?.nativeElement.offsetWidth - fileSizeCellPadding;
     }
 
     private updateLocaleParams = () => {

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -104,29 +104,26 @@ export class KbqMultipleFileUploadComponent
 
     /** Emits an event containing updated file list.
      * public output will be renamed to filesChange in next major release (#DS-3700) */
-    @Output('fileQueueChanged') filesChange: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
+    @Output('fileQueueChanged') readonly filesChange: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
     /**
      * Emits an event containing a chunk of files added to the file list.
      * Useful when handling added files, skipping filtering file list.
      */
-    @Output() filesAdded: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
+    @Output() readonly filesAdded: EventEmitter<KbqFileItem[]> = new EventEmitter<KbqFileItem[]>();
     /**
      * Emits an event containing a tuple of file and file's index when removed from the file list.
      * Useful when handle removed files, skipping filtering file list.
      */
-    @Output() fileRemoved: EventEmitter<[KbqFileItem, number]> = new EventEmitter<[KbqFileItem, number]>();
+    @Output() readonly fileRemoved: EventEmitter<[KbqFileItem, number]> = new EventEmitter<[KbqFileItem, number]>();
 
     /** File Icon Template */
-    @ContentChild('kbqFileIcon', { static: false, read: TemplateRef }) customFileIcon: TemplateRef<HTMLElement>;
+    @ContentChild('kbqFileIcon', { static: false, read: TemplateRef })
+    protected readonly customFileIcon: TemplateRef<HTMLElement>;
 
     /** @docs-private */
-    @ViewChild('input') input: ElementRef<HTMLInputElement>;
-
-    /** @docs-private */
-    @ViewChild(KbqListSelection) listSelection: KbqListSelection;
-
-    /** @docs-private */
-    @ViewChild('fileSizeHeaderCell') private fileSizeHeaderCell: ElementRef<HTMLElement>;
+    @ViewChild('input') readonly input: ElementRef<HTMLInputElement>;
+    @ViewChild(KbqListSelection) private readonly listSelection: KbqListSelection;
+    @ViewChild('fileSizeHeaderCell') private readonly fileSizeHeaderCell: ElementRef<HTMLElement>;
 
     /** @docs-private */
     @ContentChildren(KbqHint) protected readonly hint: QueryList<TemplateRef<any>>;

--- a/packages/components/file-upload/single-file-upload.component.html
+++ b/packages/components/file-upload/single-file-upload.component.html
@@ -9,7 +9,7 @@
         <div class="dropzone">
             <i kbq-icon="kbq-cloud-arrow-up-o_24" class="kbq-dropzone__icon"></i>
             <!-- prettier-ignore -->
-            <span class="dropzone__text">{{ separatedCaptionText[0] }}<label kbq-link pseudo [disabled]="disabled" [tabIndex]="-1" [for]="inputId">{{ config.browseLink }}<input #input type="file" class="cdk-visually-hidden" [id]="inputId" [accept]="acceptedFiles" [disabled]="disabled" (change)="onFileSelectedViaClick($event)"></label>{{ separatedCaptionText[1] }}</span>
+            <span class="dropzone__text">{{ separatedCaptionText[0] }}<label kbq-link pseudo [disabled]="disabled" [tabIndex]="-1" [for]="inputId">{{ config.browseLink }}<input #input type="file" class="cdk-visually-hidden" [id]="inputId" [accept]="acceptedFiles" [disabled]="disabled" (change)="onFileSelectedViaClick($event)" tabindex="0"></label>{{ separatedCaptionText[1] }}</span>
         </div>
     } @else {
         @if (file) {

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-default-validation-reactive-forms-overview/file-upload-multiple-default-validation-reactive-forms-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-default-validation-reactive-forms-overview/file-upload-multiple-default-validation-reactive-forms-overview-example.ts
@@ -34,7 +34,7 @@ const MAX_FILE_SIZE = 5 * 2 ** 20;
             @for (control of fileList.controls; track $index) {
                 <kbq-hint color="error">
                     @if (control.hasError('maxFileSize')) {
-                        {{ control.value?.file?.name }} - {{ maxFileSizeErrorMessage }}
+                        {{ control.value?.file?.name }} — {{ maxFileSizeErrorMessage }}
                     }
                 </kbq-hint>
             }

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-error-overview/file-upload-multiple-error-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-error-overview/file-upload-multiple-error-overview-example.ts
@@ -6,9 +6,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 const MAX_FILE_SIZE = 5 * 2 ** 20;
 
 const maxFileExceeded = (file: File): string | null => {
-    return (file?.size ?? 0) > MAX_FILE_SIZE
-        ? `${file.name} - Размер файла превышает максимально допустимый (5 МБ)`
-        : null;
+    return (file?.size ?? 0) > MAX_FILE_SIZE ? `${file.name} — The file size has exceeded the limit (5 MB)` : null;
 };
 
 /**
@@ -27,7 +25,7 @@ const maxFileExceeded = (file: File): string | null => {
                     <i kbq-icon="kbq-exclamation-triangle_16"></i>
                 }
             </ng-template>
-            <kbq-hint>Максимальный размер файла 5 МБ</kbq-hint>
+            <kbq-hint>Maximum file size 5 MB</kbq-hint>
             @for (error of errors; track error) {
                 <kbq-hint color="error">{{ error }}</kbq-hint>
             }

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -28,7 +28,6 @@ import * as i7 from '@koobiq/components/icon';
 import * as i8 from '@koobiq/components/button';
 import * as i9 from '@koobiq/components/list';
 import { InjectionToken } from '@angular/core';
-import { KbqListSelection } from '@koobiq/components/list';
 import { KbqLocaleService } from '@koobiq/components/core';
 import { NgControl } from '@angular/forms';
 import { NgForm } from '@angular/forms';
@@ -163,7 +162,7 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     }[];
     config: KbqInputFileMultipleLabel;
     readonly configuration: KbqInputFileMultipleLabel | null;
-    customFileIcon: TemplateRef<HTMLElement>;
+    protected readonly customFileIcon: TemplateRef<HTMLElement>;
     // @deprecated (undocumented)
     customValidation?: KbqFileValidatorFn[];
     cvaOnChange: (_: KbqFileItem[]) => void;
@@ -173,22 +172,21 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     // @deprecated (undocumented)
     errors: string[];
     errorStateMatcher: ErrorStateMatcher;
-    fileRemoved: EventEmitter<[KbqFileItem, number]>;
+    readonly fileRemoved: EventEmitter<[KbqFileItem, number]>;
     // (undocumented)
     get files(): KbqFileItem[];
     set files(currentFileList: KbqFileItem[]);
-    filesAdded: EventEmitter<KbqFileItem[]>;
-    filesChange: EventEmitter<KbqFileItem[]>;
+    readonly filesAdded: EventEmitter<KbqFileItem[]>;
+    readonly filesChange: EventEmitter<KbqFileItem[]>;
     protected get fileSizeCellMaxWidth(): number;
     // @deprecated (undocumented)
     get hasErrors(): boolean;
     hasFocus: boolean;
     get hasHint(): boolean;
     protected readonly hint: QueryList<TemplateRef<any>>;
-    input: ElementRef<HTMLInputElement>;
+    readonly input: ElementRef<HTMLInputElement>;
     inputId: string;
     get invalid(): boolean;
-    listSelection: KbqListSelection;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -157,6 +157,7 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     constructor();
     accept?: string[];
     get acceptedFiles(): string;
+    protected calculateFileSizeCellMaxWidth(): number;
     columnDefs: {
         header: string;
         cssClass: string;
@@ -179,6 +180,7 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     set files(currentFileList: KbqFileItem[]);
     filesAdded: EventEmitter<KbqFileItem[]>;
     filesChange: EventEmitter<KbqFileItem[]>;
+    fileSizeHeaderCell: ElementRef<HTMLElement>;
     // @deprecated (undocumented)
     get hasErrors(): boolean;
     hasFocus: boolean;

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -157,7 +157,6 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     constructor();
     accept?: string[];
     get acceptedFiles(): string;
-    protected calculateFileSizeCellMaxWidth(): number;
     columnDefs: {
         header: string;
         cssClass: string;
@@ -180,7 +179,7 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     set files(currentFileList: KbqFileItem[]);
     filesAdded: EventEmitter<KbqFileItem[]>;
     filesChange: EventEmitter<KbqFileItem[]>;
-    fileSizeHeaderCell: ElementRef<HTMLElement>;
+    protected get fileSizeCellMaxWidth(): number;
     // @deprecated (undocumented)
     get hasErrors(): boolean;
     hasFocus: boolean;

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -28,6 +28,7 @@ import * as i7 from '@koobiq/components/icon';
 import * as i8 from '@koobiq/components/button';
 import * as i9 from '@koobiq/components/list';
 import { InjectionToken } from '@angular/core';
+import { KbqListSelection } from '@koobiq/components/list';
 import { KbqLocaleService } from '@koobiq/components/core';
 import { NgControl } from '@angular/forms';
 import { NgForm } from '@angular/forms';
@@ -186,6 +187,7 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
     input: ElementRef<HTMLInputElement>;
     inputId: string;
     get invalid(): boolean;
+    listSelection: KbqListSelection;
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)


### PR DESCRIPTION
## Summary

* Fixed the position of the file deletion crosses
* Adjusted the height of the header panel and the file list row to match the design
* Reduced the file size column (set a fixed width)
* Removed focus frame switching to the previous row when clicking the cross in multiple mode
* Changed the header text color to `--kbq-foreground-contrast-secondary`
* Enabled Tab focus transfer from the file list to the "choose" pseudo-link
* Fixed filename truncation in the middle when resizing
* Added CSS variables for the compact type


<details>
   <summary>ru-RU</summary>

- Поправил положение крестиков удаления файлов
- Поправил высоту панели шапки и высоту строки списка файлов в соответствии с дизайном
- Уменьшил колонку с размером файла  (сделал фиксированную ширину)
- Убрал переключение рамки фокуса на предыдущую строку при нажатии на крестик в multiple-режиме
- Поменял цвет текста в шапке на `--kbq-foreground-contrast-secondary`
- Сделал перевод фокуса  Tab'ом с листа файлов на псевдоссылку «выберите»
- Поправил сворачивание имени файла посередине при ресайзе.
- Добавил css-переменные для типа compact.
</details>

