### PR TITLE
feat(file-upload): added file size info in single (#DS-2362)

### DIFF
--- a/packages/components-dev/file-upload/module.ts
+++ b/packages/components-dev/file-upload/module.ts
@@ -27,12 +27,7 @@ import {
 } from '@angular/forms';
 import { KbqButtonModule } from '@koobiq/components/button';
 import { KbqCheckboxModule } from '@koobiq/components/checkbox';
-import {
-    FileValidators,
-    KbqDataSizePipe,
-    KbqLocaleServiceModule,
-    ShowOnFormSubmitErrorStateMatcher
-} from '@koobiq/components/core';
+import { FileValidators, KbqLocaleServiceModule, ShowOnFormSubmitErrorStateMatcher } from '@koobiq/components/core';
 import {
     KBQ_FILE_UPLOAD_CONFIGURATION,
     KBQ_MULTIPLE_FILE_UPLOAD_DEFAULT_CONFIGURATION,
@@ -129,7 +124,7 @@ export class DevCustomTextDirective {}
                         <i kbq-icon="kbq-info-circle_16"></i>
                     </kbq-file-upload>
                 </td>
-                <td>
+                <td colspan="2">
                     <kbq-file-upload class="dev-dragover">
                         <i kbq-icon="kbq-info-circle_16"></i>
                     </kbq-file-upload>
@@ -151,8 +146,30 @@ export class DevCustomTextDirective {}
                         <i kbq-icon="kbq-info-circle_16"></i>
                     </kbq-file-upload>
                 </td>
-                <td>
+                <td colspan="2">
                     <kbq-file-upload class="dev-dragover" [formControl]="file">
+                        <i kbq-icon="kbq-file-o_16"></i>
+                    </kbq-file-upload>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <kbq-file-upload [formControl]="file" [showFileSize]="false">
+                        <i kbq-icon="kbq-file-o_16"></i>
+                    </kbq-file-upload>
+                </td>
+                <td>
+                    <kbq-file-upload [formControl]="fileControlDisabled" [showFileSize]="false">
+                        <i kbq-icon="kbq-file-o_16"></i>
+                    </kbq-file-upload>
+                </td>
+                <td>
+                    <kbq-file-upload #withErrorState [formControl]="fileControlInvalid" [showFileSize]="false">
+                        <i kbq-icon="kbq-info-circle_16"></i>
+                    </kbq-file-upload>
+                </td>
+                <td colspan="2">
+                    <kbq-file-upload class="dev-dragover" [formControl]="file" [showFileSize]="false">
                         <i kbq-icon="kbq-file-o_16"></i>
                     </kbq-file-upload>
                 </td>
@@ -179,7 +196,7 @@ export class DevCustomTextDirective {}
                         </ng-template>
                     </kbq-multiple-file-upload>
                 </td>
-                <td>
+                <td colspan="2">
                     <kbq-multiple-file-upload class="dev-dragover">
                         <ng-template #kbqFileIcon>
                             <i kbq-icon="kbq-file-o_16"></i>
@@ -216,8 +233,6 @@ export class DevCustomTextDirective {}
                         </ng-template>
                     </kbq-multiple-file-upload>
                 </td>
-            </tr>
-            <tr>
                 <td>
                     <kbq-multiple-file-upload size="compact">
                         <ng-template #kbqFileIcon>
@@ -404,7 +419,6 @@ export class DevMultipleFileUploadCompact {
         KbqIconModule,
         KbqCheckboxModule,
         KbqRadioModule,
-        KbqDataSizePipe,
         DevMultipleFileUploadCompact,
         DevCustomTextDirective,
         DevFileUploadStateAndStyle

--- a/packages/components/file-upload/_file-upload-theme.scss
+++ b/packages/components/file-upload/_file-upload-theme.scss
@@ -16,6 +16,10 @@
             background-color: var(--kbq-file-upload-single-default-container-background);
             border-color: var(--kbq-file-upload-single-default-container-border) !important;
 
+            .kbq-file-item__size {
+                color: var(--kbq-file-upload-single-file-size-text-color);
+            }
+
             &:not(.kbq-disabled, .kbq-error) {
                 .kbq-file-upload__action {
                     color: var(--kbq-file-upload-single-default-icon-button-color);
@@ -36,6 +40,10 @@
             }
 
             &.kbq-error:not(.kbq-disabled) {
+                --kbq-file-upload-single-file-size-text-color: var(
+                    --kbq-file-upload-single-states-error-text-block-color
+                );
+
                 &:not(.dragover) {
                     background-color: var(--kbq-file-upload-single-states-error-container-background);
                     border-color: var(--kbq-file-upload-single-states-error-container-border) !important;
@@ -60,6 +68,10 @@
             }
 
             &.kbq-disabled {
+                --kbq-file-upload-single-file-size-text-color: var(
+                    --kbq-file-upload-single-states-disabled-text-block-color
+                );
+
                 background-color: var(--kbq-file-upload-single-states-disabled-container-background);
                 border-color: var(--kbq-file-upload-single-states-disabled-container-border) !important;
 

--- a/packages/components/file-upload/_file-upload-theme.scss
+++ b/packages/components/file-upload/_file-upload-theme.scss
@@ -16,10 +16,6 @@
             background-color: var(--kbq-file-upload-single-default-container-background);
             border-color: var(--kbq-file-upload-single-default-container-border) !important;
 
-            .kbq-file-item__size {
-                color: var(--kbq-file-upload-single-file-size-text-color);
-            }
-
             &:not(.kbq-disabled, .kbq-error) {
                 .kbq-file-upload__action {
                     color: var(--kbq-file-upload-single-default-icon-button-color);
@@ -32,6 +28,10 @@
                 .file-item__text-wrapper .kbq-icon.kbq-empty {
                     color: var(--kbq-file-upload-single-default-left-icon-color);
                 }
+
+                .kbq-file-item__size {
+                    color: var(--kbq-file-upload-single-default-file-size-text-color);
+                }
             }
 
             &.dragover {
@@ -40,10 +40,6 @@
             }
 
             &.kbq-error:not(.kbq-disabled) {
-                --kbq-file-upload-single-file-size-text-color: var(
-                    --kbq-file-upload-single-states-error-text-block-color
-                );
-
                 &:not(.dragover) {
                     background-color: var(--kbq-file-upload-single-states-error-container-background);
                     border-color: var(--kbq-file-upload-single-states-error-container-border) !important;
@@ -62,16 +58,16 @@
                     color: var(--kbq-file-upload-single-states-error-text-block-color);
                 }
 
+                .kbq-file-item__size {
+                    color: var(--kbq-file-upload-single-states-error-file-size-text-color);
+                }
+
                 .kbq-file-upload__action {
                     color: var(--kbq-file-upload-single-states-error-icon-button-color);
                 }
             }
 
             &.kbq-disabled {
-                --kbq-file-upload-single-file-size-text-color: var(
-                    --kbq-file-upload-single-states-disabled-text-block-color
-                );
-
                 background-color: var(--kbq-file-upload-single-states-disabled-container-background);
                 border-color: var(--kbq-file-upload-single-states-disabled-container-border) !important;
 
@@ -86,6 +82,10 @@
                 .dropzone__text,
                 .file-item__text {
                     color: var(--kbq-file-upload-single-states-disabled-text-block-color);
+                }
+
+                .kbq-file-item__size {
+                    color: var(--kbq-file-upload-single-states-disabled-file-size-text-color);
                 }
 
                 .kbq-file-upload__action {
@@ -203,6 +203,10 @@
             .multiple__uploaded-item {
                 .kbq-file-upload__file .kbq-icon.kbq-empty {
                     color: var(--kbq-file-upload-multiple-default-left-icon-color);
+                }
+
+                .kbq-file-upload__size {
+                    color: var(--kbq-file-upload-multiple-default-file-size-text-color);
                 }
 
                 .kbq-file-upload__action .kbq-icon.kbq-empty {

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -28,7 +28,7 @@
     --kbq-file-upload-single-default-left-icon-color: var(--kbq-icon-contrast-fade);
     --kbq-file-upload-single-default-text-block-color: var(--kbq-foreground-contrast);
     --kbq-file-upload-single-default-icon-button-color: var(--kbq-icon-contrast);
-    --kbq-file-upload-single-file-size-text-color: var(--kbq-foreground-contrast-secondary);
+    --kbq-file-upload-single-default-file-size-text-color: var(--kbq-foreground-contrast-secondary);
     --kbq-file-upload-single-states-on-drag-container-border: var(--kbq-line-theme-fade);
     --kbq-file-upload-single-states-on-drag-container-background: var(--kbq-background-theme-fade);
     --kbq-file-upload-single-states-on-drag-upload-icon-color: var(--kbq-icon-contrast-fade);
@@ -40,12 +40,14 @@
     --kbq-file-upload-single-states-error-left-icon-color: var(--kbq-icon-error);
     --kbq-file-upload-single-states-error-text-block-color: var(--kbq-foreground-error);
     --kbq-file-upload-single-states-error-icon-button-color: var(--kbq-icon-error);
+    --kbq-file-upload-single-states-error-file-size-text-color: var(--kbq-foreground-error);
     --kbq-file-upload-single-states-disabled-container-border: var(--kbq-states-line-disabled);
     --kbq-file-upload-single-states-disabled-container-background: var(--kbq-states-background-disabled);
     --kbq-file-upload-single-states-disabled-upload-icon-color: var(--kbq-states-icon-disabled);
     --kbq-file-upload-single-states-disabled-left-icon-color: var(--kbq-states-icon-disabled);
     --kbq-file-upload-single-states-disabled-icon-button-color: var(--kbq-states-icon-disabled);
     --kbq-file-upload-single-states-disabled-text-block-color: var(--kbq-states-foreground-disabled);
+    --kbq-file-upload-single-states-disabled-file-size-text-color: var(--kbq-states-foreground-disabled);
     --kbq-file-upload-single-states-focused-focus-outline-color: var(--kbq-states-line-focus-theme);
     --kbq-file-upload-multiple-default-container-border: var(--kbq-line-contrast-fade);
     --kbq-file-upload-multiple-default-container-background: var(--kbq-background-bg);
@@ -54,6 +56,7 @@
     --kbq-file-upload-multiple-default-text-block-color: var(--kbq-foreground-contrast);
     --kbq-file-upload-multiple-default-icon-button-color: var(--kbq-icon-contrast);
     --kbq-file-upload-multiple-default-grid-divider-color: var(--kbq-line-contrast-less);
+    --kbq-file-upload-multiple-default-file-size-text-color: var(--kbq-foreground-contrast-secondary);
     --kbq-file-upload-multiple-states-on-drag-container-border: var(--kbq-line-theme-fade);
     --kbq-file-upload-multiple-states-on-drag-container-background: var(--kbq-background-theme-fade);
     --kbq-file-upload-multiple-states-on-drag-upload-icon-color: var(--kbq-icon-contrast-fade);

--- a/packages/components/file-upload/file-upload-tokens.scss
+++ b/packages/components/file-upload/file-upload-tokens.scss
@@ -28,6 +28,7 @@
     --kbq-file-upload-single-default-left-icon-color: var(--kbq-icon-contrast-fade);
     --kbq-file-upload-single-default-text-block-color: var(--kbq-foreground-contrast);
     --kbq-file-upload-single-default-icon-button-color: var(--kbq-icon-contrast);
+    --kbq-file-upload-single-file-size-text-color: var(--kbq-foreground-contrast-secondary);
     --kbq-file-upload-single-states-on-drag-container-border: var(--kbq-line-theme-fade);
     --kbq-file-upload-single-states-on-drag-container-background: var(--kbq-background-theme-fade);
     --kbq-file-upload-single-states-on-drag-upload-icon-color: var(--kbq-icon-contrast-fade);

--- a/packages/components/file-upload/single-file-upload.component.html
+++ b/packages/components/file-upload/single-file-upload.component.html
@@ -25,6 +25,11 @@
                     }
                     <div class="file-item__text" [kbqEllipsisCenter]="file.file.name" [minVisibleLength]="10"></div>
                 </div>
+                @if (showFileSize) {
+                    <div class="kbq-file-item__size">
+                        {{ file.file.size | kbqDataSize }}
+                    </div>
+                }
                 <i
                     kbq-icon-button="kbq-xmark-circle_16"
                     class="kbq-file-upload__action"

--- a/packages/components/file-upload/single-file-upload.component.scss
+++ b/packages/components/file-upload/single-file-upload.component.scss
@@ -44,5 +44,13 @@
                 flex-grow: 1;
             }
         }
+
+        .kbq-file-item__size {
+            padding: 0 var(--kbq-size-s);
+        }
+
+        .kbq-file-upload__action {
+            padding: var(--kbq-size-xxs);
+        }
     }
 }

--- a/packages/components/file-upload/single-file-upload.component.ts
+++ b/packages/components/file-upload/single-file-upload.component.ts
@@ -1,5 +1,6 @@
 import {
     AfterViewInit,
+    booleanAttribute,
     ChangeDetectionStrategy,
     Component,
     ContentChildren,
@@ -81,6 +82,12 @@ export class KbqSingleFileUploadComponent
         this.cvaOnChange(this._file);
         this.cdr.markForCheck();
     }
+
+    /**
+     * Controls whether to display the file size information.
+     * @default true
+     */
+    @Input({ transform: booleanAttribute }) showFileSize: boolean = true;
 
     /** Emits an event containing updated file.
      * public output will be renamed to fileChange in next major release (#DS-3700) */

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -236,6 +236,8 @@ export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements A
     inputId: string;
     get invalid(): boolean;
     // (undocumented)
+    static ngAcceptInputType_showFileSize: unknown;
+    // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
     ngDoCheck(): void;
@@ -247,9 +249,10 @@ export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements A
     registerOnTouched(fn: any): void;
     separatedCaptionText: string[];
     setDisabledState(isDisabled: boolean): void;
+    showFileSize: boolean;
     writeValue(file: File | KbqFileItem | null): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSingleFileUploadComponent, "kbq-single-file-upload,kbq-file-upload:not([multiple])", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "file": { "alias": "file"; "required": false; }; }, { "fileChange": "fileQueueChange"; }, ["hint"], ["[kbq-icon]", "kbq-hint"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqSingleFileUploadComponent, "kbq-single-file-upload,kbq-file-upload:not([multiple])", never, { "progressMode": { "alias": "progressMode"; "required": false; }; "accept": { "alias": "accept"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "errors": { "alias": "errors"; "required": false; }; "inputId": { "alias": "inputId"; "required": false; }; "customValidation": { "alias": "customValidation"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "file": { "alias": "file"; "required": false; }; "showFileSize": { "alias": "showFileSize"; "required": false; }; }, { "fileChange": "fileQueueChange"; }, ["hint"], ["[kbq-icon]", "kbq-hint"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqSingleFileUploadComponent, never>;
 }


### PR DESCRIPTION
## Summary
- Added optional file size representation for single
- Added extra padding for x mark
- Updated dev example 
- Synced file size color text in multiple 
- Need to be merged after #825

<img width="1525" alt="image" src="https://github.com/user-attachments/assets/714a306b-195f-4dec-bba8-8d204a11dbd3" />