### PR TITLE
fix(breadcrumbs): resolve hydration duplication (#DS-3679)

### DIFF
--- a/packages/components/breadcrumbs/breadcrumbs.html
+++ b/packages/components/breadcrumbs/breadcrumbs.html
@@ -1,3 +1,8 @@
+<!--
+@TODO: check when updated to Angular 20.x (#DS-4034)
+resolved SSR issue with official hack https://github.com/angular/angular/issues/50543#issuecomment-1572900259
+-->
+<ng-content />
 @if (items.length < minVisibleItems || wrapMode !== 'auto') {
     @for (item of items; track item; let last = $last) {
         <div class="kbq-breadcrumb-item__container">
@@ -16,8 +21,6 @@
         [style.max-width.px]="maxWidth"
     >
         <div class="kbq-breadcrumb-item__container" [kbqOverflowItem]="0" [order]="items.length">
-            <!--  resolved SSR issue with official hack https://github.com/angular/angular/issues/50543#issuecomment-1572900259-->
-            <ng-content />
             <ng-container *ngTemplateOutlet="breadcrumbTemplate; context: { $implicit: items.first, last: false }" />
             <ng-container [ngTemplateOutlet]="separatorTemplate" />
         </div>


### PR DESCRIPTION
## Summary

Moved suggested angular team's solution to the begging of `KbqBreadcrumbs` template to support all branches of `@if @else` conditions.