### PR TITLE
fix(core): provide rounding options in filesize formatter (#DS-3806)

### DIFF
--- a/packages/components/core/formatters/filesize/__snapshots__/formatter.spec.ts.snap
+++ b/packages/components/core/formatters/filesize/__snapshots__/formatter.spec.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Filesize formatter getFormattedSizeParts should format value to locale-independent numeric string 1`] = `"50.634944915771484"`;
+
+exports[`Filesize formatter getFormattedSizeParts should format value to selected unit system 1`] = `"53.094588"`;

--- a/packages/components/core/formatters/filesize/formatter.spec.ts
+++ b/packages/components/core/formatters/filesize/formatter.spec.ts
@@ -80,48 +80,17 @@ describe('Filesize formatter', () => {
         const selectedUnitSystem = KBQ_SIZE_UNITS_DEFAULT_CONFIG.unitSystems[KbqMeasurementSystem.IEC];
 
         it('should format value to locale-independent numeric string', () => {
-            const precision = 2;
-            const expected = '50.63';
+            const { value } = getFormattedSizeParts(raw, selectedUnitSystem);
 
-            const { value } = getFormattedSizeParts(raw, precision, selectedUnitSystem);
-
-            expect(value).toBe(expected);
-        });
-
-        it('should format value to selected precision', () => {
-            const precision = 1;
-            const selectedUnitSystem = KBQ_SIZE_UNITS_DEFAULT_CONFIG.unitSystems[KbqMeasurementSystem.IEC];
-
-            const { value } = getFormattedSizeParts(raw, precision, selectedUnitSystem);
-
-            expect(value.split('.')[1].length).toBe(precision);
-        });
-
-        it('should NOT format value to selected precision if value is less than 1 KB', () => {
-            let raw = 1000;
-            let res: { value: string; unit: string };
-            const precision = 2;
-            const selectedUnitSystem = KBQ_SIZE_UNITS_DEFAULT_CONFIG.unitSystems[KbqMeasurementSystem.IEC];
-
-            res = getFormattedSizeParts(raw, precision, selectedUnitSystem);
-
-            expect(res.value.split('.')[1]?.length).not.toBe(precision);
-
-            raw = 1000.153;
-
-            res = getFormattedSizeParts(raw, precision, selectedUnitSystem);
-
-            expect(res.value.split('.')[1].length).not.toBe(precision);
+            expect(value).toMatchSnapshot();
         });
 
         it('should format value to selected unit system', () => {
-            const precision = 2;
-            const expected = '53.09';
             const selectedUnitSystem = KBQ_SIZE_UNITS_DEFAULT_CONFIG.unitSystems[KbqMeasurementSystem.SI];
 
-            const { value } = getFormattedSizeParts(raw, precision, selectedUnitSystem);
+            const { value } = getFormattedSizeParts(raw, selectedUnitSystem);
 
-            expect(value).toBe(expected);
+            expect(value).toMatchSnapshot();
         });
     });
 
@@ -255,7 +224,6 @@ describe('Filesize formatter', () => {
                 const result = pipe.transform(1500);
                 const { value, unit } = getFormattedSizeParts(
                     1500,
-                    2,
                     KBQ_SIZE_UNITS_DEFAULT_CONFIG.unitSystems[KbqMeasurementSystem.SI]
                 );
 

--- a/packages/components/core/formatters/filesize/formatter.ts
+++ b/packages/components/core/formatters/filesize/formatter.ts
@@ -35,18 +35,19 @@ export class KbqDataSizePipe implements PipeTransform {
     }
 
     /** Transforms bytes into localized size string */
-    transform(source: number, precision?: number, unitSystemName?: KbqMeasurementSystemType, locale?: string): string {
-        const currentLocale = locale || this.localeService?.id || KBQ_DEFAULT_LOCALE_ID;
-        const selectedPrecision = precision ?? this.config.defaultPrecision;
-
+    transform(
+        source: number,
+        precision: number = this.config.defaultPrecision,
+        unitSystemName: KbqMeasurementSystemType = this.config.defaultUnitSystem,
+        locale: string = this.localeService?.id || KBQ_DEFAULT_LOCALE_ID
+    ): string {
         const resolvedUnitSystems: Record<KbqMeasurementSystem, KbqUnitSystem> = locale
             ? this.localeService?.locales[locale].sizeUnits.unitSystems
             : this.config.unitSystems;
 
-        const unitSystem = resolvedUnitSystems[unitSystemName || this.config.defaultUnitSystem];
+        const { value, unit } = getFormattedSizeParts(source, precision, resolvedUnitSystems[unitSystemName]);
 
-        const { value, unit } = getFormattedSizeParts(source, selectedPrecision, unitSystem);
-        const formattedValue = this.numberPipe?.transform(value, undefined, currentLocale) || value;
+        const formattedValue = this.numberPipe?.transform(value, `1.${precision}-${precision}`, locale) || value;
 
         return formattedValue ? `${formattedValue}${this.nonBreakingSpace}${unit}` : '';
     }

--- a/packages/components/core/formatters/filesize/formatter.ts
+++ b/packages/components/core/formatters/filesize/formatter.ts
@@ -41,13 +41,13 @@ export class KbqDataSizePipe implements PipeTransform {
         unitSystemName: KbqMeasurementSystemType = this.config.defaultUnitSystem,
         locale: string = this.localeService?.id || KBQ_DEFAULT_LOCALE_ID
     ): string {
-        const resolvedUnitSystems: Record<KbqMeasurementSystem, KbqUnitSystem> = locale
-            ? this.localeService?.locales[locale].sizeUnits.unitSystems
+        const resolvedUnitSystems: Record<KbqMeasurementSystem, KbqUnitSystem> = this.localeService
+            ? this.localeService.locales[locale].sizeUnits.unitSystems
             : this.config.unitSystems;
 
-        const { value, unit } = getFormattedSizeParts(source, precision, resolvedUnitSystems[unitSystemName]);
+        const { value, unit } = getFormattedSizeParts(source, resolvedUnitSystems[unitSystemName]);
 
-        const formattedValue = this.numberPipe?.transform(value, `1.${precision}-${precision}`, locale) || value;
+        const formattedValue = this.numberPipe?.transform(value, `1.0-${precision}`, locale) || value;
 
         return formattedValue ? `${formattedValue}${this.nonBreakingSpace}${unit}` : '';
     }

--- a/packages/components/core/formatters/filesize/size.ts
+++ b/packages/components/core/formatters/filesize/size.ts
@@ -26,6 +26,7 @@ export const formatDataSize = (
     };
 };
 
+// @TODO: remove deprecated (#DS-3849)
 /**
  * Converts a byte value into locale-independent file size parts: numeric value and unit abbreviation.
  *
@@ -36,14 +37,38 @@ export const formatDataSize = (
  * @example
  * formatDataSize(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
  */
-export const getFormattedSizeParts = (value: number, system: KbqUnitSystem): { value: string; unit: string } => {
-    const { result, unit } = getHumanizedBytes(value, system);
+export function getFormattedSizeParts(value: number, system: KbqUnitSystem): { value: string; unit: string };
+/**
+ * Converts a byte value into locale-independent file size parts: numeric value and unit abbreviation.
+ *
+ * @param value - size in bytes.
+ * @param  _deprecatedPrecision deprecated, use `Intl.NumberFormat` rounding options instead. This param will be remove in next major version.
+ * @param system - unit system defining abbreviations and base scaling (SI/IEC).
+ * @returns Object with the formatted size info.
+ *
+ * @example
+ * formatDataSize(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
+ */
+export function getFormattedSizeParts(
+    value: number,
+    _deprecatedPrecision: number,
+    system: KbqUnitSystem
+): { value: string; unit: string };
+export function getFormattedSizeParts(
+    value: number,
+    _deprecatedPrecisionOrUnitSystem: number | KbqUnitSystem,
+    system?: KbqUnitSystem
+): { value: string; unit: string } {
+    const resolvedSystem =
+        typeof _deprecatedPrecisionOrUnitSystem === 'number' ? system! : _deprecatedPrecisionOrUnitSystem;
+
+    const { result, unit } = getHumanizedBytes(value, resolvedSystem);
 
     return {
         value: result.toString(),
         unit
     };
-};
+}
 
 /**
  * Converts bytes to Kb, Mb, Gb

--- a/packages/components/core/formatters/filesize/size.ts
+++ b/packages/components/core/formatters/filesize/size.ts
@@ -26,7 +26,6 @@ export const formatDataSize = (
     };
 };
 
-// @TODO: remove deprecated (#DS-3849)
 /**
  * Converts a byte value into locale-independent file size parts: numeric value and unit abbreviation.
  *
@@ -35,19 +34,21 @@ export const formatDataSize = (
  * @returns Object with the formatted size info.
  *
  * @example
- * formatDataSize(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
+ * getFormattedSizeParts(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
  */
 export function getFormattedSizeParts(value: number, system: KbqUnitSystem): { value: string; unit: string };
 /**
  * Converts a byte value into locale-independent file size parts: numeric value and unit abbreviation.
  *
  * @param value - size in bytes.
- * @param  _precision deprecated, use `Intl.NumberFormat` rounding options instead. This param will be remove in next major version.
+ * @param _precision param is deprecated, use `Intl.NumberFormat` rounding options instead.
  * @param system - unit system defining abbreviations and base scaling (SI/IEC).
  * @returns Object with the formatted size info.
+ * @deprecated `_precision` - this param will be remove in next major version.
+ * @TODO remove deprecated (#DS-3849).
  *
  * @example
- * formatDataSize(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
+ * getFormattedSizeParts(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
  */
 export function getFormattedSizeParts(
     value: number,
@@ -59,7 +60,19 @@ export function getFormattedSizeParts(
     _precision: number | KbqUnitSystem,
     system?: KbqUnitSystem
 ): { value: string; unit: string } {
-    const resolvedSystem = typeof _precision === 'number' ? system! : _precision;
+    let resolvedSystem: KbqUnitSystem | null = null;
+
+    if (arguments.length === 2 && typeof _precision === 'object') {
+        resolvedSystem = _precision satisfies KbqUnitSystem;
+    }
+
+    if (arguments.length === 3 && typeof _precision === 'number' && system) {
+        resolvedSystem = system;
+    }
+
+    if (!resolvedSystem) {
+        throw new Error('Unexpected arguments size');
+    }
 
     const { result, unit } = getHumanizedBytes(value, resolvedSystem);
 

--- a/packages/components/core/formatters/filesize/size.ts
+++ b/packages/components/core/formatters/filesize/size.ts
@@ -30,23 +30,17 @@ export const formatDataSize = (
  * Converts a byte value into locale-independent file size parts: numeric value and unit abbreviation.
  *
  * @param value - size in bytes.
- * @param precision - digits after the decimal point (e.g., `2` → "1.02 KB").
  * @param system - unit system defining abbreviations and base scaling (SI/IEC).
  * @returns Object with the formatted size info.
  *
  * @example
  * formatDataSize(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
  */
-export const getFormattedSizeParts = (
-    value: number,
-    precision: number,
-    system: KbqUnitSystem
-): { value: string; unit: string } => {
+export const getFormattedSizeParts = (value: number, system: KbqUnitSystem): { value: string; unit: string } => {
     const { result, unit } = getHumanizedBytes(value, system);
 
     return {
-        // No precision for bytes (e.g., "512 B")
-        value: unit === system.abbreviations[0] ? result.toString() : result.toFixed(precision),
+        value: result.toString(),
         unit
     };
 };

--- a/packages/components/core/formatters/filesize/size.ts
+++ b/packages/components/core/formatters/filesize/size.ts
@@ -34,7 +34,7 @@ export const formatDataSize = (
  * @returns Object with the formatted size info.
  *
  * @example
- * getFormattedSizeParts(1500, 2, 'SI'); // { value: "1.50", unit: "KB" }
+ * getFormattedSizeParts(1500, 'SI'); // { value: "1.50", unit: "KB" }
  */
 export function getFormattedSizeParts(value: number, system: KbqUnitSystem): { value: string; unit: string };
 /**

--- a/packages/components/core/formatters/filesize/size.ts
+++ b/packages/components/core/formatters/filesize/size.ts
@@ -42,7 +42,7 @@ export function getFormattedSizeParts(value: number, system: KbqUnitSystem): { v
  * Converts a byte value into locale-independent file size parts: numeric value and unit abbreviation.
  *
  * @param value - size in bytes.
- * @param  _deprecatedPrecision deprecated, use `Intl.NumberFormat` rounding options instead. This param will be remove in next major version.
+ * @param  _precision deprecated, use `Intl.NumberFormat` rounding options instead. This param will be remove in next major version.
  * @param system - unit system defining abbreviations and base scaling (SI/IEC).
  * @returns Object with the formatted size info.
  *
@@ -51,16 +51,15 @@ export function getFormattedSizeParts(value: number, system: KbqUnitSystem): { v
  */
 export function getFormattedSizeParts(
     value: number,
-    _deprecatedPrecision: number,
+    _precision: number,
     system: KbqUnitSystem
 ): { value: string; unit: string };
 export function getFormattedSizeParts(
     value: number,
-    _deprecatedPrecisionOrUnitSystem: number | KbqUnitSystem,
+    _precision: number | KbqUnitSystem,
     system?: KbqUnitSystem
 ): { value: string; unit: string } {
-    const resolvedSystem =
-        typeof _deprecatedPrecisionOrUnitSystem === 'number' ? system! : _deprecatedPrecisionOrUnitSystem;
+    const resolvedSystem = typeof _precision === 'number' ? system! : _precision;
 
     const { result, unit } = getHumanizedBytes(value, resolvedSystem);
 

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -665,7 +665,13 @@ export const formatDataSize: (value: number, precision: number, system: KbqUnitS
 export function formatNumberWithLocale(value: unknown, formatter: Intl.NumberFormat, options?: KbqNumberFormatOptions): string;
 
 // @public
-export const getFormattedSizeParts: (value: number, system: KbqUnitSystem) => {
+export function getFormattedSizeParts(value: number, system: KbqUnitSystem): {
+    value: string;
+    unit: string;
+};
+
+// @public
+export function getFormattedSizeParts(value: number, _deprecatedPrecision: number, system: KbqUnitSystem): {
     value: string;
     unit: string;
 };

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -670,7 +670,7 @@ export function getFormattedSizeParts(value: number, system: KbqUnitSystem): {
     unit: string;
 };
 
-// @public
+// @public @deprecated
 export function getFormattedSizeParts(value: number, _precision: number, system: KbqUnitSystem): {
     value: string;
     unit: string;

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -671,7 +671,7 @@ export function getFormattedSizeParts(value: number, system: KbqUnitSystem): {
 };
 
 // @public
-export function getFormattedSizeParts(value: number, _deprecatedPrecision: number, system: KbqUnitSystem): {
+export function getFormattedSizeParts(value: number, _precision: number, system: KbqUnitSystem): {
     value: string;
     unit: string;
 };

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -665,7 +665,7 @@ export const formatDataSize: (value: number, precision: number, system: KbqUnitS
 export function formatNumberWithLocale(value: unknown, formatter: Intl.NumberFormat, options?: KbqNumberFormatOptions): string;
 
 // @public
-export const getFormattedSizeParts: (value: number, precision: number, system: KbqUnitSystem) => {
+export const getFormattedSizeParts: (value: number, system: KbqUnitSystem) => {
     value: string;
     unit: string;
 };


### PR DESCRIPTION
## Summary

Removed `precision` argument from `getFormattedSizeParts` function, put it in `Intl.NumberFormatter`, because it is more flexible - you can customise it and everything works out of the box

<details>
    <summary>ru-RU</summary>

    Убрал precision из функции, вынес в number formatter, потому что он гибче - можно настраивать и все работает из коробки
</details>
