### PR TITLE
fix(top-bar): properly align end container (#DS-3886)

### DIFF
--- a/packages/components/overflow-items/overflow-items.ts
+++ b/packages/components/overflow-items/overflow-items.ts
@@ -82,7 +82,10 @@ export class KbqOverflowItemsResult extends ElementVisibilityManager {}
     standalone: true,
     selector: '[kbqOverflowItem]',
     exportAs: 'kbqOverflowItem',
-    host: { class: 'kbq-overflow-item' }
+    host: {
+        class: 'kbq-overflow-item',
+        '[class.kbq-overflow-item_always-visible]': 'alwaysVisible()'
+    }
 })
 export class KbqOverflowItem extends ElementVisibilityManager {
     /**

--- a/packages/components/top-bar/top-bar.scss
+++ b/packages/components/top-bar/top-bar.scss
@@ -1,5 +1,24 @@
 @use '../core/styles/common/tokens';
 
+@mixin _overflow-items-margins {
+    padding: var(--kbq-size-border-width);
+
+    > .kbq-overflow-item {
+        &:not(:last-of-type) {
+            margin-right: var(--kbq-top-bar-container-end-gap);
+        }
+
+        // apply margin if the last item needs to be alwaysVisible
+        &:last-of-type:is([aria-hidden='false']) + .kbq-overflow-items-result {
+            margin-left: var(--kbq-top-bar-container-end-gap);
+        }
+    }
+
+    .kbq-overflow-items-result:first-child {
+        margin-right: var(--kbq-top-bar-container-end-gap);
+    }
+}
+
 .kbq-top-bar {
     display: flex;
     align-items: center;
@@ -15,6 +34,17 @@
     .kbq-top-bar-spacer {
         height: 100%;
         flex: 0 0 var(--kbq-top-bar-spacer-min-width);
+    }
+
+    .kbq-top-bar-container {
+        &:has(> .kbq-overflow-items) {
+            gap: unset;
+            overflow: hidden;
+        }
+
+        .kbq-overflow-items {
+            @include _overflow-items-margins;
+        }
     }
 
     .kbq-top-bar-container__start {
@@ -34,22 +64,8 @@
     .kbq-top-bar-container__with-overflow-items {
         gap: unset;
         justify-content: unset;
-        padding: 1px;
 
-        > .kbq-overflow-item {
-            &:not(:last-of-type) {
-                margin-right: var(--kbq-top-bar-container-end-gap);
-            }
-
-            // apply margin if the last item needs to be alwaysVisible
-            &:last-of-type:is([aria-hidden='false']) + .kbq-overflow-items-result {
-                margin-left: var(--kbq-top-bar-container-end-gap);
-            }
-        }
-
-        .kbq-overflow-items-result:first-child {
-            margin-right: var(--kbq-top-bar-container-end-gap);
-        }
+        @include _overflow-items-margins;
     }
 
     &.kbq-top-bar_with-shadow {

--- a/packages/components/top-bar/top-bar.scss
+++ b/packages/components/top-bar/top-bar.scss
@@ -9,7 +9,7 @@
         }
 
         // apply margin if the last item needs to be alwaysVisible
-        &:last-of-type:is([aria-hidden='false']) + .kbq-overflow-items-result {
+        &:last-of-type:is(.kbq-overflow-item_always-visible) + .kbq-overflow-items-result {
             margin-left: var(--kbq-top-bar-container-end-gap);
         }
     }

--- a/packages/components/top-bar/top-bar.scss
+++ b/packages/components/top-bar/top-bar.scss
@@ -31,6 +31,11 @@
     padding: var(--kbq-top-bar-padding-vertical) var(--kbq-top-bar-padding-horizontal);
     border-radius: var(--kbq-top-bar-border-radius);
 
+    &.kbq-top-bar_with-shadow {
+        box-shadow: var(--kbq-top-bar-shadow-bottom);
+        transition: box-shadow var(--kbq-top-bar-shadow-transition);
+    }
+
     .kbq-top-bar-spacer {
         height: 100%;
         flex: 0 0 var(--kbq-top-bar-spacer-min-width);
@@ -45,32 +50,27 @@
         .kbq-overflow-items {
             @include _overflow-items-margins;
         }
-    }
 
-    .kbq-top-bar-container__start {
-        display: flex;
-        gap: var(--kbq-top-bar-container-start-gap);
-        flex: 1 0 var(--kbq-top-bar-container-start-basis);
-        justify-content: flex-start;
-        min-width: 0;
-    }
+        &.kbq-top-bar-container__start {
+            display: flex;
+            gap: var(--kbq-top-bar-container-start-gap);
+            flex: 1 0 var(--kbq-top-bar-container-start-basis);
+            justify-content: flex-start;
+            min-width: 0;
+        }
 
-    .kbq-top-bar-container__end {
-        display: flex;
-        gap: var(--kbq-top-bar-container-end-gap);
-        justify-content: end;
-    }
+        &.kbq-top-bar-container__end {
+            display: flex;
+            gap: var(--kbq-top-bar-container-end-gap);
+            justify-content: end;
+        }
 
-    .kbq-top-bar-container__with-overflow-items {
-        gap: unset;
-        justify-content: unset;
+        &.kbq-top-bar-container__with-overflow-items {
+            gap: unset;
+            justify-content: unset;
 
-        @include _overflow-items-margins;
-    }
-
-    &.kbq-top-bar_with-shadow {
-        box-shadow: var(--kbq-top-bar-shadow-bottom);
-        transition: box-shadow var(--kbq-top-bar-shadow-transition);
+            @include _overflow-items-margins;
+        }
     }
 
     @include tokens.kbq-typography-level-to-styles-css-variables(typography, text-normal);

--- a/packages/docs-examples/components/top-bar/top-bar-actions/top-bar-actions-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-actions/top-bar-actions-example.ts
@@ -46,47 +46,49 @@ type ExampleAction = {
 
             <div kbqTopBarSpacer></div>
 
-            <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems kbqTopBarContainer placement="end">
-                @for (action of actions; track action.id) {
-                    <button
-                        [kbqOverflowItem]="action.id"
-                        [alwaysVisible]="action?.alwaysVisible"
-                        [kbqStyle]="action.style"
-                        [color]="action.color"
-                        [kbqPlacement]="PopUpPlacements.Bottom"
-                        [kbqTooltipArrow]="false"
-                        [kbqTooltipDisabled]="canTooltipBeAppied(action)"
-                        [kbqTooltip]="action.text || action.id"
-                        kbq-button
-                    >
-                        @if (action.icon) {
-                            <i [class]="action.icon" kbq-icon=""></i>
-                        }
-                        @if (canTooltipBeAppied(action)) {
-                            {{ action.text }}
-                        }
-                    </button>
-                }
-
-                <div kbqOverflowItemsResult>
-                    <button
-                        [kbqStyle]="KbqButtonStyles.Transparent"
-                        [color]="KbqComponentColors.Contrast"
-                        [kbqDropdownTriggerFor]="appDropdown"
-                        kbq-button
-                    >
-                        <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
-                    </button>
-
-                    <kbq-dropdown #appDropdown="kbqDropdown">
-                        @for (action of actions; track action.id) {
-                            @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
-                                <button kbq-dropdown-item>
-                                    {{ action.text || action.id }}
-                                </button>
+            <div kbqTopBarContainer placement="end">
+                <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
+                    @for (action of actions; track action.id) {
+                        <button
+                            [kbqOverflowItem]="action.id"
+                            [alwaysVisible]="action?.alwaysVisible"
+                            [kbqStyle]="action.style"
+                            [color]="action.color"
+                            [kbqPlacement]="PopUpPlacements.Bottom"
+                            [kbqTooltipArrow]="false"
+                            [kbqTooltipDisabled]="canTooltipBeAppied(action)"
+                            [kbqTooltip]="action.text || action.id"
+                            kbq-button
+                        >
+                            @if (action.icon) {
+                                <i [class]="action.icon" kbq-icon=""></i>
                             }
-                        }
-                    </kbq-dropdown>
+                            @if (canTooltipBeAppied(action)) {
+                                {{ action.text }}
+                            }
+                        </button>
+                    }
+
+                    <div kbqOverflowItemsResult>
+                        <button
+                            [kbqStyle]="KbqButtonStyles.Transparent"
+                            [color]="KbqComponentColors.Contrast"
+                            [kbqDropdownTriggerFor]="appDropdown"
+                            kbq-button
+                        >
+                            <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        </button>
+
+                        <kbq-dropdown #appDropdown="kbqDropdown">
+                            @for (action of actions; track action.id) {
+                                @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
+                                    <button kbq-dropdown-item>
+                                        {{ action.text || action.id }}
+                                    </button>
+                                }
+                            }
+                        </kbq-dropdown>
+                    </div>
                 </div>
             </div>
         </kbq-top-bar>

--- a/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
@@ -91,54 +91,56 @@ const ExampleLocalizedData = new InjectionToken<Record<string | 'default', Examp
                 </nav>
             </div>
             <div kbqTopBarSpacer></div>
-            <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems kbqTopBarContainer placement="end">
-                <button
-                    [kbqStyle]="KbqButtonStyles.Transparent"
-                    [color]="KbqComponentColors.Contrast"
-                    [kbqPlacement]="PopUpPlacements.Bottom"
-                    [kbqTooltipArrow]="false"
-                    kbqOverflowItem="filter"
-                    kbqTooltip="Filter"
-                    kbq-button
-                >
-                    <i kbq-icon="kbq-filter_16"></i>
-                </button>
-
-                <button
-                    [kbqStyle]="KbqButtonStyles.Filled"
-                    [color]="KbqComponentColors.ContrastFade"
-                    [kbqTooltipDisabled]="isDesktop()"
-                    [kbqPlacement]="PopUpPlacements.Bottom"
-                    [kbqTooltipArrow]="false"
-                    kbqOverflowItem="share"
-                    kbqTooltip="Share"
-                    kbq-button
-                >
-                    @if (isDesktop()) {
-                        Share
-                    } @else {
-                        <i kbq-icon="kbq-arrow-up-from-rectangle_16"></i>
-                    }
-                </button>
-
-                <div kbqOverflowItemsResult>
+            <div kbqTopBarContainer placement="end">
+                <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     <button
                         [kbqStyle]="KbqButtonStyles.Transparent"
                         [color]="KbqComponentColors.Contrast"
-                        [kbqDropdownTriggerFor]="appDropdown"
+                        [kbqPlacement]="PopUpPlacements.Bottom"
+                        [kbqTooltipArrow]="false"
+                        kbqOverflowItem="filter"
+                        kbqTooltip="Filter"
                         kbq-button
                     >
-                        <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        <i kbq-icon="kbq-filter_16"></i>
                     </button>
 
-                    <kbq-dropdown #appDropdown="kbqDropdown">
-                        @if (kbqOverflowItems.hiddenItemIDs().has('filter')) {
-                            <button kbq-dropdown-item>Filter</button>
+                    <button
+                        [kbqStyle]="KbqButtonStyles.Filled"
+                        [color]="KbqComponentColors.ContrastFade"
+                        [kbqTooltipDisabled]="isDesktop()"
+                        [kbqPlacement]="PopUpPlacements.Bottom"
+                        [kbqTooltipArrow]="false"
+                        kbqOverflowItem="share"
+                        kbqTooltip="Share"
+                        kbq-button
+                    >
+                        @if (isDesktop()) {
+                            Share
+                        } @else {
+                            <i kbq-icon="kbq-arrow-up-from-rectangle_16"></i>
                         }
-                        @if (kbqOverflowItems.hiddenItemIDs().has('share')) {
-                            <button kbq-dropdown-item>Share</button>
-                        }
-                    </kbq-dropdown>
+                    </button>
+
+                    <div kbqOverflowItemsResult>
+                        <button
+                            [kbqStyle]="KbqButtonStyles.Transparent"
+                            [color]="KbqComponentColors.Contrast"
+                            [kbqDropdownTriggerFor]="appDropdown"
+                            kbq-button
+                        >
+                            <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        </button>
+
+                        <kbq-dropdown #appDropdown="kbqDropdown">
+                            @if (kbqOverflowItems.hiddenItemIDs().has('filter')) {
+                                <button kbq-dropdown-item>Filter</button>
+                            }
+                            @if (kbqOverflowItems.hiddenItemIDs().has('share')) {
+                                <button kbq-dropdown-item>Share</button>
+                            }
+                        </kbq-dropdown>
+                    </div>
                 </div>
             </div>
         </kbq-top-bar>
@@ -158,12 +160,8 @@ const ExampleLocalizedData = new InjectionToken<Record<string | 'default', Examp
             }
 
             .kbq-top-bar-container[placement='start'] {
-                min-width: 135px;
-                --kbq-top-bar-container-start-basis: 135px;
-            }
-
-            .kbq-top-bar-container[placement='end'] {
-                flex-grow: 0.3 !important;
+                min-width: 180px;
+                --kbq-top-bar-container-start-basis: 180px;
             }
         }
 
@@ -215,7 +213,7 @@ export class ExampleTopBarBreadcrumbs {
         <div class="layout-margin-top-3xl layout-margin-bottom-l">
             {{ text().rightSideCompression }}
         </div>
-        <example-top-bar-breadcrumbs [style.width.px]="300" />
+        <example-top-bar-breadcrumbs [style.width.px]="342" />
     `,
     styles: `
         div {

--- a/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { kbqBreadcrumbsConfigurationProvider, KbqBreadcrumbsModule } from '@koobiq/components/breadcrumbs';
@@ -10,6 +10,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqOverflowItemsModule } from '@koobiq/components/overflow-items';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 import { KbqTopBarModule } from '@koobiq/components/top-bar';
+import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 interface ExampleLocalizedText {
@@ -223,15 +224,13 @@ export class ExampleTopBarBreadcrumbs {
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TopBarBreadcrumbsAdaptiveExample implements OnInit {
-    protected readonly localeService = inject(KBQ_LOCALE_SERVICE, { optional: true });
+export class TopBarBreadcrumbsAdaptiveExample {
     protected readonly data = inject(ExampleLocalizedData);
+    protected readonly localeId = toSignal(inject(KBQ_LOCALE_SERVICE, { optional: true })?.changes || of(''));
 
-    protected readonly text = signal(this.data.default);
+    protected readonly text = computed(() => {
+        const localeId = this.localeId();
 
-    ngOnInit() {
-        if (this.localeService) {
-            this.localeService.changes.subscribe((id: string) => this.text.set(this.data[id] || this.data.default));
-        }
-    }
+        return (localeId && this.data[localeId]) || this.data.default;
+    });
 }

--- a/packages/docs-examples/components/top-bar/top-bar-breadcrumbs/top-bar-breadcrumbs-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-breadcrumbs/top-bar-breadcrumbs-example.ts
@@ -42,54 +42,56 @@ import { map } from 'rxjs/operators';
                 </nav>
             </div>
             <div kbqTopBarSpacer></div>
-            <div #kbqOverflowItems="kbqOverflowItems" kbqTopBarContainer kbqOverflowItems placement="end">
-                <button
-                    [kbqStyle]="KbqButtonStyles.Transparent"
-                    [color]="KbqComponentColors.Contrast"
-                    [kbqPlacement]="PopUpPlacements.Bottom"
-                    [kbqTooltipArrow]="false"
-                    kbqOverflowItem="0"
-                    kbqTooltip="Filter"
-                    kbq-button
-                >
-                    <i kbq-icon="kbq-filter_16"></i>
-                </button>
-
-                <button
-                    [kbqStyle]="KbqButtonStyles.Filled"
-                    [color]="KbqComponentColors.ContrastFade"
-                    [kbqTooltipDisabled]="isDesktop()"
-                    [kbqPlacement]="PopUpPlacements.Bottom"
-                    [kbqTooltipArrow]="false"
-                    kbqOverflowItem="1"
-                    kbqTooltip="Share"
-                    kbq-button
-                >
-                    @if (isDesktop()) {
-                        Share
-                    } @else {
-                        <i kbq-icon="kbq-arrow-up-from-rectangle_16"></i>
-                    }
-                </button>
-
-                <div kbqOverflowItemsResult>
+            <div kbqTopBarContainer placement="end">
+                <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     <button
                         [kbqStyle]="KbqButtonStyles.Transparent"
                         [color]="KbqComponentColors.Contrast"
-                        [kbqDropdownTriggerFor]="appDropdown"
+                        [kbqPlacement]="PopUpPlacements.Bottom"
+                        [kbqTooltipArrow]="false"
+                        kbqOverflowItem="0"
+                        kbqTooltip="Filter"
                         kbq-button
                     >
-                        <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        <i kbq-icon="kbq-filter_16"></i>
                     </button>
 
-                    <kbq-dropdown #appDropdown="kbqDropdown">
-                        @if (kbqOverflowItems.hiddenItemIDs().has('0')) {
-                            <button kbq-dropdown-item>Filter</button>
+                    <button
+                        [kbqStyle]="KbqButtonStyles.Filled"
+                        [color]="KbqComponentColors.ContrastFade"
+                        [kbqTooltipDisabled]="isDesktop()"
+                        [kbqPlacement]="PopUpPlacements.Bottom"
+                        [kbqTooltipArrow]="false"
+                        kbqOverflowItem="1"
+                        kbqTooltip="Share"
+                        kbq-button
+                    >
+                        @if (isDesktop()) {
+                            Share
+                        } @else {
+                            <i kbq-icon="kbq-arrow-up-from-rectangle_16"></i>
                         }
-                        @if (kbqOverflowItems.hiddenItemIDs().has('1')) {
-                            <button kbq-dropdown-item>Share</button>
-                        }
-                    </kbq-dropdown>
+                    </button>
+
+                    <div kbqOverflowItemsResult>
+                        <button
+                            [kbqStyle]="KbqButtonStyles.Transparent"
+                            [color]="KbqComponentColors.Contrast"
+                            [kbqDropdownTriggerFor]="appDropdown"
+                            kbq-button
+                        >
+                            <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        </button>
+
+                        <kbq-dropdown #appDropdown="kbqDropdown">
+                            @if (kbqOverflowItems.hiddenItemIDs().has('0')) {
+                                <button kbq-dropdown-item>Filter</button>
+                            }
+                            @if (kbqOverflowItems.hiddenItemIDs().has('1')) {
+                                <button kbq-dropdown-item>Share</button>
+                            }
+                        </kbq-dropdown>
+                    </div>
                 </div>
             </div>
         </kbq-top-bar>
@@ -98,10 +100,6 @@ import { map } from 'rxjs/operators';
         :host {
             .kbq-top-bar-container[placement='start'] {
                 min-width: 238px;
-            }
-
-            .kbq-top-bar-container[placement='end'] {
-                flex-grow: 0.3 !important;
             }
         }
     `

--- a/packages/docs-examples/components/top-bar/top-bar-overflow/top-bar-overflow-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-overflow/top-bar-overflow-example.ts
@@ -60,47 +60,49 @@ type ExampleAction = {
                 </div>
             </div>
             <div kbqTopBarSpacer></div>
-            <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems kbqTopBarContainer placement="end">
-                @for (action of actions; track action.id) {
-                    <button
-                        [kbqOverflowItem]="action.id"
-                        [kbqStyle]="action.style"
-                        [color]="action.color"
-                        [kbqPlacement]="PopUpPlacements.Bottom"
-                        [kbqTooltipArrow]="false"
-                        [kbqTooltipDisabled]="canTooltipBeAppied(action)"
-                        [kbqTooltip]="action.text || action.id"
-                        [alwaysVisible]="action?.alwaysVisible"
-                        kbq-button
-                    >
-                        @if (action.icon) {
-                            <i [class]="action.icon" kbq-icon=""></i>
-                        }
-                        @if (canTooltipBeAppied(action)) {
-                            {{ action.text }}
-                        }
-                    </button>
-                }
-
-                <div kbqOverflowItemsResult>
-                    <button
-                        [kbqStyle]="KbqButtonStyles.Transparent"
-                        [color]="KbqComponentColors.Contrast"
-                        [kbqDropdownTriggerFor]="appDropdown"
-                        kbq-button
-                    >
-                        <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
-                    </button>
-
-                    <kbq-dropdown #appDropdown="kbqDropdown">
-                        @for (action of actions; track action.id) {
-                            @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
-                                <button kbq-dropdown-item>
-                                    {{ action.text || action.id }}
-                                </button>
+            <div kbqTopBarContainer placement="end">
+                <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
+                    @for (action of actions; track action.id) {
+                        <button
+                            [kbqOverflowItem]="action.id"
+                            [kbqStyle]="action.style"
+                            [color]="action.color"
+                            [kbqPlacement]="PopUpPlacements.Bottom"
+                            [kbqTooltipArrow]="false"
+                            [kbqTooltipDisabled]="canTooltipBeAppied(action)"
+                            [kbqTooltip]="action.text || action.id"
+                            [alwaysVisible]="action?.alwaysVisible"
+                            kbq-button
+                        >
+                            @if (action.icon) {
+                                <i [class]="action.icon" kbq-icon=""></i>
                             }
-                        }
-                    </kbq-dropdown>
+                            @if (canTooltipBeAppied(action)) {
+                                {{ action.text }}
+                            }
+                        </button>
+                    }
+
+                    <div kbqOverflowItemsResult>
+                        <button
+                            [kbqStyle]="KbqButtonStyles.Transparent"
+                            [color]="KbqComponentColors.Contrast"
+                            [kbqDropdownTriggerFor]="appDropdown"
+                            kbq-button
+                        >
+                            <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        </button>
+
+                        <kbq-dropdown #appDropdown="kbqDropdown">
+                            @for (action of actions; track action.id) {
+                                @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
+                                    <button kbq-dropdown-item>
+                                        {{ action.text || action.id }}
+                                    </button>
+                                }
+                            }
+                        </kbq-dropdown>
+                    </div>
                 </div>
             </div>
         </kbq-top-bar>
@@ -152,10 +154,6 @@ type ExampleAction = {
 
             .kbq-top-bar {
                 border-radius: var(--kbq-size-border-radius) var(--kbq-size-border-radius) 0 0;
-            }
-
-            .kbq-overflow-items {
-                max-width: 291px;
             }
         }
 

--- a/packages/docs-examples/components/top-bar/top-bar-overview/top-bar-overview-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-overview/top-bar-overview-example.ts
@@ -48,46 +48,48 @@ type ExampleAction = {
 
             <div kbqTopBarSpacer></div>
 
-            <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems kbqTopBarContainer placement="end">
-                @for (action of actions; track action.id) {
-                    <button
-                        [kbqOverflowItem]="action.id"
-                        [kbqStyle]="action.style"
-                        [color]="action.color"
-                        [kbqPlacement]="PopUpPlacements.Bottom"
-                        [kbqTooltipArrow]="false"
-                        [kbqTooltipDisabled]="isDesktop()"
-                        [kbqTooltip]="action.text || action.id"
-                        kbq-button
-                    >
-                        @if (action.icon) {
-                            <i [class]="action.icon" kbq-icon=""></i>
-                        }
-                        @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
-                            {{ action.text }}
-                        }
-                    </button>
-                }
-
-                <div kbqOverflowItemsResult>
-                    <button
-                        [kbqStyle]="KbqButtonStyles.Transparent"
-                        [color]="KbqComponentColors.Contrast"
-                        [kbqDropdownTriggerFor]="appDropdown"
-                        kbq-button
-                    >
-                        <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
-                    </button>
-
-                    <kbq-dropdown #appDropdown="kbqDropdown">
-                        @for (action of actions; track action.id) {
-                            @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
-                                <button kbq-dropdown-item>
-                                    {{ action.text || action.id }}
-                                </button>
+            <div kbqTopBarContainer placement="end">
+                <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
+                    @for (action of actions; track action.id) {
+                        <button
+                            [kbqOverflowItem]="action.id"
+                            [kbqStyle]="action.style"
+                            [color]="action.color"
+                            [kbqPlacement]="PopUpPlacements.Bottom"
+                            [kbqTooltipArrow]="false"
+                            [kbqTooltipDisabled]="isDesktop()"
+                            [kbqTooltip]="action.text || action.id"
+                            kbq-button
+                        >
+                            @if (action.icon) {
+                                <i [class]="action.icon" kbq-icon=""></i>
                             }
-                        }
-                    </kbq-dropdown>
+                            @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
+                                {{ action.text }}
+                            }
+                        </button>
+                    }
+
+                    <div kbqOverflowItemsResult>
+                        <button
+                            [kbqStyle]="KbqButtonStyles.Transparent"
+                            [color]="KbqComponentColors.Contrast"
+                            [kbqDropdownTriggerFor]="appDropdown"
+                            kbq-button
+                        >
+                            <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        </button>
+
+                        <kbq-dropdown #appDropdown="kbqDropdown">
+                            @for (action of actions; track action.id) {
+                                @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
+                                    <button kbq-dropdown-item>
+                                        {{ action.text || action.id }}
+                                    </button>
+                                }
+                            }
+                        </kbq-dropdown>
+                    </div>
                 </div>
             </div>
         </kbq-top-bar>
@@ -96,10 +98,6 @@ type ExampleAction = {
         :host {
             .kbq-top-bar-container__start {
                 --kbq-top-bar-container-start-basis: 115px;
-            }
-
-            .kbq-top-bar-container__end {
-                max-width: 330px;
             }
         }
     `,

--- a/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
@@ -78,46 +78,48 @@ type ExampleAction = {
 
             <div kbqTopBarSpacer></div>
 
-            <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems kbqTopBarContainer placement="end">
-                @for (action of actions; track action.id) {
-                    <button
-                        [kbqOverflowItem]="action.id"
-                        [kbqStyle]="action.style"
-                        [color]="action.color"
-                        [kbqPlacement]="PopUpPlacements.Bottom"
-                        [kbqTooltipArrow]="false"
-                        [kbqTooltipDisabled]="isDesktop()"
-                        [kbqTooltip]="action.text || action.id"
-                        kbq-button
-                    >
-                        @if (action.icon) {
-                            <i [class]="action.icon" kbq-icon=""></i>
-                        }
-                        @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
-                            {{ action.text }}
-                        }
-                    </button>
-                }
-
-                <div kbqOverflowItemsResult>
-                    <button
-                        [kbqStyle]="KbqButtonStyles.Transparent"
-                        [color]="KbqComponentColors.Contrast"
-                        [kbqDropdownTriggerFor]="appDropdown"
-                        kbq-button
-                    >
-                        <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
-                    </button>
-
-                    <kbq-dropdown #appDropdown="kbqDropdown">
-                        @for (action of actions; track action.id) {
-                            @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
-                                <button kbq-dropdown-item>
-                                    {{ action.text || action.id }}
-                                </button>
+            <div kbqTopBarContainer placement="end">
+                <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
+                    @for (action of actions; track action.id) {
+                        <button
+                            [kbqOverflowItem]="action.id"
+                            [kbqStyle]="action.style"
+                            [color]="action.color"
+                            [kbqPlacement]="PopUpPlacements.Bottom"
+                            [kbqTooltipArrow]="false"
+                            [kbqTooltipDisabled]="isDesktop()"
+                            [kbqTooltip]="action.text || action.id"
+                            kbq-button
+                        >
+                            @if (action.icon) {
+                                <i [class]="action.icon" kbq-icon=""></i>
                             }
-                        }
-                    </kbq-dropdown>
+                            @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
+                                {{ action.text }}
+                            }
+                        </button>
+                    }
+
+                    <div kbqOverflowItemsResult>
+                        <button
+                            [kbqStyle]="KbqButtonStyles.Transparent"
+                            [color]="KbqComponentColors.Contrast"
+                            [kbqDropdownTriggerFor]="appDropdown"
+                            kbq-button
+                        >
+                            <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        </button>
+
+                        <kbq-dropdown #appDropdown="kbqDropdown">
+                            @for (action of actions; track action.id) {
+                                @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
+                                    <button kbq-dropdown-item>
+                                        {{ action.text || action.id }}
+                                    </button>
+                                }
+                            }
+                        </kbq-dropdown>
+                    </div>
                 </div>
             </div>
         </kbq-top-bar>
@@ -131,18 +133,6 @@ type ExampleAction = {
             max-width: 100%;
             min-width: 110px;
             container-type: inline-size;
-
-            @container (width < 590px) {
-                .kbq-overflow-items {
-                    max-width: 96px;
-                }
-            }
-
-            @container (width > 590px) {
-                .kbq-overflow-items {
-                    max-width: 190px;
-                }
-            }
 
             .kbq-top-bar {
                 width: 100%;

--- a/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { KbqButtonModule, KbqButtonStyles } from '@koobiq/components/button';
 import { KBQ_LOCALE_SERVICE, KbqComponentColors, KbqFormattersModule, PopUpPlacements } from '@koobiq/components/core';
@@ -8,6 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqOverflowItemsModule } from '@koobiq/components/overflow-items';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 import { KbqTopBarModule } from '@koobiq/components/top-bar';
+import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 interface ExampleLocalizedText {
@@ -209,15 +210,13 @@ export class ExampleTopBar {
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TopBarTitleCounterAdaptiveExample implements OnInit {
-    protected readonly localeService = inject(KBQ_LOCALE_SERVICE, { optional: true });
+export class TopBarTitleCounterAdaptiveExample {
     protected readonly data = inject(ExampleLocalizedData);
+    protected readonly localeId = toSignal(inject(KBQ_LOCALE_SERVICE, { optional: true })?.changes || of(''));
 
-    protected readonly text = signal(this.data.default);
+    protected readonly text = computed(() => {
+        const localeId = this.localeId();
 
-    ngOnInit() {
-        if (this.localeService) {
-            this.localeService.changes.subscribe((id: string) => this.text.set(this.data[id] || this.data.default));
-        }
-    }
+        return (localeId && this.data[localeId]) || this.data.default;
+    });
 }

--- a/packages/docs-examples/components/top-bar/top-bar-title-counter/top-bar-title-counter-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-title-counter/top-bar-title-counter-example.ts
@@ -54,47 +54,49 @@ type ExampleAction = {
 
             <div kbqTopBarSpacer></div>
 
-            <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems kbqTopBarContainer placement="end">
-                @for (action of actions; track action.id) {
-                    <button
-                        [kbqOverflowItem]="action.id"
-                        [kbqStyle]="action.style"
-                        [color]="action.color"
-                        [kbqPlacement]="PopUpPlacements.Bottom"
-                        [kbqTooltipArrow]="false"
-                        [kbqTooltipDisabled]="isDesktop()"
-                        [kbqTooltip]="action.text || action.id.toString()"
-                        [alwaysVisible]="action?.alwaysVisible"
-                        kbq-button
-                    >
-                        @if (action.icon) {
-                            <i [class]="action.icon" kbq-icon=""></i>
-                        }
-                        @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
-                            {{ action.text }}
-                        }
-                    </button>
-                }
-
-                <div kbqOverflowItemsResult>
-                    <button
-                        [kbqStyle]="KbqButtonStyles.Transparent"
-                        [color]="KbqComponentColors.Contrast"
-                        [kbqDropdownTriggerFor]="appDropdown"
-                        kbq-button
-                    >
-                        <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
-                    </button>
-
-                    <kbq-dropdown #appDropdown="kbqDropdown">
-                        @for (action of actions; track action.id) {
-                            @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
-                                <button kbq-dropdown-item>
-                                    {{ action.text || action.id }}
-                                </button>
+            <div kbqTopBarContainer placement="end">
+                <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
+                    @for (action of actions; track action.id) {
+                        <button
+                            [kbqOverflowItem]="action.id"
+                            [kbqStyle]="action.style"
+                            [color]="action.color"
+                            [kbqPlacement]="PopUpPlacements.Bottom"
+                            [kbqTooltipArrow]="false"
+                            [kbqTooltipDisabled]="isDesktop()"
+                            [kbqTooltip]="action.text || action.id.toString()"
+                            [alwaysVisible]="action?.alwaysVisible"
+                            kbq-button
+                        >
+                            @if (action.icon) {
+                                <i [class]="action.icon" kbq-icon=""></i>
                             }
-                        }
-                    </kbq-dropdown>
+                            @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
+                                {{ action.text }}
+                            }
+                        </button>
+                    }
+
+                    <div kbqOverflowItemsResult>
+                        <button
+                            [kbqStyle]="KbqButtonStyles.Transparent"
+                            [color]="KbqComponentColors.Contrast"
+                            [kbqDropdownTriggerFor]="appDropdown"
+                            kbq-button
+                        >
+                            <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
+                        </button>
+
+                        <kbq-dropdown #appDropdown="kbqDropdown">
+                            @for (action of actions; track action.id) {
+                                @if (kbqOverflowItems.hiddenItemIDs().has(action.id)) {
+                                    <button kbq-dropdown-item>
+                                        {{ action.text || action.id }}
+                                    </button>
+                                }
+                            }
+                        </kbq-dropdown>
+                    </div>
                 </div>
             </div>
         </kbq-top-bar>

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -3631,6 +3631,18 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "primaryFile": "timezone-trigger-overview-example.ts",
     "importPath": "components/timezone"
   },
+  "title-overview": {
+    "packagePath": "components/title/title-overview",
+    "title": "Title",
+    "componentName": "TitleOverviewExample",
+    "files": [
+      "title-overview-example.ts"
+    ],
+    "selector": "title-overview-example",
+    "additionalComponents": [],
+    "primaryFile": "title-overview-example.ts",
+    "importPath": "components/title"
+  },
   "toast-actions-overview": {
     "packagePath": "components/toast/toast-actions-overview",
     "title": "Toast actions",
@@ -4964,6 +4976,8 @@ return import('@koobiq/docs-examples/components/timezone');
 return import('@koobiq/docs-examples/components/timezone');
   case 'timezone-trigger-overview':
 return import('@koobiq/docs-examples/components/timezone');
+  case 'title-overview':
+return import('@koobiq/docs-examples/components/title');
   case 'toast-actions-overview':
 return import('@koobiq/docs-examples/components/toast');
   case 'toast-hide-overview':


### PR DESCRIPTION
## Summary

put `overflow-items` inside `top-bar-container` instead of merging them. It will resolve the hiding logic work along with `justify-contend: end`.

```html
<div kbqOverflowItems KbqTopBarContainer placement="end"></div>
```
to
```html
<div KbqTopBarContainer placement="end">
       <div kbqOverflowItems></div>
</div>
```