### PR TITLE
chore(top-bar): styles order & examples refactoring (#DS-3886)

### DIFF
--- a/packages/components/top-bar/top-bar.scss
+++ b/packages/components/top-bar/top-bar.scss
@@ -31,6 +31,11 @@
     padding: var(--kbq-top-bar-padding-vertical) var(--kbq-top-bar-padding-horizontal);
     border-radius: var(--kbq-top-bar-border-radius);
 
+    &.kbq-top-bar_with-shadow {
+        box-shadow: var(--kbq-top-bar-shadow-bottom);
+        transition: box-shadow var(--kbq-top-bar-shadow-transition);
+    }
+
     .kbq-top-bar-spacer {
         height: 100%;
         flex: 0 0 var(--kbq-top-bar-spacer-min-width);
@@ -45,32 +50,27 @@
         .kbq-overflow-items {
             @include _overflow-items-margins;
         }
-    }
 
-    .kbq-top-bar-container__start {
-        display: flex;
-        gap: var(--kbq-top-bar-container-start-gap);
-        flex: 1 0 var(--kbq-top-bar-container-start-basis);
-        justify-content: flex-start;
-        min-width: 0;
-    }
+        &.kbq-top-bar-container__start {
+            display: flex;
+            gap: var(--kbq-top-bar-container-start-gap);
+            flex: 1 0 var(--kbq-top-bar-container-start-basis);
+            justify-content: flex-start;
+            min-width: 0;
+        }
 
-    .kbq-top-bar-container__end {
-        display: flex;
-        gap: var(--kbq-top-bar-container-end-gap);
-        justify-content: end;
-    }
+        &.kbq-top-bar-container__end {
+            display: flex;
+            gap: var(--kbq-top-bar-container-end-gap);
+            justify-content: end;
+        }
 
-    .kbq-top-bar-container__with-overflow-items {
-        gap: unset;
-        justify-content: unset;
+        &.kbq-top-bar-container__with-overflow-items {
+            gap: unset;
+            justify-content: unset;
 
-        @include _overflow-items-margins;
-    }
-
-    &.kbq-top-bar_with-shadow {
-        box-shadow: var(--kbq-top-bar-shadow-bottom);
-        transition: box-shadow var(--kbq-top-bar-shadow-transition);
+            @include _overflow-items-margins;
+        }
     }
 
     @include tokens.kbq-typography-level-to-styles-css-variables(typography, text-normal);

--- a/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { kbqBreadcrumbsConfigurationProvider, KbqBreadcrumbsModule } from '@koobiq/components/breadcrumbs';
@@ -10,6 +10,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqOverflowItemsModule } from '@koobiq/components/overflow-items';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 import { KbqTopBarModule } from '@koobiq/components/top-bar';
+import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 interface ExampleLocalizedText {
@@ -223,15 +224,13 @@ export class ExampleTopBarBreadcrumbs {
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TopBarBreadcrumbsAdaptiveExample implements OnInit {
-    protected readonly localeService = inject(KBQ_LOCALE_SERVICE, { optional: true });
+export class TopBarBreadcrumbsAdaptiveExample {
     protected readonly data = inject(ExampleLocalizedData);
+    protected readonly localeId = toSignal(inject(KBQ_LOCALE_SERVICE, { optional: true })?.changes || of(''));
 
-    protected readonly text = signal(this.data.default);
+    protected readonly text = computed(() => {
+        const localeId = this.localeId();
 
-    ngOnInit() {
-        if (this.localeService) {
-            this.localeService.changes.subscribe((id: string) => this.text.set(this.data[id] || this.data.default));
-        }
-    }
+        return (localeId && this.data[localeId]) || this.data.default;
+    });
 }

--- a/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { KbqButtonModule, KbqButtonStyles } from '@koobiq/components/button';
 import { KBQ_LOCALE_SERVICE, KbqComponentColors, KbqFormattersModule, PopUpPlacements } from '@koobiq/components/core';
@@ -8,6 +8,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqOverflowItemsModule } from '@koobiq/components/overflow-items';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 import { KbqTopBarModule } from '@koobiq/components/top-bar';
+import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 interface ExampleLocalizedText {
@@ -209,15 +210,13 @@ export class ExampleTopBar {
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TopBarTitleCounterAdaptiveExample implements OnInit {
-    protected readonly localeService = inject(KBQ_LOCALE_SERVICE, { optional: true });
+export class TopBarTitleCounterAdaptiveExample {
     protected readonly data = inject(ExampleLocalizedData);
+    protected readonly localeId = toSignal(inject(KBQ_LOCALE_SERVICE, { optional: true })?.changes || of(''));
 
-    protected readonly text = signal(this.data.default);
+    protected readonly text = computed(() => {
+        const localeId = this.localeId();
 
-    ngOnInit() {
-        if (this.localeService) {
-            this.localeService.changes.subscribe((id: string) => this.text.set(this.data[id] || this.data.default));
-        }
-    }
+        return (localeId && this.data[localeId]) || this.data.default;
+    });
 }

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -3631,6 +3631,18 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "primaryFile": "timezone-trigger-overview-example.ts",
     "importPath": "components/timezone"
   },
+  "title-overview": {
+    "packagePath": "components/title/title-overview",
+    "title": "Title",
+    "componentName": "TitleOverviewExample",
+    "files": [
+      "title-overview-example.ts"
+    ],
+    "selector": "title-overview-example",
+    "additionalComponents": [],
+    "primaryFile": "title-overview-example.ts",
+    "importPath": "components/title"
+  },
   "toast-actions-overview": {
     "packagePath": "components/toast/toast-actions-overview",
     "title": "Toast actions",
@@ -4964,6 +4976,8 @@ return import('@koobiq/docs-examples/components/timezone');
 return import('@koobiq/docs-examples/components/timezone');
   case 'timezone-trigger-overview':
 return import('@koobiq/docs-examples/components/timezone');
+  case 'title-overview':
+return import('@koobiq/docs-examples/components/title');
   case 'toast-actions-overview':
 return import('@koobiq/docs-examples/components/toast');
   case 'toast-hide-overview':


### PR DESCRIPTION
## Summary

1. Reordered styles of top-bar in the next order:

- `container`
   - `&.modifiers`
   - `elements`
      - `&.element-modifiers` 

2. small refactor of examples to use signal approach