### PR TITLE
fix(input): adjust password focus for validation (#DS-3965)

### DIFF
--- a/packages/components/input/input-password.ts
+++ b/packages/components/input/input-password.ts
@@ -236,14 +236,14 @@ export class KbqInputPassword
     }
 
     onBlur(): void {
+        this.focusChanged(false);
+
         if (this.ngControl?.control) {
             const control = this.ngControl.control;
 
             control.updateValueAndValidity({ emitEvent: false });
             (control.statusChanges as EventEmitter<string>).emit(control.status);
         }
-
-        this.focusChanged(false);
     }
 
     /** Callback for the cases where the focused state of the input changes. */


### PR DESCRIPTION
## Summary

Synced `onBlur` for `KbqInputPassword` and `KbqInput`.

Improper focused state affected validation directive condition:

```
if (this.validationControl.invalid && this.formFieldControl.focused) {
```