### PR TITLE
style: enabled @angular-eslint/template/attributes-order rule (#DS-2920)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -238,7 +238,6 @@ const templateRules = {
         '@angular-eslint/template/no-inline-styles': 0,
         '@angular-eslint/template/button-has-type': 0,
         '@angular-eslint/template/no-interpolation-in-attributes': 0,
-        '@angular-eslint/template/attributes-order': 0,
         '@angular-eslint/template/no-any': 0
     }
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,23 +1,5 @@
 // @ts-check
 
-/** @type {import('prettier-plugin-organize-attributes').PrettierPluginOrganizeAttributesParserOptions} */
-const organizeAttributesPluginAngularConfig = {
-    attributeGroups: [
-        '$ANGULAR_STRUCTURAL_DIRECTIVE',
-        '$ANGULAR_ELEMENT_REF',
-        '$ID',
-        '$DEFAULT',
-        '$CLASS',
-        '$ANGULAR_INPUT',
-        '$ANGULAR_TWO_WAY_BINDING',
-        '$ANGULAR_OUTPUT',
-        '$ANGULAR_ANIMATION',
-        '$ANGULAR_ANIMATION_INPUT'
-    ],
-    attributeSort: 'ASC',
-    attributeIgnoreCase: true
-};
-
 /** @type {import('prettier').Options} */
 const config = {
     printWidth: 120,
@@ -27,7 +9,6 @@ const config = {
     trailingComma: 'none',
     htmlWhitespaceSensitivity: 'ignore',
     plugins: [
-        'prettier-plugin-organize-attributes',
         'prettier-plugin-organize-imports',
         // should be last
         'prettier-plugin-multiline-arrays'
@@ -48,15 +29,9 @@ const config = {
         },
         {
             files: ['*.html'],
+            excludeFiles: ['index.html'],
             options: {
-                parser: 'angular',
-                ...organizeAttributesPluginAngularConfig
-            }
-        },
-        {
-            files: ['index.html'],
-            options: {
-                parser: 'html'
+                parser: 'angular'
             }
         }
     ]

--- a/apps/docs/src/app/components/design-tokens-viewers/design-tokens-viewer.ts
+++ b/apps/docs/src/app/components/design-tokens-viewers/design-tokens-viewer.ts
@@ -19,9 +19,9 @@ import { DocsRegisterHeaderDirective } from '../register-header/register-header.
         <div class="docs-component-header">
             <div class="docs-component-name" docsRegisterHeader>Дизайн-токены</div>
             <div class="docs-component-navbar layout-padding-top-s">
-                <nav [tabNavPanel]="tabNavPanel" kbqTabNavBar>
+                <nav kbqTabNavBar [tabNavPanel]="tabNavPanel">
                     @for (link of links; track link) {
-                        <a [routerLink]="link.value" kbqTabLink routerLinkActive="kbq-selected">
+                        <a kbqTabLink routerLinkActive="kbq-selected" [routerLink]="link.value">
                             {{ link.title[locale()] }}
                         </a>
                     }

--- a/apps/docs/src/app/components/icons-viewer/icon-preview-modal/icon-preview-modal.template.html
+++ b/apps/docs/src/app/components/icons-viewer/icon-preview-modal/icon-preview-modal.template.html
@@ -35,7 +35,7 @@
         </kbq-form-field>
 
         <div class="docs-icon-preview-modal__buttons">
-            <a download href="{{ svgLink }}" kbq-button>
+            <a download kbq-button href="{{ svgLink }}">
                 <i kbq-icon="kbq-arrow-down-to-line_16"></i>
                 {{ isRuLocale() ? 'Скачать SVG' : 'Download SVG' }}
             </a>

--- a/apps/docs/src/app/components/live-example/docs-live-example.ts
+++ b/apps/docs/src/app/components/live-example/docs-live-example.ts
@@ -41,15 +41,15 @@ import { DocsLiveExampleViewerComponent } from '../live-example-viewer/docs-live
     selector: 'docs-live-example',
     template: `
         {{ isRuLocale() ? 'Загрузка документа...' : 'Loading document...' }}
-        <ng-template cdkPortal let-htmlContent let-contentToCopy="textContent" let-language="language">
-            <kbq-code-block [files]="[{ content: contentToCopy, language }]" filled lineNumbers />
+        <ng-template let-htmlContent let-contentToCopy="textContent" let-language="language" cdkPortal>
+            <kbq-code-block filled lineNumbers [files]="[{ content: contentToCopy, language }]" />
         </ng-template>
-        <ng-template #codeSnippet cdkPortal let-htmlContent>
+        <ng-template #codeSnippet let-htmlContent cdkPortal>
             <span
                 class="kbq-mono-normal"
+                docsCodeSnippet
                 [innerHTML]="htmlContent"
                 [kbqTooltip]="isRuLocale() ? 'Скопировать' : 'Copy'"
-                docsCodeSnippet
             ></span>
         </ng-template>
     `,

--- a/apps/docs/src/app/components/welcome/welcome.component.html
+++ b/apps/docs/src/app/components/welcome/welcome.component.html
@@ -17,8 +17,8 @@
             @for (item of category.items; track item) {
                 <a class="docs-welcome__category-item" [routerLink]="[category.id, item.id]">
                     <img
-                        src="./assets/images/welcome/{{ item.svgPreview || 'generic' }}-{{ currentTheme$ | async }}.png"
                         class="docs-welcome__category-item-preview"
+                        src="./assets/images/welcome/{{ item.svgPreview || 'generic' }}-{{ currentTheme$ | async }}.png"
                         [alt]="item.id"
                     />
                     <div class="docs-welcome__category-item-title">{{ item.name[locale()] }}</div>

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
         "postcss-discard-comments": "^7.0.4",
         "prettier": "^3.6.2",
         "prettier-plugin-multiline-arrays": "^3.0.6",
-        "prettier-plugin-organize-attributes": "^1.0.0",
         "prettier-plugin-organize-imports": "^4.1.0",
         "rimraf": "^5.0.5",
         "rollup": "^4.44.1",

--- a/packages/components-dev/button/module.ts
+++ b/packages/components-dev/button/module.ts
@@ -43,7 +43,7 @@ type DevButton = DevButtonState & DevButtonStyle;
     template: `
         <div class="dev-options">
             <kbq-checkbox [(ngModel)]="showPrefixIcon">show prefix icon</kbq-checkbox>
-            <kbq-checkbox [(ngModel)]="showTitle" [disabled]="!showPrefixIcon() && !showSuffixIcon()">
+            <kbq-checkbox [disabled]="!showPrefixIcon() && !showSuffixIcon()" [(ngModel)]="showTitle">
                 show title
             </kbq-checkbox>
             <kbq-checkbox [(ngModel)]="showSuffixIcon">show suffix icon</kbq-checkbox>
@@ -55,6 +55,7 @@ type DevButton = DevButtonState & DevButtonStyle;
                     @for (button of buttons; track button.title) {
                         <td>
                             <button
+                                kbq-button
                                 [class.cdk-keyboard-focused]="button.focused"
                                 [class.kbq-active]="button.active"
                                 [class.kbq-hover]="button.hover"
@@ -62,7 +63,6 @@ type DevButton = DevButtonState & DevButtonStyle;
                                 [disabled]="button.disabled"
                                 [kbqStyle]="button.style!"
                                 [color]="button.color!"
-                                kbq-button
                             >
                                 @if (showPrefixIcon()) {
                                     <i kbq-icon="kbq-play_16"></i>

--- a/packages/components-dev/content-panel/module.ts
+++ b/packages/components-dev/content-panel/module.ts
@@ -20,20 +20,20 @@ import { DevThemeToggle } from '../theme-toggle';
     selector: 'dev-content-panel-overview',
     template: `
         <kbq-content-panel-container
-            class="example-content-panel-container"
             #contentPanelContainer="kbqContentPanelContainer"
+            class="example-content-panel-container"
         >
             <div class="example-content-panel-container__content">
-                <button (click)="contentPanelContainer.toggle()" kbq-button>Toggle</button>
+                <button kbq-button (click)="contentPanelContainer.toggle()">Toggle</button>
             </div>
             <kbq-content-panel>
                 <kbq-content-panel-aside>
                     @for (_b of asideButtons; track $index) {
                         <button
+                            kbq-button
                             [class.kbq-active]="$index === 0"
                             [color]="componentColors.Contrast"
                             [kbqStyle]="buttonStyles.Transparent"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-bug_16"></i>
                         </button>
@@ -47,7 +47,7 @@ import { DevThemeToggle } from '../theme-toggle';
                     </div>
                     <div class="example-content-header-actions" kbqContentPanelHeaderActions>
                         @for (_i of headerActions; track $index) {
-                            <button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent" kbq-button>
+                            <button kbq-button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent">
                                 <i kbq-icon="kbq-link_16"></i>
                             </button>
                         }
@@ -71,7 +71,7 @@ import { DevThemeToggle } from '../theme-toggle';
                 </kbq-content-panel-body>
                 <kbq-content-panel-footer class="example-content-panel-footer">
                     @for (_a of footerActions; track $index) {
-                        <button [color]="componentColors.ContrastFade" kbq-button>Button {{ $index }}</button>
+                        <button kbq-button [color]="componentColors.ContrastFade">Button {{ $index }}</button>
                     }
                 </kbq-content-panel-footer>
             </kbq-content-panel>

--- a/packages/components-dev/dropdown/template.html
+++ b/packages/components-dev/dropdown/template.html
@@ -20,7 +20,7 @@
     </ng-template>
 </kbq-dropdown>
 <kbq-dropdown #domainsDropdown>
-    <ng-template kbqDropdownContent let-domains="domains">
+    <ng-template let-domains="domains" kbqDropdownContent>
         @for (domain of domains; track domain) {
             <button kbq-dropdown-item (click)="selectDomain(domain.id)">
                 {{ domain.name }}
@@ -110,7 +110,7 @@
 </button>
 
 <kbq-dropdown #appDropdownLazy="kbqDropdown">
-    <ng-template kbqDropdownContent let-someValue="someValue">
+    <ng-template let-someValue="someValue" kbqDropdownContent>
         <button kbq-dropdown-item>
             Point 1
             <span class="kbq-dropdown-item__caption">Some info</span>

--- a/packages/components-dev/e2e/components/button.ts
+++ b/packages/components-dev/e2e/components/button.ts
@@ -32,15 +32,15 @@ type DevButton = DevButtonState & DevButtonStyle;
     },
     template: `
         <div class="dev-options">
-            <kbq-checkbox [(ngModel)]="showPrefixIcon" data-testid="e2eShowPrefixIcon">show prefix icon</kbq-checkbox>
+            <kbq-checkbox data-testid="e2eShowPrefixIcon" [(ngModel)]="showPrefixIcon">show prefix icon</kbq-checkbox>
             <kbq-checkbox
-                [(ngModel)]="showTitle"
-                [disabled]="!showPrefixIcon() && !showSuffixIcon()"
                 data-testid="e2eShowTitle"
+                [disabled]="!showPrefixIcon() && !showSuffixIcon()"
+                [(ngModel)]="showTitle"
             >
                 show title
             </kbq-checkbox>
-            <kbq-checkbox [(ngModel)]="showSuffixIcon" data-testid="e2eShowSuffixIcon">show suffix icon</kbq-checkbox>
+            <kbq-checkbox data-testid="e2eShowSuffixIcon" [(ngModel)]="showSuffixIcon">show suffix icon</kbq-checkbox>
         </div>
 
         <table>
@@ -49,6 +49,7 @@ type DevButton = DevButtonState & DevButtonStyle;
                     @for (button of buttons; track button.title) {
                         <td>
                             <button
+                                kbq-button
                                 [class.cdk-keyboard-focused]="button.focused"
                                 [class.kbq-active]="button.active"
                                 [class.kbq-hover]="button.hover"
@@ -56,7 +57,6 @@ type DevButton = DevButtonState & DevButtonStyle;
                                 [disabled]="button.disabled"
                                 [kbqStyle]="button.style!"
                                 [color]="button.color!"
-                                kbq-button
                             >
                                 @if (showPrefixIcon()) {
                                     <i kbq-icon="kbq-play_16"></i>

--- a/packages/components-dev/file-upload/module.ts
+++ b/packages/components-dev/file-upload/module.ts
@@ -241,7 +241,7 @@ export class DevCustomTextDirective {}
                     </kbq-multiple-file-upload>
                 </td>
                 <td>
-                    <kbq-multiple-file-upload [disabled]="true" size="compact">
+                    <kbq-multiple-file-upload size="compact" [disabled]="true">
                         <ng-template #kbqFileIcon>
                             <i kbq-icon="kbq-file-o_16"></i>
                         </ng-template>
@@ -265,8 +265,8 @@ export class DevCustomTextDirective {}
             <tr>
                 <td colspan="4">
                     <kbq-multiple-file-upload
-                        class="dev-dragover"
                         #multipleWithErrorState
+                        class="dev-dragover"
                         [formControl]="multipleFileControlInvalid"
                     >
                         <ng-template #kbqFileIcon>
@@ -372,11 +372,11 @@ class DevExamples {}
     selector: 'dev-file-upload-compact',
     template: `
         <kbq-multiple-file-upload
+            size="compact"
             [disabled]="disabled"
             [inputId]="'test-compact'"
             [files]="files"
             (fileQueueChanged)="addedFiles($event)"
-            size="compact"
         >
             <ng-template #kbqFileIcon>
                 <i color="contrast-fade" kbq-icon="kbq-file-o_16"></i>

--- a/packages/components-dev/link/template.html
+++ b/packages/components-dev/link/template.html
@@ -37,35 +37,35 @@
     </tr>
     <tr>
         <td>
-            <a href="{{ url }}" kbq-link noUnderline [compact]="true" [disabled]="true">Отчет сканирования</a>
+            <a kbq-link noUnderline href="{{ url }}" [compact]="true" [disabled]="true">Отчет сканирования</a>
         </td>
         <td>
-            <a href="{{ url }}" kbq-link noUnderline [compact]="true">Отчет сканирования</a>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [compact]="true" [disabled]="true">
-                <span class="kbq-link__text">Отчет сканирования</span>
-                <i kbq-icon="kbq-north-east_16"></i>
-            </a>
-        </td>
-        <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [compact]="true">
-                <span class="kbq-link__text">Отчет сканирования</span>
-                <i kbq-icon="kbq-north-east_16"></i>
-            </a>
+            <a kbq-link noUnderline href="{{ url }}" [compact]="true">Отчет сканирования</a>
         </td>
     </tr>
     <tr>
         <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [compact]="true" [disabled]="true">
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [compact]="true" [disabled]="true">
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
         </td>
         <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [compact]="true">
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [compact]="true">
+                <span class="kbq-link__text">Отчет сканирования</span>
+                <i kbq-icon="kbq-north-east_16"></i>
+            </a>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [compact]="true" [disabled]="true">
+                <span class="kbq-link__text">Отчет сканирования</span>
+                <i kbq-icon="kbq-north-east_16"></i>
+            </a>
+        </td>
+        <td>
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [compact]="true">
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
@@ -74,11 +74,11 @@
     <tr>
         <td>
             <a
-                href="{{ url }}"
                 kbq-link
                 target="_blank"
                 useVisited
                 class="kbq-link_external"
+                href="{{ url }}"
                 [compact]="true"
                 [disabled]="true"
             >
@@ -88,7 +88,7 @@
             </a>
         </td>
         <td>
-            <a href="{{ url }}" kbq-link target="_blank" useVisited class="kbq-link_external" [compact]="true">
+            <a kbq-link target="_blank" useVisited class="kbq-link_external" href="{{ url }}" [compact]="true">
                 <i kbq-icon="kbq-calendar-o_16"></i>
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
@@ -189,35 +189,21 @@
     </tr>
     <tr>
         <td>
-            <a href="{{ url }}" kbq-link noUnderline [disabled]="true">Отчет сканирования</a>
+            <a kbq-link noUnderline href="{{ url }}" [disabled]="true">Отчет сканирования</a>
         </td>
         <td>
-            <a href="{{ url }}" kbq-link noUnderline>Отчет сканирования</a>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [disabled]="true">
-                <span class="kbq-link__text">Отчет сканирования</span>
-                <i kbq-icon="kbq-north-east_16"></i>
-            </a>
-        </td>
-        <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external">
-                <span class="kbq-link__text">Отчет сканирования</span>
-                <i kbq-icon="kbq-north-east_16"></i>
-            </a>
+            <a kbq-link noUnderline href="{{ url }}">Отчет сканирования</a>
         </td>
     </tr>
     <tr>
         <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [disabled]="true">
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [disabled]="true">
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
         </td>
         <td>
-            <a href="{{ url }}" kbq-link target="_blank" class="kbq-link_external">
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}">
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
@@ -225,14 +211,28 @@
     </tr>
     <tr>
         <td>
-            <a href="{{ url }}" kbq-link target="_blank" useVisited class="kbq-link_external" [disabled]="true">
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [disabled]="true">
+                <span class="kbq-link__text">Отчет сканирования</span>
+                <i kbq-icon="kbq-north-east_16"></i>
+            </a>
+        </td>
+        <td>
+            <a kbq-link target="_blank" class="kbq-link_external" href="{{ url }}">
+                <span class="kbq-link__text">Отчет сканирования</span>
+                <i kbq-icon="kbq-north-east_16"></i>
+            </a>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <a kbq-link target="_blank" useVisited class="kbq-link_external" href="{{ url }}" [disabled]="true">
                 <i kbq-icon="kbq-calendar-o_16"></i>
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
         </td>
         <td>
-            <a href="{{ url }}" kbq-link target="_blank" useVisited class="kbq-link_external">
+            <a kbq-link target="_blank" useVisited class="kbq-link_external" href="{{ url }}">
                 <i kbq-icon="kbq-calendar-o_16"></i>
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
@@ -333,35 +333,21 @@
     </tr>
     <tr>
         <td>
-            <a big href="{{ url }}" kbq-link noUnderline [disabled]="true">Отчет сканирования</a>
+            <a big kbq-link noUnderline href="{{ url }}" [disabled]="true">Отчет сканирования</a>
         </td>
         <td>
-            <a big href="{{ url }}" kbq-link noUnderline>Отчет сканирования</a>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <a big href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [disabled]="true">
-                <span class="kbq-link__text">Отчет сканирования</span>
-                <i kbq-icon="kbq-north-east_16"></i>
-            </a>
-        </td>
-        <td>
-            <a big href="{{ url }}" kbq-link target="_blank" class="kbq-link_external">
-                <span class="kbq-link__text">Отчет сканирования</span>
-                <i kbq-icon="kbq-north-east_16"></i>
-            </a>
+            <a big kbq-link noUnderline href="{{ url }}">Отчет сканирования</a>
         </td>
     </tr>
     <tr>
         <td>
-            <a big href="{{ url }}" kbq-link target="_blank" class="kbq-link_external" [disabled]="true">
+            <a big kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [disabled]="true">
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
         </td>
         <td>
-            <a big href="{{ url }}" kbq-link target="_blank" class="kbq-link_external">
+            <a big kbq-link target="_blank" class="kbq-link_external" href="{{ url }}">
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
@@ -369,14 +355,28 @@
     </tr>
     <tr>
         <td>
-            <a big href="{{ url }}" kbq-link target="_blank" useVisited class="kbq-link_external" [disabled]="true">
+            <a big kbq-link target="_blank" class="kbq-link_external" href="{{ url }}" [disabled]="true">
+                <span class="kbq-link__text">Отчет сканирования</span>
+                <i kbq-icon="kbq-north-east_16"></i>
+            </a>
+        </td>
+        <td>
+            <a big kbq-link target="_blank" class="kbq-link_external" href="{{ url }}">
+                <span class="kbq-link__text">Отчет сканирования</span>
+                <i kbq-icon="kbq-north-east_16"></i>
+            </a>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <a big kbq-link target="_blank" useVisited class="kbq-link_external" href="{{ url }}" [disabled]="true">
                 <i kbq-icon="kbq-calendar-o_16"></i>
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>
             </a>
         </td>
         <td>
-            <a big href="{{ url }}" kbq-link target="_blank" useVisited class="kbq-link_external">
+            <a big kbq-link target="_blank" useVisited class="kbq-link_external" href="{{ url }}">
                 <i kbq-icon="kbq-calendar-o_16"></i>
                 <span class="kbq-link__text">Отчет сканирования</span>
                 <i kbq-icon="kbq-north-east_16"></i>

--- a/packages/components-dev/modal/module.ts
+++ b/packages/components-dev/modal/module.ts
@@ -62,7 +62,7 @@ export class DevModalLongCustomComponent {
             <h4>{{ subtitle }}</h4>
             <p>
                 <span>Get Modal instance in component</span>
-                <button [color]="componentColors.Contrast" (click)="destroyModal()" kbq-button>
+                <button kbq-button [color]="componentColors.Contrast" (click)="destroyModal()">
                     destroy modal in the component
                 </button>
             </p>
@@ -102,15 +102,15 @@ export class DevModalCustomComponent {
             <h4>{{ subtitle }}</h4>
             <p>
                 <span>Get Modal instance in component</span>
-                <button [color]="componentColors.Contrast" (click)="destroyModal()" kbq-button>
+                <button kbq-button [color]="componentColors.Contrast" (click)="destroyModal()">
                     destroy modal in the component
                 </button>
             </p>
         </kbq-modal-body>
 
         <div kbq-modal-footer>
-            <button [color]="componentColors.Contrast" kbq-button>Save</button>
-            <button (click)="destroyModal()" kbq-button autofocus>Close</button>
+            <button kbq-button [color]="componentColors.Contrast">Save</button>
+            <button kbq-button autofocus (click)="destroyModal()">Close</button>
         </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/components-dev/scrollbar/module.ts
+++ b/packages/components-dev/scrollbar/module.ts
@@ -13,7 +13,7 @@ import {
     selector: 'dev-scrollbar-with-options',
     template: `
         <h4>ScrollbarWithOptions:</h4>
-        <kbq-scrollbar [options]="options" style="width: 200px; height: 200px;">
+        <kbq-scrollbar style="width: 200px; height: 200px;" [options]="options">
             @for (item of items; track item) {
                 <div>{{ item }}</div>
                 <hr />
@@ -69,16 +69,16 @@ export class DevScrollbarWithCustomConfig {
     ],
     template: `
         <h4>ScrollbarScrollToTop:</h4>
-        <kbq-scrollbar #scrollbarRef="kbqScrollbar" (onScroll)="onScroll($event)" style="width: 200px; height: 200px;">
+        <kbq-scrollbar #scrollbarRef="kbqScrollbar" style="width: 200px; height: 200px;" (onScroll)="onScroll($event)">
             @for (item of items; track item) {
                 <div>{{ item }}</div>
                 <hr />
             }
         </kbq-scrollbar>
         <button
+            kbq-button
             [disabled]="!(scrollbarRef?.contentElement?.nativeElement?.scrollTop || 0 > 0)"
             (click)="scrollbarRef.scrollTo({ top: 0, behavior: 'smooth' })"
-            kbq-button
         >
             Scroll To Top
         </button>

--- a/packages/components-dev/sidepanel/module.ts
+++ b/packages/components-dev/sidepanel/module.ts
@@ -34,7 +34,7 @@ import { KbqToggleModule } from '@koobiq/components/toggle';
 
         <kbq-sidepanel-footer>
             <kbq-sidepanel-actions>
-                <button [color]="'contrast'" (click)="openComponentSidepanel()" kbq-button>
+                <button kbq-button [color]="'contrast'" (click)="openComponentSidepanel()">
                     <span>Open another sidepanel</span>
                 </button>
 

--- a/packages/components-dev/ssr/components/breadcrumbs.ts
+++ b/packages/components-dev/ssr/components/breadcrumbs.ts
@@ -16,12 +16,12 @@ import { map } from 'rxjs/operators';
                 <nav kbq-breadcrumbs wrapMode="none">
                     @for (breadcrumb of breadcrumbs; track breadcrumb.label; let last = $last) {
                         <kbq-breadcrumb-item [routerLink]="breadcrumb.url" [text]="breadcrumb.label">
-                            <a *kbqBreadcrumbView [routerLink]="breadcrumb.url" tabindex="-1">
+                            <a *kbqBreadcrumbView tabindex="-1" [routerLink]="breadcrumb.url">
                                 <button
-                                    [disabled]="last"
-                                    [attr.aria-current]="last ? 'page' : null"
                                     kbq-button
                                     kbqBreadcrumb
+                                    [disabled]="last"
+                                    [attr.aria-current]="last ? 'page' : null"
                                 >
                                     <span>{{ breadcrumb.label }}</span>
                                 </button>

--- a/packages/components-dev/tag/module.ts
+++ b/packages/components-dev/tag/module.ts
@@ -94,10 +94,10 @@ class DevExamples {}
                 }
 
                 <input
-                    [kbqTagInputFor]="inputTagList"
-                    (kbqTagInputTokenEnd)="createTag($event)"
                     kbqInput
                     placeholder="New keyword..."
+                    [kbqTagInputFor]="inputTagList"
+                    (kbqTagInputTokenEnd)="createTag($event)"
                 />
             </kbq-tag-list>
 

--- a/packages/components-experimental/form-field/cleaner.ts
+++ b/packages/components-experimental/form-field/cleaner.ts
@@ -13,7 +13,7 @@ import { KbqFormField } from './form-field';
     selector: 'kbq-cleaner',
     exportAs: 'kbqCleaner',
     template: `
-        <i [autoColor]="true" color="contrast-fade" kbq-icon-button="kbq-xmark-circle_16"></i>
+        <i color="contrast-fade" kbq-icon-button="kbq-xmark-circle_16" [autoColor]="true"></i>
     `,
     styleUrl: './cleaner.scss',
     host: {

--- a/packages/components-experimental/form-field/form-field.spec.ts
+++ b/packages/components-experimental/form-field/form-field.spec.ts
@@ -96,7 +96,7 @@ const getSubmitButtonNativeElement = (debugElement: DebugElement): HTMLInputElem
     ],
     template: `
         <kbq-form-field>
-            <input [formControl]="control" kbqInput />
+            <input kbqInput [formControl]="control" />
             <kbq-hint id="test-hint-id">Hint</kbq-hint>
             <kbq-error id="test-error-id">Error</kbq-error>
         </kbq-form-field>
@@ -133,7 +133,7 @@ export class InputFormFieldWithPrefixAndSuffix {}
     ],
     template: `
         <kbq-form-field>
-            <input [formControl]="control" kbqInput />
+            <input kbqInput [formControl]="control" />
             <kbq-cleaner />
         </kbq-form-field>
     `
@@ -170,7 +170,7 @@ export class InputFormFieldWithoutFormFieldControl {
     template: `
         <kbq-form-field>
             <kbq-label id="test-label-id">Label</kbq-label>
-            <input [id]="id" kbqInput />
+            <input kbqInput [id]="id" />
         </kbq-form-field>
     `
 })
@@ -195,7 +195,7 @@ class CustomErrorStateMatcher implements ErrorStateMatcher {
     template: `
         <form [formGroup]="formGroup">
             <kbq-form-field>
-                <input [errorStateMatcher]="errorStateMatcher" formControlName="email" kbqInput />
+                <input formControlName="email" kbqInput [errorStateMatcher]="errorStateMatcher" />
                 <kbq-error id="test-error-id">Error</kbq-error>
                 <input type="submit" />
             </kbq-form-field>
@@ -237,7 +237,7 @@ export class InputFormFieldWithBorderCustomization {
     ],
     template: `
         <kbq-form-field>
-            <input [formControl]="formControl" kbqInputPassword />
+            <input kbqInputPassword [formControl]="formControl" />
             <kbq-password-toggle />
             <kbq-password-hint id="test-password-hint-id" [hasError]="formControl.hasError('minLength')">
                 Min length

--- a/packages/components-experimental/form-field/hint.ts
+++ b/packages/components-experimental/form-field/hint.ts
@@ -103,7 +103,7 @@ export class KbqError extends KbqHint {
     imports: [NgClass, KbqIconModule],
     selector: 'kbq-password-hint',
     template: `
-        <i [ngClass]="icon" kbq-icon=""></i>
+        <i kbq-icon="" [ngClass]="icon"></i>
 
         <span class="kbq-hint__text">
             <ng-content />

--- a/packages/components-experimental/form-field/password-toggle.ts
+++ b/packages/components-experimental/form-field/password-toggle.ts
@@ -16,7 +16,7 @@ const getKbqPasswordToggleMissingControlError = (): Error => {
     selector: `kbq-password-toggle`,
     exportAs: 'kbqPasswordToggle',
     template: `
-        <i [ngClass]="icon" [autoColor]="true" color="contrast-fade" kbq-icon-button=""></i>
+        <i color="contrast-fade" kbq-icon-button="" [ngClass]="icon" [autoColor]="true"></i>
     `,
     styleUrl: './password-toggle.scss',
     host: {

--- a/packages/components-experimental/form-field/stepper.ts
+++ b/packages/components-experimental/form-field/stepper.ts
@@ -17,21 +17,21 @@ const getKbqStepperToggleMissingControlError = (): Error => {
     template: `
         <i
             class="kbq-stepper__step-up"
+            color="contrast-fade"
+            kbq-icon-button="kbq-chevron-up-s_16"
             [tabindex]="-1"
             [autoColor]="true"
             [disabled]="control.disabled"
             (mousedown)="stepUp($event)"
-            color="contrast-fade"
-            kbq-icon-button="kbq-chevron-up-s_16"
         ></i>
         <i
             class="kbq-stepper__step-down"
+            color="contrast-fade"
+            kbq-icon-button="kbq-chevron-down-s_16"
             [tabindex]="-1"
             [autoColor]="true"
             [disabled]="control.disabled"
             (mousedown)="stepDown($event)"
-            color="contrast-fade"
-            kbq-icon-button="kbq-chevron-down-s_16"
         ></i>
     `,
     styleUrl: './stepper.scss',

--- a/packages/components/actions-panel/actions-panel-container.ts
+++ b/packages/components/actions-panel/actions-panel-container.ts
@@ -97,11 +97,11 @@ const KBQ_ACTIONS_PANEL_CONTAINER_ANIMATION = trigger('state', [
             <kbq-divider class="kbq-actions-panel-container__vertical-divider" [vertical]="true" />
             <button
                 class="kbq-actions-panel-container__close-button"
+                color="contrast"
+                kbq-button
                 [kbqTooltip]="localeConfiguration()!.closeTooltip"
                 [kbqTooltipOffset]="16"
                 (click)="close()"
-                color="contrast"
-                kbq-button
             >
                 <i kbq-icon="kbq-xmark-circle_16"></i>
             </button>

--- a/packages/components/autocomplete/autocomplete.karma-spec.ts
+++ b/packages/components/autocomplete/autocomplete.karma-spec.ts
@@ -267,17 +267,17 @@ describe('KbqAutocomplete', () => {
     template: `
         <kbq-form-field [style.width.px]="width">
             <input
+                kbqInput
+                placeholder="State"
                 [kbqAutocomplete]="auto"
                 [kbqAutocompleteDisabled]="autocompleteDisabled"
                 [formControl]="stateCtrl"
-                kbqInput
-                placeholder="State"
             />
         </kbq-form-field>
 
         <kbq-autocomplete
-            class="class-one class-two"
             #auto="kbqAutocomplete"
+            class="class-one class-two"
             [displayWith]="displayFn"
             (opened)="openedSpy()"
             (closed)="closedSpy()"

--- a/packages/components/autocomplete/autocomplete.spec.ts
+++ b/packages/components/autocomplete/autocomplete.spec.ts
@@ -2113,17 +2113,17 @@ describe('KbqAutocomplete', () => {
     template: `
         <kbq-form-field [style.width.px]="width">
             <input
+                kbqInput
+                placeholder="State"
                 [kbqAutocomplete]="auto"
                 [kbqAutocompleteDisabled]="autocompleteDisabled"
                 [formControl]="stateCtrl"
-                kbqInput
-                placeholder="State"
             />
         </kbq-form-field>
 
         <kbq-autocomplete
-            class="class-one class-two"
             #auto="kbqAutocomplete"
+            class="class-one class-two"
             [displayWith]="displayFn"
             (opened)="openedSpy()"
             (closed)="closedSpy()"
@@ -2185,7 +2185,7 @@ class SimpleAutocomplete implements OnDestroy {
     template: `
         @if (isVisible) {
             <kbq-form-field>
-                <input [kbqAutocomplete]="auto" [formControl]="optionCtrl" kbqInput placeholder="Choose" />
+                <input kbqInput placeholder="Choose" [kbqAutocomplete]="auto" [formControl]="optionCtrl" />
             </kbq-form-field>
         }
 
@@ -2220,7 +2220,7 @@ class NgIfAutocomplete {
 @Component({
     template: `
         <kbq-form-field>
-            <input [kbqAutocomplete]="auto" (input)="onInput($event.target?.value)" kbqInput placeholder="State" />
+            <input kbqInput placeholder="State" [kbqAutocomplete]="auto" (input)="onInput($event.target?.value)" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
@@ -2249,11 +2249,11 @@ class AutocompleteWithoutForms {
     template: `
         <kbq-form-field>
             <input
-                [(ngModel)]="selectedState"
-                [kbqAutocomplete]="auto"
-                (ngModelChange)="onInput($event)"
                 kbqInput
                 placeholder="State"
+                [kbqAutocomplete]="auto"
+                [(ngModel)]="selectedState"
+                (ngModelChange)="onInput($event)"
             />
         </kbq-form-field>
 
@@ -2283,7 +2283,7 @@ class AutocompleteWithNgModel {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="selectedNumber" [kbqAutocomplete]="auto" kbqInput placeholder="Number" />
+            <input kbqInput placeholder="Number" [kbqAutocomplete]="auto" [(ngModel)]="selectedNumber" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
@@ -2304,7 +2304,7 @@ class AutocompleteWithNumbers {
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <input [kbqAutocomplete]="auto" type="text" kbqInput />
+            <input type="text" kbqInput [kbqAutocomplete]="auto" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
@@ -2329,7 +2329,7 @@ class AutocompleteWithOnPushDelay implements OnInit {
 
 @Component({
     template: `
-        <input [kbqAutocomplete]="auto" [formControl]="optionCtrl" placeholder="Choose" />
+        <input placeholder="Choose" [kbqAutocomplete]="auto" [formControl]="optionCtrl" />
 
         <kbq-autocomplete #auto="kbqAutocomplete">
             @for (option of filteredOptions | async; track option) {
@@ -2360,7 +2360,7 @@ class AutocompleteWithNativeInput {
 
 @Component({
     template: `
-        <input [kbqAutocomplete]="auto" [formControl]="control" placeholder="Choose" />
+        <input placeholder="Choose" [kbqAutocomplete]="auto" [formControl]="control" />
     `
 })
 class AutocompleteWithoutPanel {
@@ -2371,7 +2371,7 @@ class AutocompleteWithoutPanel {
 @Component({
     template: `
         <kbq-form-field>
-            <input [kbqAutocomplete]="auto" [formControl]="formControl" placeholder="State" kbqInput />
+            <input placeholder="State" kbqInput [kbqAutocomplete]="auto" [formControl]="formControl" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
@@ -2386,7 +2386,7 @@ class AutocompleteWithFormsAndNonfloatingLabel {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="selectedState" [kbqAutocomplete]="auto" kbqInput placeholder="State" />
+            <input kbqInput placeholder="State" [kbqAutocomplete]="auto" [(ngModel)]="selectedState" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
@@ -2424,7 +2424,7 @@ class AutocompleteWithGroups {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="selectedState" [kbqAutocomplete]="auto" kbqInput placeholder="State" />
+            <input kbqInput placeholder="State" [kbqAutocomplete]="auto" [(ngModel)]="selectedState" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete" (optionSelected)="optionSelected($event)">
@@ -2458,7 +2458,7 @@ class PlainAutocompleteInputWithFormControl {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="selectedValue" [kbqAutocomplete]="auto" type="number" kbqInput />
+            <input type="number" kbqInput [kbqAutocomplete]="auto" [(ngModel)]="selectedValue" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
@@ -2480,15 +2480,15 @@ class AutocompleteWithNumberInputAndNgModel {
         <div>
             <kbq-form-field>
                 <input
-                    [(ngModel)]="selectedValue"
+                    kbqInput
                     [kbqAutocomplete]="auto"
                     [kbqAutocompleteConnectedTo]="connectedTo"
-                    kbqInput
+                    [(ngModel)]="selectedValue"
                 />
             </kbq-form-field>
         </div>
 
-        <div class="origin" #origin="kbqAutocompleteOrigin" kbqAutocompleteOrigin style="margin-top: 50px">
+        <div #origin="kbqAutocompleteOrigin" class="origin" kbqAutocompleteOrigin style="margin-top: 50px">
             Connection element
         </div>
 
@@ -2512,7 +2512,7 @@ class AutocompleteWithDifferentOrigin {
 
 @Component({
     template: `
-        <input [(ngModel)]="value" [kbqAutocomplete]="auto" autocomplete="changed" />
+        <input autocomplete="changed" [kbqAutocomplete]="auto" [(ngModel)]="value" />
         <kbq-autocomplete #auto="kbqAutocomplete" />
     `
 })
@@ -2521,14 +2521,14 @@ class AutocompleteWithNativeAutocompleteAttribute {
 }
 
 @Component({
-    template: '<input [kbqAutocomplete]="null" kbqAutocompleteDisabled>'
+    template: '<input kbqAutocompleteDisabled [kbqAutocomplete]="null">'
 })
 class InputWithoutAutocompleteAndDisabled {}
 
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="selectedState" [kbqAutocomplete]="auto" kbqInput placeholder="States" />
+            <input kbqInput placeholder="States" [kbqAutocomplete]="auto" [(ngModel)]="selectedState" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
@@ -2562,7 +2562,7 @@ class AutocompleteWithDisabledItems {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="selectedState" [kbqAutocomplete]="auto" kbqInput placeholder="States" />
+            <input kbqInput placeholder="States" [kbqAutocomplete]="auto" [(ngModel)]="selectedState" />
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete" [openOnFocus]="false">

--- a/packages/components/breadcrumbs/breadcrumbs.karma-spec.ts
+++ b/packages/components/breadcrumbs/breadcrumbs.karma-spec.ts
@@ -208,7 +208,7 @@ class SimpleBreadcrumbs {
 
             @for (item of items; track item) {
                 <kbq-breadcrumb-item [text]="item.text" [disabled]="item.disabled">
-                    <a class="custom-breadcrumb" *kbqBreadcrumbView>CUSTOM_BREADCRUMB_TEMPLATE</a>
+                    <a *kbqBreadcrumbView class="custom-breadcrumb">CUSTOM_BREADCRUMB_TEMPLATE</a>
                 </kbq-breadcrumb-item>
             }
         </kbq-breadcrumbs>

--- a/packages/components/button-toggle/button-toggle.component.spec.ts
+++ b/packages/components/button-toggle/button-toggle.component.spec.ts
@@ -616,7 +616,7 @@ describe('KbqButtonToggle without forms', () => {
 
 @Component({
     template: `
-        <kbq-button-toggle-group [(value)]="groupValue" [disabled]="isGroupDisabled" [vertical]="isVertical">
+        <kbq-button-toggle-group [disabled]="isGroupDisabled" [vertical]="isVertical" [(value)]="groupValue">
             @if (renderFirstToggle) {
                 <kbq-button-toggle [value]="'test1'">Test1</kbq-button-toggle>
             }
@@ -634,7 +634,7 @@ class ButtonTogglesInsideButtonToggleGroup {
 
 @Component({
     template: `
-        <kbq-button-toggle-group [(ngModel)]="modelValue" [name]="groupName" (change)="lastEvent = $event">
+        <kbq-button-toggle-group [name]="groupName" [(ngModel)]="modelValue" (change)="lastEvent = $event">
             @for (option of options; track option) {
                 <kbq-button-toggle [value]="option.value">
                     {{ option.label }}
@@ -656,7 +656,7 @@ class ButtonToggleGroupWithNgModel {
 
 @Component({
     template: `
-        <kbq-button-toggle-group [disabled]="isGroupDisabled" [vertical]="isVertical" multiple>
+        <kbq-button-toggle-group multiple [disabled]="isGroupDisabled" [vertical]="isVertical">
             <kbq-button-toggle [value]="'eggs'">Eggs</kbq-button-toggle>
             <kbq-button-toggle [value]="'flour'">Flour</kbq-button-toggle>
             <kbq-button-toggle [value]="'sugar'">Sugar</kbq-button-toggle>
@@ -670,7 +670,7 @@ class ButtonTogglesInsideButtonToggleGroupMultiple {
 
 @Component({
     template: `
-        <kbq-button-toggle-group [value]="value" multiple>
+        <kbq-button-toggle-group multiple [value]="value">
             <kbq-button-toggle [value]="0">Eggs</kbq-button-toggle>
             <kbq-button-toggle [value]="null">Flour</kbq-button-toggle>
             <kbq-button-toggle [value]="false">Sugar</kbq-button-toggle>

--- a/packages/components/button-toggle/button-toggle.component.ts
+++ b/packages/components/button-toggle/button-toggle.component.ts
@@ -293,16 +293,16 @@ export class KbqButtonToggleGroup implements ControlValueAccessor, OnInit, After
     exportAs: 'kbqButtonToggle',
     template: `
         <button
+            kbq-button
+            kbq-title
+            type="button"
             [kbqStyle]="'transparent'"
             [class.kbq-selected]="checked"
             [disabled]="disabled"
             [tabIndex]="tabIndex || 0"
             (click)="onToggleClick()"
-            kbq-button
-            kbq-title
-            type="button"
         >
-            <div class="kbq-button-toggle-wrapper" #kbqTitleText>
+            <div #kbqTitleText class="kbq-button-toggle-wrapper">
                 <ng-content />
             </div>
         </button>

--- a/packages/components/button/button.component.spec.ts
+++ b/packages/components/button/button.component.spec.ts
@@ -298,8 +298,8 @@ describe('Button with icon', () => {
 @Component({
     selector: 'test-app',
     template: `
-        <button [color]="buttonColor" [disabled]="isDisabled" (click)="increment()" kbq-button type="button"></button>
-        <a [color]="buttonColor" [disabled]="isDisabled" (click)="increment()" href="#" kbq-button></a>
+        <button kbq-button type="button" [color]="buttonColor" [disabled]="isDisabled" (click)="increment()"></button>
+        <a href="#" kbq-button [color]="buttonColor" [disabled]="isDisabled" (click)="increment()"></a>
     `
 })
 class TestApp {
@@ -455,10 +455,10 @@ class KbqButtonIconNgIfCaseTestApp {
 
 @Component({
     template: `
-        <button #triggerEl [kbqDropdownTriggerFor]="dropdown" kbq-button>Toggle dropdown</button>
+        <button #triggerEl kbq-button [kbqDropdownTriggerFor]="dropdown">Toggle dropdown</button>
         <kbq-dropdown
-            class="custom-one custom-two"
             #dropdown="kbqDropdown"
+            class="custom-one custom-two"
             [backdropClass]="backdropClass"
             [hasBackdrop]="true"
         >

--- a/packages/components/checkbox/checkbox.component.spec.ts
+++ b/packages/components/checkbox/checkbox.component.spec.ts
@@ -820,7 +820,6 @@ describe('KbqCheckbox', () => {
     template: `
         <div (click)="parentElementClicked = true" (keyup)="parentElementKeyedUp = true">
             <kbq-checkbox
-                [(indeterminate)]="isIndeterminate"
                 [id]="checkboxId"
                 [required]="isRequired"
                 [labelPosition]="labelPos"
@@ -828,6 +827,7 @@ describe('KbqCheckbox', () => {
                 [disabled]="isDisabled"
                 [color]="checkboxColor"
                 [value]="checkboxValue"
+                [(indeterminate)]="isIndeterminate"
                 (click)="onCheckboxClick($event)"
                 (change)="onCheckboxChange($event)"
             >
@@ -856,7 +856,7 @@ class SingleCheckbox {
 @Component({
     template: `
         <form>
-            <kbq-checkbox [(ngModel)]="isGood" name="cb">Be good</kbq-checkbox>
+            <kbq-checkbox name="cb" [(ngModel)]="isGood">Be good</kbq-checkbox>
         </form>
     `
 })
@@ -867,7 +867,7 @@ class CheckboxWithFormDirectives {
 /** Simple component for testing an KbqCheckbox with required ngModel. */
 @Component({
     template: `
-        <kbq-checkbox [(ngModel)]="isGood" [required]="isRequired">Be good</kbq-checkbox>
+        <kbq-checkbox [required]="isRequired" [(ngModel)]="isGood">Be good</kbq-checkbox>
     `
 })
 class CheckboxWithNgModel {

--- a/packages/components/code-block/code-block.spec.ts
+++ b/packages/components/code-block/code-block.spec.ts
@@ -59,8 +59,6 @@ const getViewAllButtonElement = (debugElement: DebugElement): HTMLButtonElement 
     imports: [KbqCodeBlockModule],
     template: `
         <kbq-code-block
-            [(activeFileIndex)]="activeFileIndex"
-            [(softWrap)]="softWrap"
             [files]="files"
             [filled]="filled"
             [lineNumbers]="lineNumbers"
@@ -70,6 +68,8 @@ const getViewAllButtonElement = (debugElement: DebugElement): HTMLButtonElement 
             [hideTabs]="hideTabs"
             [canCopy]="canCopy"
             [maxHeight]="maxHeight"
+            [(activeFileIndex)]="activeFileIndex"
+            [(softWrap)]="softWrap"
         />
     `,
     changeDetection: ChangeDetectionStrategy.Default

--- a/packages/components/content-panel/content-panel.spec.ts
+++ b/packages/components/content-panel/content-panel.spec.ts
@@ -33,12 +33,12 @@ const ESCAPE_KEY_EVENT = new KeyboardEvent('keydown', { key: 'Escape' });
     selector: 'test-content-panel',
     template: `
         <kbq-content-panel-container
-            [(opened)]="opened"
             [width]="width()"
             [maxWidth]="maxWidth()"
             [minWidth]="minWidth()"
             [disableClose]="disableClose()"
             [disableCloseByEscape]="disableCloseByEscape()"
+            [(opened)]="opened"
         >
             <div>test</div>
 

--- a/packages/components/content-panel/content-panel.ts
+++ b/packages/components/content-panel/content-panel.ts
@@ -99,11 +99,11 @@ export class KbqContentPanelHeaderActions {}
                 @if (!contentPanelContainer.disableClose()) {
                     <button
                         class="kbq-content-panel-header__close-button"
+                        kbq-button
+                        type="button"
                         [color]="componentColors.Contrast"
                         [kbqStyle]="buttonStyles.Transparent"
                         (click)="contentPanelContainer.close()"
-                        kbq-button
-                        type="button"
                     >
                         <i kbq-icon="kbq-xmark_16"></i>
                     </button>
@@ -255,11 +255,11 @@ export class KbqContentPanel {
         @if (openedState()) {
             <div
                 class="kbq-content-panel-container__panel"
+                kbqResizable
                 @panelAnimation
                 [style.min-width.px]="minWidth()"
                 [style.width.px]="widthState()"
                 [style.max-width.px]="maxWidth()"
-                kbqResizable
             >
                 @if (!disableResizer()) {
                     <div

--- a/packages/components/datepicker/calendar-body.spec.ts
+++ b/packages/components/datepicker/calendar-body.spec.ts
@@ -99,6 +99,7 @@ describe('KbqCalendarBody', () => {
 @Component({
     template: `
         <table
+            kbq-calendar-body
             [rows]="rows"
             [todayValue]="todayValue"
             [selectedValue]="selectedValue"
@@ -106,7 +107,6 @@ describe('KbqCalendarBody', () => {
             [numCols]="numCols"
             [activeCell]="10"
             (selectedValueChange)="onSelect($event)"
-            kbq-calendar-body
         ></table>
     `
 })

--- a/packages/components/datepicker/calendar-header.spec.ts
+++ b/packages/components/datepicker/calendar-header.spec.ts
@@ -71,8 +71,8 @@ describe('KbqCalendarHeader', () => {
 @Component({
     template: `
         <kbq-calendar
-            [(selected)]="selected"
             [startAt]="startDate"
+            [(selected)]="selected"
             (yearSelected)="selectedYear = $event"
             (monthSelected)="selectedMonth = $event"
         />

--- a/packages/components/datepicker/calendar.spec.ts
+++ b/packages/components/datepicker/calendar.spec.ts
@@ -344,8 +344,8 @@ describe('KbqCalendar', () => {
 @Component({
     template: `
         <kbq-calendar
-            [(selected)]="selected"
             [startAt]="startDate"
+            [(selected)]="selected"
             (yearSelected)="selectedYear = $event"
             (monthSelected)="selectedMonth = $event"
         />
@@ -375,7 +375,7 @@ class CalendarWithMinMax {
 
 @Component({
     template: `
-        <kbq-calendar [(selected)]="selected" [startAt]="startDate" [dateFilter]="dateFilter" />
+        <kbq-calendar [startAt]="startDate" [dateFilter]="dateFilter" [(selected)]="selected" />
     `
 })
 class CalendarWithDateFilter {

--- a/packages/components/datepicker/datepicker-content.html
+++ b/packages/components/datepicker/datepicker-content.html
@@ -7,9 +7,9 @@
     [ngClass]="datepicker.panelClass"
     [selected]="datepicker.selected"
     [startAt]="datepicker.startAt"
+    [@fadeInCalendar]="'enter'"
     (monthSelected)="datepicker.selectMonth($event)"
     (selectedChange)="datepicker.select($event)"
     (userSelection)="datepicker.close()"
     (yearSelected)="datepicker.selectYear($event)"
-    [@fadeInCalendar]="'enter'"
 />

--- a/packages/components/datepicker/datepicker-toggle.component.ts
+++ b/packages/components/datepicker/datepicker-toggle.component.ts
@@ -35,12 +35,12 @@ export class KbqDatepickerToggleIcon {}
     template: `
         <ng-content select="[kbqDatepickerToggleIcon]">
             <i
+                color="contrast-fade"
+                kbq-icon-button="kbq-calendar-o_16"
                 [tabindex]="-1"
                 [class.kbq-active]="datepicker && datepicker.opened"
                 [disabled]="disabled"
                 [autoColor]="true"
-                color="contrast-fade"
-                kbq-icon-button="kbq-calendar-o_16"
             ></i>
         </ng-content>
     `,

--- a/packages/components/datepicker/datepicker.spec.ts
+++ b/packages/components/datepicker/datepicker.spec.ts
@@ -1283,7 +1283,7 @@ class DatepickerWithStartAt {
 
 @Component({
     template: `
-        <input [(ngModel)]="selected" [kbqDatepicker]="d" />
+        <input [kbqDatepicker]="d" [(ngModel)]="selected" />
         <kbq-datepicker #d />
     `
 })
@@ -1334,7 +1334,7 @@ class DatepickerWithCustomIcon {}
 
 @Component({
     template: `
-        <input [(ngModel)]="date" [kbqDatepicker]="d" [min]="minDate" [max]="maxDate" />
+        <input [kbqDatepicker]="d" [min]="minDate" [max]="maxDate" [(ngModel)]="date" />
         <kbq-datepicker-toggle [for]="d" />
         <kbq-datepicker #d />
     `
@@ -1348,7 +1348,7 @@ class DatepickerWithMinAndMaxValidation {
 
 @Component({
     template: `
-        <input [(ngModel)]="date" [kbqDatepicker]="d" [kbqDatepickerFilter]="filter" />
+        <input [kbqDatepicker]="d" [kbqDatepickerFilter]="filter" [(ngModel)]="date" />
         <kbq-datepicker-toggle [for]="d" />
         <kbq-datepicker #d />
     `
@@ -1362,8 +1362,8 @@ class DatepickerWithFilterAndValidation {
 @Component({
     template: `
         <input
-            [(ngModel)]="value"
             [kbqDatepicker]="d"
+            [(ngModel)]="value"
             (change)="onChange()"
             (dateChange)="onDateChange($event)"
             (dateInput)="onDateInput()"
@@ -1384,7 +1384,7 @@ class DatepickerWithChangeAndInputEvents {
 
 @Component({
     template: `
-        <input [(ngModel)]="date" [kbqDatepicker]="d" />
+        <input [kbqDatepicker]="d" [(ngModel)]="date" />
         <kbq-datepicker #d />
     `
 })
@@ -1396,7 +1396,7 @@ class DatepickerWithi18n {
 
 @Component({
     template: `
-        <input [(ngModel)]="value" [kbqDatepicker]="d" [min]="min" [max]="max" />
+        <input [kbqDatepicker]="d" [min]="min" [max]="max" [(ngModel)]="value" />
         <kbq-datepicker #d [startAt]="startAt" />
     `
 })
@@ -1411,7 +1411,7 @@ class DatepickerWithISOStrings {
 
 @Component({
     template: `
-        <input [(ngModel)]="selected" [kbqDatepicker]="d" />
+        <input [kbqDatepicker]="d" [(ngModel)]="selected" />
         <kbq-datepicker #d (opened)="openedSpy()" (closed)="closedSpy()" />
     `
 })

--- a/packages/components/dropdown/dropdown.html
+++ b/packages/components/dropdown/dropdown.html
@@ -5,11 +5,11 @@
         [class.kbq-dropdown__panel_nested]="parent"
         [ngClass]="classList"
         [style.min-width]="triggerWidth"
+        [@transformDropdown]="panelAnimationState"
         (@transformDropdown.done)="onAnimationDone($event)"
         (@transformDropdown.start)="onAnimationStart($event)"
         (click)="close()"
         (keydown)="handleKeydown($event)"
-        [@transformDropdown]="panelAnimationState"
     >
         <div class="kbq-dropdown__content">
             <ng-content />

--- a/packages/components/dropdown/dropdown.karma-spec.ts
+++ b/packages/components/dropdown/dropdown.karma-spec.ts
@@ -186,20 +186,20 @@ describe('KbqDropdown', () => {
 
         <kbq-dropdown #root="kbqDropdown" [hasBackdrop]="true" (closed)="rootCloseCallback($event)">
             <button
-                id="level-one-trigger"
                 #levelOneTrigger="kbqDropdownTrigger"
-                [kbqDropdownTriggerFor]="levelOne"
+                id="level-one-trigger"
                 kbq-dropdown-item
+                [kbqDropdownTriggerFor]="levelOne"
             >
                 One
             </button>
             <button kbq-dropdown-item>Two</button>
             @if (showLazy) {
                 <button
-                    id="lazy-trigger"
                     #lazyTrigger="kbqDropdownTrigger"
-                    [kbqDropdownTriggerFor]="lazy"
+                    id="lazy-trigger"
                     kbq-dropdown-item
+                    [kbqDropdownTriggerFor]="lazy"
                 >
                     Three
                 </button>
@@ -209,10 +209,10 @@ describe('KbqDropdown', () => {
         <kbq-dropdown #levelOne="kbqDropdown" [hasBackdrop]="true" (closed)="levelOneCloseCallback($event)">
             <button kbq-dropdown-item>Four</button>
             <button
-                id="level-two-trigger"
                 #levelTwoTrigger="kbqDropdownTrigger"
-                [kbqDropdownTriggerFor]="levelTwo"
+                id="level-two-trigger"
                 kbq-dropdown-item
+                [kbqDropdownTriggerFor]="levelTwo"
             >
                 Five
             </button>

--- a/packages/components/dropdown/dropdown.spec.ts
+++ b/packages/components/dropdown/dropdown.spec.ts
@@ -1641,8 +1641,8 @@ describe('KbqDropdown default overrides', () => {
     template: `
         <button #triggerEl [kbqDropdownTriggerFor]="dropdown">Toggle dropdown</button>
         <kbq-dropdown
-            class="custom-one custom-two"
             #dropdown="kbqDropdown"
+            class="custom-one custom-two"
             [backdropClass]="backdropClass"
             [hasBackdrop]="true"
             (closed)="closeCallback($event)"
@@ -1760,20 +1760,20 @@ class CustomDropdown {
 
         <kbq-dropdown #root="kbqDropdown" [hasBackdrop]="true" (closed)="rootCloseCallback($event)">
             <button
-                id="level-one-trigger"
                 #levelOneTrigger="kbqDropdownTrigger"
-                [kbqDropdownTriggerFor]="levelOne"
+                id="level-one-trigger"
                 kbq-dropdown-item
+                [kbqDropdownTriggerFor]="levelOne"
             >
                 One
             </button>
             <button kbq-dropdown-item>Two</button>
             @if (showLazy) {
                 <button
-                    id="lazy-trigger"
                     #lazyTrigger="kbqDropdownTrigger"
-                    [kbqDropdownTriggerFor]="lazy"
+                    id="lazy-trigger"
                     kbq-dropdown-item
+                    [kbqDropdownTriggerFor]="lazy"
                 >
                     Three
                 </button>
@@ -1783,10 +1783,10 @@ class CustomDropdown {
         <kbq-dropdown #levelOne="kbqDropdown" [hasBackdrop]="true" (closed)="levelOneCloseCallback($event)">
             <button kbq-dropdown-item>Four</button>
             <button
-                id="level-two-trigger"
                 #levelTwoTrigger="kbqDropdownTrigger"
-                [kbqDropdownTriggerFor]="levelTwo"
+                id="level-two-trigger"
                 kbq-dropdown-item
+                [kbqDropdownTriggerFor]="levelTwo"
             >
                 Five
             </button>
@@ -1831,7 +1831,7 @@ class NestedDropdown {
         <button #rootTriggerEl [kbqDropdownTriggerFor]="root">Toggle dropdown</button>
         <kbq-dropdown #root="kbqDropdown">
             @for (item of items; track item) {
-                <button class="level-one-trigger" [kbqDropdownTriggerFor]="levelOne" kbq-dropdown-item>
+                <button class="level-one-trigger" kbq-dropdown-item [kbqDropdownTriggerFor]="levelOne">
                     {{ item }}
                 </button>
             }
@@ -1855,7 +1855,7 @@ class NestedDropdownRepeater {
         <button #rootTriggerEl [kbqDropdownTriggerFor]="root">Toggle dropdown</button>
 
         <kbq-dropdown #root="kbqDropdown">
-            <button class="level-one-trigger" [kbqDropdownTriggerFor]="levelOne" kbq-dropdown-item>One</button>
+            <button class="level-one-trigger" kbq-dropdown-item [kbqDropdownTriggerFor]="levelOne">One</button>
 
             <kbq-dropdown #levelOne="kbqDropdown">
                 <button class="level-two-item" kbq-dropdown-item>Two</button>

--- a/packages/components/empty-state/empty-state.component.spec.ts
+++ b/packages/components/empty-state/empty-state.component.spec.ts
@@ -50,13 +50,13 @@ describe('KbqEmptyState', () => {
     selector: 'empty-state-with-params',
     template: `
         <kbq-empty-state>
-            <i [fade]="true" [big]="true" [color]="'contrast'" kbq-icon-item="kbq-bell_16" kbq-empty-state-icon></i>
+            <i kbq-icon-item="kbq-bell_16" kbq-empty-state-icon [fade]="true" [big]="true" [color]="'contrast'"></i>
             <div kbq-empty-state-title>kbq-empty-state-title</div>
             <div kbq-empty-state-text>kbq-empty-state-text</div>
             <div kbq-empty-state-actions>
-                <button [kbqStyle]="styles.Transparent" [color]="colors.Theme" kbq-button>Action 1</button>
-                <button [kbqStyle]="styles.Transparent" [color]="colors.Theme" kbq-button>Action 2</button>
-                <button [kbqStyle]="styles.Transparent" [color]="colors.Theme" kbq-button>Action 3</button>
+                <button kbq-button [kbqStyle]="styles.Transparent" [color]="colors.Theme">Action 1</button>
+                <button kbq-button [kbqStyle]="styles.Transparent" [color]="colors.Theme">Action 2</button>
+                <button kbq-button [kbqStyle]="styles.Transparent" [color]="colors.Theme">Action 3</button>
             </div>
         </kbq-empty-state>
     `

--- a/packages/components/file-upload/single-file-upload.component.html
+++ b/packages/components/file-upload/single-file-upload.component.html
@@ -9,7 +9,7 @@
         <div class="dropzone">
             <i kbq-icon="kbq-cloud-arrow-up-o_24" class="kbq-dropzone__icon"></i>
             <!-- prettier-ignore -->
-            <span class="dropzone__text">{{ separatedCaptionText[0] }}<label kbq-link pseudo [disabled]="disabled" [tabIndex]="-1" [for]="inputId">{{ config.browseLink }}<input #input type="file" class="cdk-visually-hidden" [id]="inputId" [accept]="acceptedFiles" [disabled]="disabled" (change)="onFileSelectedViaClick($event)" tabindex="0"></label>{{ separatedCaptionText[1] }}</span>
+            <span class="dropzone__text">{{ separatedCaptionText[0] }}<label kbq-link pseudo [disabled]="disabled" [tabIndex]="-1" [for]="inputId">{{ config.browseLink }}<input #input type="file" class="cdk-visually-hidden" tabindex="0" [id]="inputId" [accept]="acceptedFiles" [disabled]="disabled" (change)="onFileSelectedViaClick($event)"></label>{{ separatedCaptionText[1] }}</span>
         </div>
     } @else {
         @if (file) {

--- a/packages/components/filter-bar/filter-bar.karma-spec.ts
+++ b/packages/components/filter-bar/filter-bar.karma-spec.ts
@@ -498,7 +498,7 @@ describe('KbqFilterBar', () => {
 @Component({
     selector: 'test-app',
     template: `
-        <kbq-filter-bar [(filter)]="activeFilter" [pipeTemplates]="pipeTemplates">
+        <kbq-filter-bar [pipeTemplates]="pipeTemplates" [(filter)]="activeFilter">
             <kbq-filters
                 [filters]="filters"
                 (onChangeFilter)="onChangeFilter($event)"

--- a/packages/components/filter-bar/filter-refresher.ts
+++ b/packages/components/filter-bar/filter-refresher.ts
@@ -6,10 +6,10 @@ import { KbqIconModule } from '@koobiq/components/icon';
     standalone: true,
     selector: 'kbq-filter-refresher, [kbq-filter-refresher]',
     template: `
-        <button [color]="'contrast'" [kbqStyle]="'transparent'" kbq-button>
+        <button kbq-button [color]="'contrast'" [kbqStyle]="'transparent'">
             <i kbq-icon="kbq-arrow-rotate-right_16"></i>
         </button>
-        <button [color]="'contrast'" [kbqStyle]="'transparent'" kbq-button>
+        <button kbq-button [color]="'contrast'" [kbqStyle]="'transparent'">
             <i kbq-icon="kbq-chevron-down_16"></i>
         </button>
     `,

--- a/packages/components/filter-bar/filter-reset.ts
+++ b/packages/components/filter-bar/filter-reset.ts
@@ -7,7 +7,7 @@ import { KbqFilter } from './filter-bar.types';
     standalone: true,
     selector: 'kbq-filter-reset',
     template: `
-        <button [color]="'theme'" [kbqStyle]="'transparent'" (click)="resetFilter()" kbq-button>
+        <button kbq-button [color]="'theme'" [kbqStyle]="'transparent'" (click)="resetFilter()">
             <ng-content>{{ localeData }}</ng-content>
         </button>
     `,

--- a/packages/components/filter-bar/filter-search.ts
+++ b/packages/components/filter-bar/filter-search.ts
@@ -23,12 +23,12 @@ import { KbqFilterBar } from './filter-bar';
     selector: 'kbq-filter-search, [kbq-filter-search]',
     template: `
         <button
+            kbq-button
             [class.kbq-filter_hidden]="isSearchActive"
             [color]="'contrast'"
             [kbqStyle]="'transparent'"
-            (click)="openSearch()"
-            kbq-button
             kbqTooltip="{{ localeData.tooltip }}"
+            (click)="openSearch()"
         >
             <i kbq-icon="kbq-magnifying-glass_16"></i>
         </button>
@@ -37,12 +37,12 @@ import { KbqFilterBar } from './filter-bar';
             <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
 
             <input
-                [formControl]="searchControl"
-                (blur)="onBlur()"
-                (keydown.escape)="onEscape()"
                 autocomplete="off"
                 kbqInput
+                [formControl]="searchControl"
                 placeholder="{{ localeData.placeholder }}"
+                (blur)="onBlur()"
+                (keydown.escape)="onEscape()"
             />
 
             <kbq-cleaner (click)="onClear()" />

--- a/packages/components/filter-bar/filters.html
+++ b/packages/components/filter-bar/filters.html
@@ -33,8 +33,8 @@
     <button
         kbq-button
         kbqFilterBarButton
-        kbqTooltip="{{ localeData.saveNewFilterTooltip }}"
         class="kbq-button_action"
+        kbqTooltip="{{ localeData.saveNewFilterTooltip }}"
         [color]="colors.Empty"
         (click)="openSaveAsNewFilterPopover()"
     >

--- a/packages/components/filter-bar/pipe-add.ts
+++ b/packages/components/filter-bar/pipe-add.ts
@@ -26,12 +26,12 @@ import { getId } from './pipes/base-pipe';
     template: `
         <kbq-select #select [tabIndex]="-1" [multiple]="true" [value]="addedPipes" [compareWith]="compareWith">
             <button
+                kbq-button
+                kbq-select-matcher
                 [color]="'contrast-fade'"
                 [kbqStyle]="'outline'"
                 [ngClass]="{ 'kbq-active': select.panelOpen }"
-                kbq-button
                 kbqTooltip="{{ filterBar.configuration.add.tooltip }}"
-                kbq-select-matcher
             >
                 <i kbq-icon="kbq-plus_16"></i>
             </button>

--- a/packages/components/filter-bar/pipes/pipe-button.ts
+++ b/packages/components/filter-bar/pipes/pipe-button.ts
@@ -22,14 +22,14 @@ import { KbqPipeState } from './pipe-state';
     template: `
         <button
             class="kbq-pipe__remove-button"
+            kbq-button
             [disabled]="pipe.data.disabled"
             [kbqPipeState]="pipe.data"
             [kbqTooltipDisabled]="pipe.data.disabled"
-            (click)="pipe.data.cleanable ? pipe.onClear() : pipe.onRemove()"
-            kbq-button
             kbqTooltip="{{ pipe.data.cleanable ? localeData.clearButtonTooltip : localeData.removeButtonTooltip }}"
+            (click)="pipe.data.cleanable ? pipe.onClear() : pipe.onRemove()"
         >
-            <i [color]="pipe.data.disabled ? 'empty' : 'contrast'" kbq-icon="kbq-xmark-s_16"></i>
+            <i kbq-icon="kbq-xmark-s_16" [color]="pipe.data.disabled ? 'empty' : 'contrast'"></i>
         </button>
     `,
     styleUrl: 'pipe-button.scss',

--- a/packages/components/filter-bar/pipes/pipe-multi-select.html
+++ b/packages/components/filter-bar/pipes/pipe-multi-select.html
@@ -38,8 +38,8 @@
             <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
             <input
                 kbqInput
-                placeholder="{{ localeData.search.placeholder }}"
                 type="text"
+                placeholder="{{ localeData.search.placeholder }}"
                 [formControl]="searchControl"
                 (keydown.enter)="toggleSelectionAllByEnterKey()"
             />

--- a/packages/components/filter-bar/pipes/pipe-multi-tree-select.html
+++ b/packages/components/filter-bar/pipes/pipe-multi-tree-select.html
@@ -19,8 +19,8 @@
         <input
             autocomplete="off"
             kbqInput
-            placeholder="{{ localeData.search.placeholder }}"
             type="text"
+            placeholder="{{ localeData.search.placeholder }}"
             [formControl]="searchControl"
             (keydown.enter)="searchKeydownHandler()"
         />

--- a/packages/components/filter-bar/pipes/pipe-readonly.ts
+++ b/packages/components/filter-bar/pipes/pipe-readonly.ts
@@ -10,9 +10,9 @@ import { KbqPipeTitleDirective } from './pipe-title';
     standalone: true,
     selector: 'kbq-pipe-readonly',
     template: `
-        <button [disabled]="data.disabled" [kbqPipeState]="data" [kbqPipeTitle]="pipeTooltip" kbq-button>
-            <span class="kbq-pipe__name" #kbqTitleText kbqPipeMinWidth>{{ data.name }}</span>
-            <span class="kbq-pipe__value" #kbqTitleText [class.kbq-pipe__value_empty]="!data.value" kbqPipeMinWidth>
+        <button kbq-button [disabled]="data.disabled" [kbqPipeState]="data" [kbqPipeTitle]="pipeTooltip">
+            <span #kbqTitleText class="kbq-pipe__name" kbqPipeMinWidth>{{ data.name }}</span>
+            <span #kbqTitleText class="kbq-pipe__value" kbqPipeMinWidth [class.kbq-pipe__value_empty]="!data.value">
                 {{ data.value }}
             </span>
         </button>

--- a/packages/components/filter-bar/pipes/pipe-select.html
+++ b/packages/components/filter-bar/pipes/pipe-select.html
@@ -32,8 +32,8 @@
             <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
             <input
                 kbqInput
-                placeholder="{{ localeData.search.placeholder }}"
                 type="text"
+                placeholder="{{ localeData.search.placeholder }}"
                 [formControl]="searchControl"
             />
             <kbq-cleaner />

--- a/packages/components/filter-bar/pipes/pipe-tree-select.html
+++ b/packages/components/filter-bar/pipes/pipe-tree-select.html
@@ -16,8 +16,8 @@
         <input
             autocomplete="off"
             kbqInput
-            placeholder="{{ localeData.search.placeholder }}"
             type="text"
+            placeholder="{{ localeData.search.placeholder }}"
             [formControl]="searchControl"
         />
         <kbq-cleaner />

--- a/packages/components/form-field/cleaner.ts
+++ b/packages/components/form-field/cleaner.ts
@@ -11,7 +11,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
     selector: 'kbq-cleaner',
     exportAs: 'kbqCleaner',
     template: `
-        <i [autoColor]="true" color="contrast-fade" kbq-icon-button="kbq-xmark-circle_16"></i>
+        <i color="contrast-fade" kbq-icon-button="kbq-xmark-circle_16" [autoColor]="true"></i>
     `,
     styleUrls: ['cleaner.scss'],
     host: {

--- a/packages/components/form-field/form-field.spec.ts
+++ b/packages/components/form-field/form-field.spec.ts
@@ -100,7 +100,7 @@ const getSubmitButtonNativeElement = (debugElement: DebugElement): HTMLInputElem
     providers: [kbqDisableLegacyValidationDirectiveProvider()],
     template: `
         <kbq-form-field>
-            <input [formControl]="control" kbqInput />
+            <input kbqInput [formControl]="control" />
             <kbq-hint id="test-hint-id">Hint</kbq-hint>
             <kbq-error id="test-error-id">Error</kbq-error>
         </kbq-form-field>
@@ -132,7 +132,7 @@ export class InputFormFieldWithPrefixAndSuffix {}
     providers: [kbqDisableLegacyValidationDirectiveProvider()],
     template: `
         <kbq-form-field>
-            <input [formControl]="control" kbqInput />
+            <input kbqInput [formControl]="control" />
             <kbq-cleaner />
         </kbq-form-field>
     `
@@ -164,7 +164,7 @@ export class InputFormFieldWithoutFormFieldControl {
     template: `
         <kbq-form-field>
             <kbq-label>Label</kbq-label>
-            <input [id]="id" kbqInput />
+            <input kbqInput [id]="id" />
         </kbq-form-field>
     `
 })
@@ -186,7 +186,7 @@ class CustomErrorStateMatcher implements ErrorStateMatcher {
     template: `
         <form [formGroup]="formGroup">
             <kbq-form-field>
-                <input [errorStateMatcher]="errorStateMatcher" formControlName="email" kbqInput />
+                <input formControlName="email" kbqInput [errorStateMatcher]="errorStateMatcher" />
                 <kbq-error id="test-error-id">Error</kbq-error>
             </kbq-form-field>
             <input type="submit" />
@@ -222,7 +222,7 @@ export class InputFormFieldWithBorderCustomization {
     providers: [kbqDisableLegacyValidationDirectiveProvider()],
     template: `
         <kbq-form-field>
-            <input [formControl]="formControl" kbqInputPassword />
+            <input kbqInputPassword [formControl]="formControl" />
             <kbq-password-toggle />
             <kbq-reactive-password-hint
                 id="test-reactive-password-hint-id"

--- a/packages/components/form-field/password-hint.ts
+++ b/packages/components/form-field/password-hint.ts
@@ -44,7 +44,7 @@ export const hasPasswordStrengthError = (passwordHints: QueryList<KbqPasswordHin
     imports: [NgClass, KbqIconModule],
     selector: 'kbq-password-hint',
     template: `
-        <i class="kbq-password-hint__icon" [ngClass]="icon" kbq-icon=""></i>
+        <i class="kbq-password-hint__icon" kbq-icon="" [ngClass]="icon"></i>
 
         <span class="kbq-hint__text">
             <ng-content />

--- a/packages/components/form-field/password-toggle.ts
+++ b/packages/components/form-field/password-toggle.ts
@@ -36,7 +36,7 @@ const getKbqPasswordToggleMissingControlError = (): Error => {
     selector: `kbq-password-toggle`,
     exportAs: 'kbqPasswordToggle',
     template: `
-        <i [ngClass]="iconClass" [autoColor]="true" kbq-icon-button="" color="contrast-fade"></i>
+        <i kbq-icon-button="" color="contrast-fade" [ngClass]="iconClass" [autoColor]="true"></i>
     `,
     styleUrls: ['password-toggle.scss'],
     host: {

--- a/packages/components/form-field/reactive-password-hint.ts
+++ b/packages/components/form-field/reactive-password-hint.ts
@@ -24,7 +24,7 @@ import { KbqHint } from './hint';
     selector: 'kbq-reactive-password-hint',
     exportAs: 'kbqReactivePasswordHint',
     template: `
-        <i [ngClass]="icon()" kbq-icon=""></i>
+        <i kbq-icon="" [ngClass]="icon()"></i>
 
         <span class="kbq-hint__text">
             <ng-content />

--- a/packages/components/form-field/stepper.ts
+++ b/packages/components/form-field/stepper.ts
@@ -28,21 +28,21 @@ const getKbqStepperToggleMissingControlError = (): Error => {
     template: `
         <i
             class="kbq-stepper-step-up"
+            color="contrast-fade"
+            kbq-icon-button="kbq-chevron-up-s_16"
             [tabindex]="-1"
             [autoColor]="true"
             [disabled]="control.disabled"
             (mousedown)="onStepUp($event)"
-            color="contrast-fade"
-            kbq-icon-button="kbq-chevron-up-s_16"
         ></i>
         <i
             class="kbq-stepper-step-down"
+            color="contrast-fade"
+            kbq-icon-button="kbq-chevron-down-s_16"
             [tabindex]="-1"
             [autoColor]="true"
             [disabled]="control.disabled"
             (mousedown)="onStepDown($event)"
-            color="contrast-fade"
-            kbq-icon-button="kbq-chevron-down-s_16"
         ></i>
     `,
     styleUrls: ['stepper.scss'],

--- a/packages/components/form-field/validate.spec.ts
+++ b/packages/components/form-field/validate.spec.ts
@@ -9,7 +9,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     selector: 'test-app',
     template: `
         <kbq-form-field>
-            <input [formControl]="testControl" kbqInput type="text" />
+            <input kbqInput type="text" [formControl]="testControl" />
         </kbq-form-field>
     `
 })

--- a/packages/components/input/input-number.spec.ts
+++ b/packages/components/input/input-number.spec.ts
@@ -49,7 +49,7 @@ function createComponent<T>(component: Type<T>, imports: any[] = [], providers: 
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" kbqNumberInput />
+            <input kbqNumberInput [(ngModel)]="value" />
             <kbq-stepper />
         </kbq-form-field>
     `
@@ -61,7 +61,7 @@ class KbqNumberInputTestComponent {
 @Component({
     template: `
         <kbq-form-field>
-            <input [formControl]="formControl" kbqNumberInput />
+            <input kbqNumberInput [formControl]="formControl" />
             <kbq-stepper />
         </kbq-form-field>
     `
@@ -72,7 +72,7 @@ class KbqNumberInputWithFormControl {
 
 @Component({
     template: `
-        <form [formGroup]="reactiveForm" novalidate>
+        <form novalidate [formGroup]="reactiveForm">
             <kbq-form-field>
                 <input kbqNumberInput formControlName="reactiveInputValue" />
                 <kbq-stepper />
@@ -93,7 +93,7 @@ class KbqNumberInputWithFormControlName {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" kbqNumberInput max="10" min="3" step="0.5" big-step="2" />
+            <input kbqNumberInput max="10" min="3" step="0.5" big-step="2" [(ngModel)]="value" />
             <kbq-stepper />
         </kbq-form-field>
     `
@@ -105,7 +105,7 @@ class KbqNumberInputMaxMinStep {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" [max]="max" [min]="min" [step]="step" [bigStep]="bigStep" kbqNumberInput />
+            <input kbqNumberInput [max]="max" [min]="min" [step]="step" [bigStep]="bigStep" [(ngModel)]="value" />
             <kbq-stepper />
         </kbq-form-field>
     `
@@ -121,7 +121,7 @@ class KbqNumberInputMaxMinStepInput {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" kbqNumberInput />
+            <input kbqNumberInput [(ngModel)]="value" />
             <kbq-cleaner />
         </kbq-form-field>
     `
@@ -134,13 +134,13 @@ class KbqNumberInputWithCleaner {
     template: `
         <kbq-form-field>
             <input
-                [(ngModel)]="value"
+                kbqNumberInput
                 [max]="max"
                 [min]="min"
                 [step]="step"
                 [bigStep]="bigStep"
                 [withThousandSeparator]="withMask"
-                kbqNumberInput
+                [(ngModel)]="value"
             />
             <kbq-stepper />
         </kbq-form-field>
@@ -162,7 +162,7 @@ class KbqNumberInputWithMask {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" [step]="step" [bigStep]="bigStep" [integer]="true" kbqNumberInput />
+            <input kbqNumberInput [step]="step" [bigStep]="bigStep" [integer]="true" [(ngModel)]="value" />
             <kbq-stepper />
         </kbq-form-field>
     `

--- a/packages/components/input/input-password.spec.ts
+++ b/packages/components/input/input-password.spec.ts
@@ -32,7 +32,7 @@ function createComponent<T>(component: Type<T>, imports: any[] = [], providers: 
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" [disabled]="disabled" kbqInputPassword />
+            <input kbqInputPassword [disabled]="disabled" [(ngModel)]="value" />
             <kbq-password-toggle
                 [kbqTooltipNotHidden]="'Скрыть пароль'"
                 [kbqTooltipDisabled]="disabled"
@@ -65,7 +65,7 @@ class KbqPasswordInputDefault {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" kbqInputPassword />
+            <input kbqInputPassword [(ngModel)]="value" />
             <kbq-password-toggle [kbqTooltipNotHidden]="'Скрыть пароль'" [kbqTooltipHidden]="'Показать пароль'" />
 
             <kbq-password-hint [rule]="passwordRules.Custom" [regex]="regex" [checkRule]="checkFunc">
@@ -84,7 +84,7 @@ class KbqPasswordInputCustomPasswordRulesUndefined {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" [disabled]="disabled" kbqInputPassword />
+            <input kbqInputPassword [disabled]="disabled" [(ngModel)]="value" />
             <kbq-password-toggle [kbqTooltipNotHidden]="'Скрыть пароль'" [kbqTooltipHidden]="'Показать пароль'" />
 
             <kbq-password-hint [rule]="passwordRules.Custom" [regex]="regex" [checkRule]="checkFunc">
@@ -115,7 +115,7 @@ class KbqPasswordInputCustomPasswordRule {
     template: `
         <form [formGroup]="form">
             <kbq-form-field>
-                <input [formControl]="form.controls.control" kbqInputPassword />
+                <input kbqInputPassword [formControl]="form.controls.control" />
             </kbq-form-field>
         </form>
     `

--- a/packages/components/input/input.karma-spec.ts
+++ b/packages/components/input/input.karma-spec.ts
@@ -23,7 +23,7 @@ function createComponent<T>(component: Type<T>, imports: any[] = [], providers: 
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" kbqInput />
+            <input kbqInput [(ngModel)]="value" />
             <kbq-cleaner />
         </kbq-form-field>
     `

--- a/packages/components/input/input.spec.ts
+++ b/packages/components/input/input.spec.ts
@@ -29,7 +29,7 @@ function createComponent<T>(component: Type<T>, imports: any[] = [], providers: 
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" [required]="true" kbqInput minlength="4" />
+            <input kbqInput minlength="4" [required]="true" [(ngModel)]="value" />
         </kbq-form-field>
     `
 })
@@ -40,7 +40,7 @@ class KbqInputInvalid {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" kbqInput kbqInputMonospace />
+            <input kbqInput kbqInputMonospace [(ngModel)]="value" />
         </kbq-form-field>
     `
 })
@@ -51,7 +51,7 @@ class KbqInputWithKbqInputMonospace {
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" [placeholder]="placeholder" [disabled]="disabled" kbqInput />
+            <input kbqInput [placeholder]="placeholder" [disabled]="disabled" [(ngModel)]="value" />
         </kbq-form-field>
     `
 })
@@ -103,7 +103,7 @@ class KbqFormFieldWithoutBorders {}
 @Component({
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="value" kbqInput required />
+            <input kbqInput required [(ngModel)]="value" />
         </kbq-form-field>
     `
 })
@@ -115,7 +115,7 @@ class KbqFormFieldWithStandaloneNgModel {
     template: `
         <form #form="ngForm">
             <kbq-form-field>
-                <input [(ngModel)]="value" kbqInput name="control" required />
+                <input kbqInput name="control" required [(ngModel)]="value" />
             </kbq-form-field>
 
             <button type="submit"></button>
@@ -137,7 +137,7 @@ class KbqFormFieldWithNgModelInForm {
             <kbq-form-field class="kbq-form__control">
                 <input kbqInput formControlName="lastName" />
             </kbq-form-field>
-            <button [color]="ThemePalette.Primary" [disabled]="reactiveForm.invalid" kbq-button type="submit">
+            <button kbq-button type="submit" [color]="ThemePalette.Primary" [disabled]="reactiveForm.invalid">
                 Отправить
             </button>
         </form>

--- a/packages/components/link/link.component.spec.ts
+++ b/packages/components/link/link.component.spec.ts
@@ -92,7 +92,7 @@ class KbqLinkBaseTestApp {}
 @Component({
     selector: 'kbq-link-print-test-app',
     template: `
-        <a [print]="print" href="http://localhost:3003/" kbq-link>Отчет сканирования</a>
+        <a href="http://localhost:3003/" kbq-link [print]="print">Отчет сканирования</a>
     `
 })
 class KbqLinkPrintTestApp {

--- a/packages/components/list/list-selection.component.karma-spec.ts
+++ b/packages/components/list/list-selection.component.karma-spec.ts
@@ -63,7 +63,7 @@ describe('should update model after keyboard interaction with multiple mode = ch
 
 @Component({
     template: `
-        <kbq-list-selection [(ngModel)]="model" [autoSelect]="false" [noUnselectLast]="false" multiple="checkbox">
+        <kbq-list-selection multiple="checkbox" [autoSelect]="false" [noUnselectLast]="false" [(ngModel)]="model">
             <kbq-list-option [value]="'value1'">value1</kbq-list-option>
             <kbq-list-option [value]="'value2'">value2</kbq-list-option>
             <kbq-list-option [value]="'value3'">value3</kbq-list-option>

--- a/packages/components/list/list-selection.component.spec.ts
+++ b/packages/components/list/list-selection.component.spec.ts
@@ -868,7 +868,7 @@ describe('should update model after keyboard interaction with multiple mode = ch
 
 @Component({
     template: `
-        <mat-selection-list [(ngModel)]="selectedOptions" [compareWith]="compareWith">
+        <mat-selection-list [compareWith]="compareWith" [(ngModel)]="selectedOptions">
             @for (option of options; track option) {
                 <mat-list-option [value]="option">
                     {{ option.label }}
@@ -897,18 +897,18 @@ class SelectionListWithCustomComparator {
     template: `
         <kbq-list-selection
             id="selection-list-1"
+            multiple="keyboard"
             [autoSelect]="false"
             [noUnselectLast]="false"
             (selectionChange)="onValueChange($event)"
-            multiple="keyboard"
         >
-            <kbq-list-option [value]="'inbox'" checkboxPosition="before" disabled="true">
+            <kbq-list-option checkboxPosition="before" disabled="true" [value]="'inbox'">
                 Inbox (disabled selection-option)
             </kbq-list-option>
-            <kbq-list-option id="testSelect" [value]="'starred'" checkboxPosition="before">Starred</kbq-list-option>
-            <kbq-list-option [value]="'sent-mail'" checkboxPosition="before">Sent Mail</kbq-list-option>
+            <kbq-list-option id="testSelect" checkboxPosition="before" [value]="'starred'">Starred</kbq-list-option>
+            <kbq-list-option checkboxPosition="before" [value]="'sent-mail'">Sent Mail</kbq-list-option>
             @if (showLastOption) {
-                <kbq-list-option [value]="'drafts'" checkboxPosition="before">Drafts</kbq-list-option>
+                <kbq-list-option checkboxPosition="before" [value]="'drafts'">Drafts</kbq-list-option>
             }
         </kbq-list-selection>
     `
@@ -921,7 +921,7 @@ class SelectionListWithListOptions {
 
 @Component({
     template: `
-        <kbq-list-selection [(ngModel)]="model" [autoSelect]="false" [noUnselectLast]="false" multiple="checkbox">
+        <kbq-list-selection multiple="checkbox" [autoSelect]="false" [noUnselectLast]="false" [(ngModel)]="model">
             <kbq-list-option [value]="'value1'">value1</kbq-list-option>
             <kbq-list-option [value]="'value2'">value2</kbq-list-option>
             <kbq-list-option [value]="'value3'">value3</kbq-list-option>
@@ -1001,7 +1001,7 @@ class SelectionListWithTabindexInDisabledState {
 
 @Component({
     template: `
-        <kbq-list-selection [(ngModel)]="selectedOptions" [autoSelect]="false">
+        <kbq-list-selection [autoSelect]="false" [(ngModel)]="selectedOptions">
             <kbq-list-option [value]="'opt1'">Option 1</kbq-list-option>
             <kbq-list-option [value]="'opt2'">Option 2</kbq-list-option>
             @if (renderLastOption) {
@@ -1032,7 +1032,7 @@ class SelectionListWithFormControl {
     template: `
         <kbq-list-selection [(ngModel)]="selectedOptions">
             <kbq-list-option [value]="'opt1'">Option 1</kbq-list-option>
-            <kbq-list-option [value]="'opt2'" selected>Option 2</kbq-list-option>
+            <kbq-list-option selected [value]="'opt2'">Option 2</kbq-list-option>
         </kbq-list-selection>
     `
 })
@@ -1044,7 +1044,7 @@ class SelectionListWithPreselectedOption {
     template: `
         <kbq-list-selection [(ngModel)]="selectedOptions">
             <kbq-list-option [value]="'opt1'">Option 1</kbq-list-option>
-            <kbq-list-option [value]="'opt2'" selected>Option 2</kbq-list-option>
+            <kbq-list-option selected [value]="'opt2'">Option 2</kbq-list-option>
         </kbq-list-selection>
     `
 })

--- a/packages/components/loader-overlay/loader-overlay.component.spec.ts
+++ b/packages/components/loader-overlay/loader-overlay.component.spec.ts
@@ -122,9 +122,9 @@ class OverlayNoParams {}
 
             <kbq-loader-overlay>
                 <kbq-progress-spinner
+                    kbq-loader-overlay-indicator
                     [mode]="'indeterminate'"
                     [color]="themePalette.Error"
-                    kbq-loader-overlay-indicator
                 />
 
                 <div kbq-loader-overlay-text>Создание отчета</div>

--- a/packages/components/markdown/markdown.component.ts
+++ b/packages/components/markdown/markdown.component.ts
@@ -32,7 +32,7 @@ export const kbqMarkdownMarkedOptionsProvider = (options: MarkedOptions): Provid
     styleUrls: ['./markdown.scss', 'markdown-tokens.scss'],
     // no need format line with ng-content it's broke textContent for markdownService.parseToHtml()
     template: `
-        <pre class="markdown-input" #contentWrapper ngPreserveWhitespaces><ng-content /></pre>
+        <pre #contentWrapper class="markdown-input" ngPreserveWhitespaces><ng-content /></pre>
         <div class="markdown-output" [innerHtml]="resultHtml"></div>
     `,
     host: {

--- a/packages/components/modal/modal.directive.ts
+++ b/packages/components/modal/modal.directive.ts
@@ -11,12 +11,12 @@ import { KbqModalComponent } from './modal.component';
         @if (modal.kbqClosable) {
             <button
                 class="kbq-modal-close kbq-button_transparent"
-                [color]="'contrast'"
-                (click)="modal.onClickCloseBtn()"
                 type="button"
                 kbq-button
+                [color]="'contrast'"
+                (click)="modal.onClickCloseBtn()"
             >
-                <i [color]="modal.componentColors.Contrast" kbq-icon="kbq-xmark_16"></i>
+                <i kbq-icon="kbq-xmark_16" [color]="modal.componentColors.Contrast"></i>
             </button>
         }
     `,

--- a/packages/components/modal/modal.karma-spec.ts
+++ b/packages/components/modal/modal.karma-spec.ts
@@ -68,11 +68,11 @@ describe('KbqModal', () => {
 @Component({
     selector: 'kbq-modal-by-service-from-dropdown',
     template: `
-        <kbq-modal [(kbqVisible)]="nonServiceModalVisible" kbqWrapClassName="__NON_SERVICE_ID_SUFFIX__" />
-        <button class="template-button" [kbqDropdownTriggerFor]="dropdown" kbq-button>Open modal from dropdown</button>
+        <kbq-modal kbqWrapClassName="__NON_SERVICE_ID_SUFFIX__" [(kbqVisible)]="nonServiceModalVisible" />
+        <button class="template-button" kbq-button [kbqDropdownTriggerFor]="dropdown">Open modal from dropdown</button>
         <kbq-dropdown #dropdown>
             <ng-template kbqDropdownContent>
-                <button (click)="showConfirm()" kbq-dropdown-item>open Component Modal</button>
+                <button kbq-dropdown-item (click)="showConfirm()">open Component Modal</button>
             </ng-template>
         </kbq-dropdown>
     `,

--- a/packages/components/modal/modal.spec.ts
+++ b/packages/components/modal/modal.spec.ts
@@ -554,7 +554,7 @@ export class CustomModalComponent {
     ],
     imports: [KbqModalModule, KbqButtonModule],
     template: `
-        <button (click)="open()" kbq-button>Button</button>
+        <button kbq-button (click)="open()">Button</button>
     `
 })
 export class CustomComponent {
@@ -581,7 +581,7 @@ class TestModalContentComponent {}
 @Component({
     selector: 'kbq-modal-by-service',
     template: `
-        <kbq-modal [(kbqVisible)]="nonServiceModalVisible" kbqWrapClassName="__NON_SERVICE_ID_SUFFIX__" />
+        <kbq-modal kbqWrapClassName="__NON_SERVICE_ID_SUFFIX__" [(kbqVisible)]="nonServiceModalVisible" />
         <button kbq-button>focusable button</button>
     `,
     // Testing for service with parent service

--- a/packages/components/navbar/navbar-item.component.ts
+++ b/packages/components/navbar/navbar-item.component.ts
@@ -538,9 +538,9 @@ export class KbqNavbarItem extends KbqTooltipTrigger implements AfterContentInit
     template: `
         @if (!customIcon) {
             <i
+                kbq-icon
                 [class.kbq-chevron-left_16]="navbar.expanded"
                 [class.kbq-chevron-right_16]="!navbar.expanded"
-                kbq-icon
             ></i>
         }
 

--- a/packages/components/overflow-items/overflow-items.karma-spec.ts
+++ b/packages/components/overflow-items/overflow-items.karma-spec.ts
@@ -43,11 +43,11 @@ const isOverflowItemsResultVisible = (debugElement: DebugElement): boolean => {
     template: `
         <div
             #kbqOverflowItems="kbqOverflowItems"
+            kbqOverflowItems
             [style.width.px]="containerWidth()"
             [reverseOverflowOrder]="reverseOverflowOrder()"
-            kbqOverflowItems
         >
-            <div [style.width.px]="resultWidth()" [style.flex-shrink]="0" kbqOverflowItemsResult>
+            <div kbqOverflowItemsResult [style.width.px]="resultWidth()" [style.flex-shrink]="0">
                 and {{ kbqOverflowItems.hiddenItemIDs().size }} more
             </div>
             @for (item of items; track item) {
@@ -73,19 +73,19 @@ export class TestOverflowItems {
     template: `
         <div
             #kbqOverflowItemsReverse="kbqOverflowItems"
-            [style.width.px]="containerWidth()"
             reverseOverflowOrder
             kbqOverflowItems
+            [style.width.px]="containerWidth()"
         >
             <div
+                kbqOverflowItem="lastHiddenItem"
                 [style.width.px]="itemWidth()"
                 [style.flex-shrink]="0"
                 [order]="items.length + 1"
-                kbqOverflowItem="lastHiddenItem"
             >
                 lastHiddenItem
             </div>
-            <div [style.width.px]="resultWidth()" [style.flex-shrink]="0" kbqOverflowItemsResult>
+            <div kbqOverflowItemsResult [style.width.px]="resultWidth()" [style.flex-shrink]="0">
                 and {{ kbqOverflowItemsReverse.hiddenItemIDs().size }} more
             </div>
             @for (item of items; track item) {
@@ -110,7 +110,7 @@ export class TestOrderedOverflowItems {
     imports: [KbqOverflowItemsModule],
     selector: 'overflow-items-test',
     template: `
-        <div #kbqOverflowItemsReverse="kbqOverflowItems" [style.width.px]="containerWidth()" kbqOverflowItems>
+        <div #kbqOverflowItemsReverse="kbqOverflowItems" kbqOverflowItems [style.width.px]="containerWidth()">
             @for (item of items; track item) {
                 @let alwaysVisible = $index === 3;
                 <div
@@ -122,7 +122,7 @@ export class TestOrderedOverflowItems {
                     {{ item }}
                 </div>
             }
-            <div [style.width.px]="resultWidth()" [style.flex-shrink]="0" kbqOverflowItemsResult>
+            <div kbqOverflowItemsResult [style.width.px]="resultWidth()" [style.flex-shrink]="0">
                 and {{ kbqOverflowItemsReverse.hiddenItemIDs().size }} more
             </div>
         </div>

--- a/packages/components/popover/popover-confirm.component.html
+++ b/packages/components/popover/popover-confirm.component.html
@@ -3,9 +3,9 @@
     cdkTrapFocusAutoCapture="true"
     class="kbq-popover-confirm kbq-popover"
     [ngClass]="classMap"
+    [@state]="visibility"
     (@state.done)="animationDone($event)"
     (@state.start)="animationStart()"
-    [@state]="visibility"
 >
     <div class="kbq-popover__container">
         <div class="kbq-popover__content">

--- a/packages/components/popover/popover.component.html
+++ b/packages/components/popover/popover.component.html
@@ -3,9 +3,9 @@
     class="kbq-popover"
     [cdkTrapFocus]="isTrapFocus"
     [ngClass]="classMap"
+    [@state]="visibility"
     (@state.done)="animationDone($event)"
     (@state.start)="animationStart()"
-    [@state]="visibility"
 >
     <div
         class="kbq-popover__container"

--- a/packages/components/popover/popover.spec.ts
+++ b/packages/components/popover/popover.spec.ts
@@ -363,7 +363,7 @@ describe('KbqPopover', () => {
     standalone: true,
     selector: 'popover-simple',
     template: `
-        <button [kbqPopoverContent]="'test'" kbqPopover>Popover Trigger</button>
+        <button kbqPopover [kbqPopoverContent]="'test'">Popover Trigger</button>
     `,
     imports: [
         KbqPopoverModule
@@ -380,24 +380,24 @@ export class PopoverSimple {
     imports: [KbqPopoverModule],
     selector: 'kbq-popover-test-component',
     template: `
-        <button #test1 [kbqTrigger]="'hover'" [kbqPopoverContent]="'_TEST1'" kbqPopover>_TEST1asdasd</button>
+        <button #test1 kbqPopover [kbqTrigger]="'hover'" [kbqPopoverContent]="'_TEST1'">_TEST1asdasd</button>
         <button
             #test2
-            [kbqTrigger]="'manual'"
-            [kbqPopoverVisible]="popoverVisibility"
             kbqPopover
             kbqPopoverContent="_TEST2"
+            [kbqTrigger]="'manual'"
+            [kbqPopoverVisible]="popoverVisibility"
         >
             _TEST2
         </button>
-        <button #test3 [kbqTrigger]="'focus'" [kbqPopoverContent]="'_TEST3'" kbqPopover>_TEST3</button>
+        <button #test3 kbqPopover [kbqTrigger]="'focus'" [kbqPopoverContent]="'_TEST3'">_TEST3</button>
 
-        <button #test4 [kbqTrigger]="'hover'" [kbqPopoverHeader]="'_TEST4'" kbqPopover>_TEST4</button>
-        <button #test5 [kbqTrigger]="'hover'" [kbqPopoverContent]="'_TEST5'" kbqPopover>_TEST5</button>
-        <button #test6 [kbqTrigger]="'hover'" [kbqPopoverFooter]="'_TEST6'" kbqPopover>_TEST6</button>
+        <button #test4 kbqPopover [kbqTrigger]="'hover'" [kbqPopoverHeader]="'_TEST4'">_TEST4</button>
+        <button #test5 kbqPopover [kbqTrigger]="'hover'" [kbqPopoverContent]="'_TEST5'">_TEST5</button>
+        <button #test6 kbqPopover [kbqTrigger]="'hover'" [kbqPopoverFooter]="'_TEST6'">_TEST6</button>
 
-        <button #test7 [kbqPopoverClass]="'_TEST7'" [kbqPopoverContent]="'_TEST7'" kbqPopover>_TEST7</button>
-        <button #test8 [kbqPopoverClass]="'_TEST8'" [kbqPopoverContent]="'_TEST8'" kbqPopover>_TEST8</button>
+        <button #test7 kbqPopover [kbqPopoverClass]="'_TEST7'" [kbqPopoverContent]="'_TEST7'">_TEST7</button>
+        <button #test8 kbqPopover [kbqPopoverClass]="'_TEST8'" [kbqPopoverContent]="'_TEST8'">_TEST8</button>
     `
 })
 class KbqPopoverTestComponent {
@@ -421,7 +421,7 @@ class KbqPopoverTestComponent {
         <button #test8 kbqPopoverConfirm>_TEST8</button>
         <button #test9 kbqPopoverConfirm kbqPopoverConfirmText="new confirm text">_TEST9</button>
         <button #test10 kbqPopoverConfirm kbqPopoverConfirmButtonText="new button text">_TEST10</button>
-        <button #test11 (confirm)="onConfirm()" kbqPopoverConfirm>_TEST11</button>
+        <button #test11 kbqPopoverConfirm (confirm)="onConfirm()">_TEST11</button>
     `
 })
 class KbqPopoverConfirmTestComponent {

--- a/packages/components/radio/radio.spec.ts
+++ b/packages/components/radio/radio.spec.ts
@@ -316,11 +316,11 @@ describe('MсRadio', () => {
 @Component({
     template: `
         <kbq-radio-group
+            name="test-name"
             [disabled]="isGroupDisabled"
             [labelPosition]="labelPos"
             [required]="isGroupRequired"
             [value]="groupValue"
-            name="test-name"
         >
             <kbq-radio-button [value]="'fire'" [disabled]="isFirstDisabled" [color]="color">
                 Charmander

--- a/packages/components/scrollbar/scrollbar.component.spec.ts
+++ b/packages/components/scrollbar/scrollbar.component.spec.ts
@@ -103,13 +103,13 @@ describe(KbqScrollbarModule.name, () => {
 @Component({
     template: `
         <div
+            style="height: 300px; max-width: 200px; overflow: auto"
+            kbq-scrollbar
             [options]="options"
             [events]="events"
             (onUpdate)="update()"
             (onInitialize)="initialize()"
             (onScroll)="scroll($event)"
-            style="height: 300px; max-width: 200px; overflow: auto"
-            kbq-scrollbar
         >
             <div style="width: 400px">
                 Vivamus suscipit tortor eget felis porttitor volutpat. Vivamus magna justo, lacinia eget consectetur

--- a/packages/components/scrollbar/scrollbar.component.ts
+++ b/packages/components/scrollbar/scrollbar.component.ts
@@ -53,11 +53,11 @@ const filterEvents = (emits: KbqScrollbarEvents, events: KbqScrollbarEvents) =>
     template: `
         <div
             #content
+            data-overlayscrollbars-contents=""
+            kbqScrollbar
             [options]="options"
             [events]="mergeEvents()"
             [defer]="defer"
-            data-overlayscrollbars-contents=""
-            kbqScrollbar
         >
             <ng-content />
         </div>

--- a/packages/components/select/select.component.karma-spec.ts
+++ b/packages/components/select/select.component.karma-spec.ts
@@ -236,7 +236,7 @@ const OPTIONS = [
     template: `
         <div [style.height.px]="heightAbove"></div>
         <kbq-form-field>
-            <kbq-select [formControl]="control" [required]="isRequired" [panelClass]="panelClass" placeholder="Food">
+            <kbq-select placeholder="Food" [formControl]="control" [required]="isRequired" [panelClass]="panelClass">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value" [disabled]="food.disabled">
                         {{ food.viewValue }}
@@ -247,9 +247,9 @@ const OPTIONS = [
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -284,7 +284,7 @@ class BasicSelect {
     selector: 'ng-model-select',
     template: `
         <kbq-form-field>
-            <kbq-select [disabled]="isDisabled" placeholder="Food" ngModel>
+            <kbq-select placeholder="Food" ngModel [disabled]="isDisabled">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -312,7 +312,7 @@ class NgModelSelect {
         @if (isShowing) {
             <div>
                 <kbq-form-field>
-                    <kbq-select [formControl]="control" placeholder="Food I want to eat right now">
+                    <kbq-select placeholder="Food I want to eat right now" [formControl]="control">
                         @for (food of foods; track food) {
                             <kbq-option [value]="food.value">
                                 {{ food.viewValue }}
@@ -367,7 +367,7 @@ class BasicSelectNoPlaceholder {}
     selector: 'select-with-groups',
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" placeholder="Pokemon">
+            <kbq-select placeholder="Pokemon" [formControl]="control">
                 @for (group of pokemonTypes; track group) {
                     <kbq-optgroup [label]="group.name" [disabled]="group.disabled">
                         @for (pokemon of group.pokemon; track pokemon) {
@@ -429,11 +429,11 @@ class SelectWithGroups {
         <kbq-form-field>
             <kbq-select>
                 <kbq-option [value]="'value1'">Not long text</kbq-option>
-                <kbq-option [value]="'value2'" style="max-width: 200px;">
+                <kbq-option style="max-width: 200px;" [value]="'value2'">
                     Long long long long Long long long long Long long long long Long long long long Long long long long
                     Long long long long text
                 </kbq-option>
-                <kbq-option [value]="'value3'" style="max-width: 200px;">
+                <kbq-option style="max-width: 200px;" [value]="'value3'">
                     {{ changingLabel }}
                 </kbq-option>
                 <ng-template #kbqSelectTagContent let-option let-select="select">
@@ -441,9 +441,9 @@ class SelectWithGroups {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -466,7 +466,7 @@ class SelectWithLongOptionText {
     selector: 'cdk-virtual-scroll-viewport-select',
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="values" [multiple]="true" [style]="style">
+            <kbq-select [multiple]="true" [style]="style" [(value)]="values">
                 <cdk-virtual-scroll-viewport [itemSize]="itemSize" [minBufferPx]="100" [maxBufferPx]="400">
                     <kbq-option *cdkVirtualFor="let option of options; templateCacheSize: 0" [value]="option">
                         {{ option }}

--- a/packages/components/select/select.component.spec.ts
+++ b/packages/components/select/select.component.spec.ts
@@ -231,11 +231,11 @@ const OPTIONS = [
         <div [style.height.px]="heightAbove"></div>
         <kbq-form-field>
             <kbq-select
+                placeholder="Food"
                 [formControl]="control"
                 [required]="isRequired"
                 [tabIndex]="tabIndexOverride"
                 [panelClass]="panelClass"
-                placeholder="Food"
             >
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value" [disabled]="food.disabled">
@@ -247,9 +247,9 @@ const OPTIONS = [
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -302,9 +302,9 @@ class BasicSelect {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -366,9 +366,9 @@ class ManySelects {}
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -398,7 +398,7 @@ class SelectWithChangeEvent {
         <kbq-form-field>
             <kbq-select #select [(value)]="singleSelectedWithSearch">
                 <kbq-form-field kbqSelectSearch>
-                    <input [formControl]="searchCtrl" kbqInput type="text" />
+                    <input kbqInput type="text" [formControl]="searchCtrl" />
                 </kbq-form-field>
 
                 @for (option of options$ | async; track option) {
@@ -411,9 +411,9 @@ class SelectWithChangeEvent {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -517,7 +517,7 @@ class ThrowsErrorOnInit implements OnInit {
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" placeholder="Food">
+            <kbq-select placeholder="Food" [formControl]="control">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -541,7 +541,7 @@ class BasicSelectOnPush {
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" placeholder="Food">
+            <kbq-select placeholder="Food" [formControl]="control">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -564,7 +564,7 @@ class BasicSelectOnPushPreselected {
     selector: 'multi-select',
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" [sortComparator]="sortComparator" multiple placeholder="Food">
+            <kbq-select multiple placeholder="Food" [formControl]="control" [sortComparator]="sortComparator">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -575,9 +575,9 @@ class BasicSelectOnPushPreselected {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -609,11 +609,11 @@ class MultiSelect {
     template: `
         <kbq-form-field>
             <kbq-select
-                [formControl]="control"
-                [sortComparator]="sortComparator"
                 multiple
                 placeholder="Food"
                 style="width: 100px;"
+                [formControl]="control"
+                [sortComparator]="sortComparator"
             >
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
@@ -625,9 +625,9 @@ class MultiSelect {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -697,7 +697,7 @@ class BasicSelectWithTheming {
     selector: 'reset-values-select',
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" placeholder="Food">
+            <kbq-select placeholder="Food" [formControl]="control">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -709,9 +709,9 @@ class BasicSelectWithTheming {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -748,9 +748,9 @@ class ResetValuesSelect {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -772,7 +772,7 @@ class FalsyValueSelect {
     selector: 'select-with-groups',
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" placeholder="Pokemon">
+            <kbq-select placeholder="Pokemon" [formControl]="control">
                 @for (group of pokemonTypes; track group) {
                     <kbq-optgroup [label]="group.name" [disabled]="group.disabled">
                         @for (pokemon of group.pokemon; track pokemon) {
@@ -832,7 +832,7 @@ class SelectWithGroups {
     selector: 'select-with-groups',
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" placeholder="Pokemon">
+            <kbq-select placeholder="Pokemon" [formControl]="control">
                 @for (group of pokemonTypes; track group) {
                     <kbq-optgroup [label]="group.name" [disabled]="group.disabled">
                         @for (pokemon of group.pokemon; track pokemon) {
@@ -896,7 +896,7 @@ class SelectInsideFormGroup {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="selectedFood" placeholder="Food">
+            <kbq-select placeholder="Food" [(value)]="selectedFood">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -922,7 +922,7 @@ class BasicSelectWithoutForms {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="selectedFood" placeholder="Food">
+            <kbq-select placeholder="Food" [(value)]="selectedFood">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -945,7 +945,7 @@ class BasicSelectWithoutFormsPreselected {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="selectedFoods" placeholder="Food" multiple>
+            <kbq-select placeholder="Food" multiple [(value)]="selectedFoods">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -970,7 +970,7 @@ class BasicSelectWithoutFormsMultiple {
     selector: 'select-with-custom-trigger',
     template: `
         <kbq-form-field>
-            <kbq-select #select="kbqSelect" [formControl]="control" placeholder="Food">
+            <kbq-select #select="kbqSelect" placeholder="Food" [formControl]="control">
                 <kbq-select__trigger>
                     {{ select.selected?.viewValue.split('').reverse().join('') }}
                 </kbq-select__trigger>
@@ -1006,9 +1006,9 @@ class SelectWithCustomTrigger {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -1056,7 +1056,7 @@ class NgModelCompareWithSelect {
 
 @Component({
     template: `
-        <kbq-select [formControl]="control" [errorStateMatcher]="errorStateMatcher" placeholder="Food">
+        <kbq-select placeholder="Food" [formControl]="control" [errorStateMatcher]="errorStateMatcher">
             @for (food of foods; track food) {
                 <kbq-option [value]="food.value">
                     {{ food.viewValue }}
@@ -1078,7 +1078,7 @@ class CustomErrorBehaviorSelect {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-select [(ngModel)]="selectedFoods" placeholder="Food">
+            <kbq-select placeholder="Food" [(ngModel)]="selectedFoods">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -1105,7 +1105,7 @@ class SingleSelectWithPreselectedArrayValues {
     selector: 'select-without-option-centering',
     template: `
         <kbq-form-field>
-            <kbq-select [formControl]="control" placeholder="Food">
+            <kbq-select placeholder="Food" [formControl]="control">
                 @for (food of foods; track food) {
                     <kbq-option [value]="food.value">
                         {{ food.viewValue }}
@@ -1153,11 +1153,11 @@ class SelectWithFormFieldLabel {
         <kbq-form-field>
             <kbq-select>
                 <kbq-option [value]="'value1'">Not long text</kbq-option>
-                <kbq-option [value]="'value2'" style="max-width: 200px;">
+                <kbq-option style="max-width: 200px;" [value]="'value2'">
                     Long long long long Long long long long Long long long long Long long long long Long long long long
                     Long long long long text
                 </kbq-option>
-                <kbq-option [value]="'value3'" style="max-width: 200px;">
+                <kbq-option style="max-width: 200px;" [value]="'value3'">
                     {{ changingLabel }}
                 </kbq-option>
                 <ng-template #kbqSelectTagContent let-option let-select="select">
@@ -1165,9 +1165,9 @@ class SelectWithFormFieldLabel {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -1190,7 +1190,7 @@ class SelectWithLongOptionText {
     selector: 'multiple-select-with-customized-tag-content',
     template: `
         <kbq-form-field>
-            <kbq-select #select [multiple]="true" [value]="selected" style="max-width: 300px">
+            <kbq-select #select style="max-width: 300px" [multiple]="true" [value]="selected">
                 <kbq-option [value]="'value1'">value</kbq-option>
                 <kbq-option [value]="'value2'">value2</kbq-option>
                 <kbq-option [value]="'value3'">value3</kbq-option>
@@ -1202,9 +1202,9 @@ class SelectWithLongOptionText {
                         {{ option.viewValue }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 kbqTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>
@@ -1224,7 +1224,7 @@ class MultiSelectWithCustomizedTagContent {
     selector: 'cdk-virtual-scroll-viewport-select',
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="values" [multiple]="true" [style]="style">
+            <kbq-select [multiple]="true" [style]="style" [(value)]="values">
                 <cdk-virtual-scroll-viewport [itemSize]="itemSize" [minBufferPx]="100" [maxBufferPx]="400">
                     <kbq-option *cdkVirtualFor="let option of options; templateCacheSize: 0" [value]="option">
                         {{ option }}
@@ -1255,7 +1255,7 @@ class CdkVirtualScrollViewportSelect<T = string> {
     selector: 'cdk-virtual-scroll-viewport-select-option-as-object',
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="values" [multiple]="true" [style]="style">
+            <kbq-select [multiple]="true" [style]="style" [(value)]="values">
                 <cdk-virtual-scroll-viewport [itemSize]="itemSize" [minBufferPx]="100" [maxBufferPx]="400">
                     <kbq-option *cdkVirtualFor="let option of options; templateCacheSize: 0" [value]="option">
                         {{ option.name }}
@@ -1267,9 +1267,9 @@ class CdkVirtualScrollViewportSelect<T = string> {
                         {{ option.value.name }}
                         @if (!option.disabled && !select.disabled) {
                             <i
-                                (click)="select.onRemoveMatcherItem(option, $event)"
                                 kbq-icon="kbq-xmark-s_16"
                                 mcTagRemove
+                                (click)="select.onRemoveMatcherItem(option, $event)"
                             ></i>
                         }
                     </kbq-tag>

--- a/packages/components/select/select.html
+++ b/packages/components/select/select.html
@@ -125,8 +125,8 @@
         <div
             #optionsContainer
             class="kbq-select__content kbq-scrollbar"
-            (@fadeInContent.done)="panelDoneAnimatingStream.next($event.toState)"
             [@fadeInContent]="'showing'"
+            (@fadeInContent.done)="panelDoneAnimatingStream.next($event.toState)"
         >
             @if (isEmptySearchResult) {
                 <div class="kbq-select__no-options-message">

--- a/packages/components/sidepanel/sidepanel-directives.ts
+++ b/packages/components/sidepanel/sidepanel-directives.ts
@@ -67,8 +67,8 @@ export class KbqSidepanelClose implements OnInit, OnChanges {
         </div>
 
         @if (closeable) {
-            <button [color]="'contrast'" [kbqStyle]="'transparent'" kbq-button kbq-sidepanel-close>
-                <i [color]="'contrast'" kbq-icon="kbq-xmark_16"></i>
+            <button kbq-button kbq-sidepanel-close [color]="'contrast'" [kbqStyle]="'transparent'">
+                <i kbq-icon="kbq-xmark_16" [color]="'contrast'"></i>
             </button>
         }
     `,

--- a/packages/components/sidepanel/sidepanel.spec.ts
+++ b/packages/components/sidepanel/sidepanel.spec.ts
@@ -320,12 +320,12 @@ class ComponentForSidepanel {}
 @Component({
     selector: 'kbq-sidepanel-from-dropdown',
     template: `
-        <button class="template-button" #trigger="kbqDropdownTrigger" [kbqDropdownTriggerFor]="dropdown" kbq-button>
+        <button #trigger="kbqDropdownTrigger" class="template-button" kbq-button [kbqDropdownTriggerFor]="dropdown">
             Open sidepanel from dropdown
         </button>
         <kbq-dropdown #dropdown>
             <ng-template kbqDropdownContent>
-                <button (click)="showSidepanel()" kbq-dropdown-item>open Component Sidepanel</button>
+                <button kbq-dropdown-item (click)="showSidepanel()">open Component Sidepanel</button>
             </ng-template>
         </kbq-dropdown>
     `,

--- a/packages/components/splitter/splitter.karma-spec.ts
+++ b/packages/components/splitter/splitter.karma-spec.ts
@@ -25,7 +25,7 @@ function createTestComponent<T>(component: Type<T>) {
 @Component({
     selector: 'kbq-demo-splitter',
     template: `
-        <kbq-splitter #splitter [direction]="direction" [useGhost]="true" style="width: 500px;">
+        <kbq-splitter #splitter style="width: 500px;" [direction]="direction" [useGhost]="true">
             <div #areaA kbq-splitter-area style="flex: 1">first</div>
             <div #areaB kbq-splitter-area style="min-width: 50px">second</div>
         </kbq-splitter>

--- a/packages/components/splitter/splitter.spec.ts
+++ b/packages/components/splitter/splitter.spec.ts
@@ -75,8 +75,8 @@ class KbqSplitterDirection {
     selector: 'kbq-demo-splitter',
     template: `
         <kbq-splitter (gutterPositionChange)="gutterPositionChange()">
-            <div #areaA (sizeChange)="areaASizeChange($event)" kbq-splitter-area>first</div>
-            <div #areaB (sizeChange)="areaBSizeChange($event)" kbq-splitter-area>second</div>
+            <div #areaA kbq-splitter-area (sizeChange)="areaASizeChange($event)">first</div>
+            <div #areaB kbq-splitter-area (sizeChange)="areaBSizeChange($event)">second</div>
         </kbq-splitter>
     `
 })
@@ -91,7 +91,7 @@ class KbqSplitterEvents {
 @Component({
     selector: 'kbq-demo-splitter',
     template: `
-        <kbq-splitter #splitter [direction]="direction" [useGhost]="true" style="width: 500px;">
+        <kbq-splitter #splitter style="width: 500px;" [direction]="direction" [useGhost]="true">
             <div #areaA kbq-splitter-area style="flex: 1">first</div>
             <div #areaB kbq-splitter-area style="min-width: 50px">second</div>
         </kbq-splitter>
@@ -107,7 +107,7 @@ class KbqSplitterGhost {
 @Component({
     selector: 'kbq-demo-splitter',
     template: `
-        <kbq-splitter [direction]="direction" [useGhost]="true" style="width: 500px;">
+        <kbq-splitter style="width: 500px;" [direction]="direction" [useGhost]="true">
             @if (isFirstRendered) {
                 <div #areaA kbq-splitter-area style="flex: 1">first</div>
             }

--- a/packages/components/tabs/tab-body.html
+++ b/packages/components/tabs/tab-body.html
@@ -2,12 +2,12 @@
     #content
     cdkScrollable
     class="kbq-tab-body__content kbq-scrollbar kbq-hide-nested-popup"
-    (@translateTab.done)="onTranslateTabComplete($event)"
-    (@translateTab.start)="onTranslateTabStarted($event)"
     [@translateTab]="{
         value: bodyPosition,
         params: { animationDuration: animationDuration }
     }"
+    (@translateTab.done)="onTranslateTabComplete($event)"
+    (@translateTab.start)="onTranslateTabStarted($event)"
 >
     <ng-template kbqTabBodyHost />
 </div>

--- a/packages/components/tabs/tab-group.spec.ts
+++ b/packages/components/tabs/tab-group.spec.ts
@@ -606,8 +606,8 @@ describe('nested KbqTabGroup with enabled animations', () => {
     template: `
         <kbq-tab-group
             class="tab-group"
-            [(selectedIndex)]="selectedIndex"
             [headerPosition]="headerPosition"
+            [(selectedIndex)]="selectedIndex"
             (animationDone)="animationDone()"
             (focusChange)="handleFocus($event)"
             (selectedTabChange)="handleSelection($event)"

--- a/packages/components/tabs/tab-header.karma-spec.ts
+++ b/packages/components/tabs/tab-header.karma-spec.ts
@@ -58,10 +58,10 @@ interface ITab {
                 @for (tab of tabs; track tab; let i = $index) {
                     <div
                         class="label-content"
-                        [disabled]="!!tab.disabled"
-                        (click)="selectedIndex = i"
                         kbqTabLabelWrapper
                         style="min-width: 30px; width: 30px"
+                        [disabled]="!!tab.disabled"
+                        (click)="selectedIndex = i"
                     >
                         {{ tab.label }}
                     </div>

--- a/packages/components/tabs/tab-header.spec.ts
+++ b/packages/components/tabs/tab-header.spec.ts
@@ -303,10 +303,10 @@ interface ITab {
                 @for (tab of tabs; track tab; let i = $index) {
                     <div
                         class="label-content"
-                        [disabled]="!!tab.disabled"
-                        (click)="selectedIndex = i"
                         kbqTabLabelWrapper
                         style="min-width: 30px; width: 30px"
+                        [disabled]="!!tab.disabled"
+                        (click)="selectedIndex = i"
                     >
                         {{ tab.label }}
                     </div>

--- a/packages/components/tabs/tab-nav-bar.karma-spec.ts
+++ b/packages/components/tabs/tab-nav-bar.karma-spec.ts
@@ -40,7 +40,7 @@ describe(KbqTabNavBar.name, () => {
     template: `
         <nav kbqTabNavBar>
             @for (tab of tabs; track tab; let index = $index) {
-                <a [active]="activeIndex === index" [disabled]="disabled" (click)="activeIndex = index" kbqTabLink>
+                <a kbqTabLink [active]="activeIndex === index" [disabled]="disabled" (click)="activeIndex = index">
                     Tab link {{ label }}
                 </a>
             }

--- a/packages/components/tabs/tab-nav-bar.spec.ts
+++ b/packages/components/tabs/tab-nav-bar.spec.ts
@@ -121,7 +121,7 @@ describe(KbqTabNavBar.name, () => {
     template: `
         <nav kbqTabNavBar>
             @for (tab of tabs; track tab; let index = $index) {
-                <a [active]="activeIndex === index" [disabled]="disabled" (click)="activeIndex = index" kbqTabLink>
+                <a kbqTabLink [active]="activeIndex === index" [disabled]="disabled" (click)="activeIndex = index">
                     Tab link {{ label }}
                 </a>
             }
@@ -155,7 +155,7 @@ class TabLinkWithNgIf {
 @Component({
     template: `
         <nav kbqTabNavBar>
-            <a [tabIndex]="tabIndex" kbqTabLink>TabIndex Link</a>
+            <a kbqTabLink [tabIndex]="tabIndex">TabIndex Link</a>
         </nav>
     `
 })

--- a/packages/components/tags/tag-list.component.spec.ts
+++ b/packages/components/tags/tag-list.component.spec.ts
@@ -1268,7 +1268,7 @@ class StandardTagList {
                         {{ tag }}
                     </kbq-tag>
                 }
-                <input [kbqTagInputFor]="tagList" name="test" />
+                <input name="test" [kbqTagInputFor]="tagList" />
             </kbq-tag-list>
         </kbq-form-field>
     `
@@ -1290,11 +1290,11 @@ class FormFieldTagList {
     template: `
         <kbq-form-field>
             <kbq-tag-list
+                placeholder="Food"
                 [formControl]="control"
                 [required]="isRequired"
                 [tabIndex]="tabIndexOverride"
                 [selectable]="selectable"
-                placeholder="Food"
             >
                 @for (food of foods; track food) {
                     <kbq-tag [value]="food.value" [disabled]="food.disabled">
@@ -1331,12 +1331,12 @@ class BasicTagList {
     template: `
         <kbq-form-field>
             <kbq-tag-list
+                placeholder="Food"
                 [multiple]="true"
                 [formControl]="control"
                 [required]="isRequired"
                 [tabIndex]="tabIndexOverride"
                 [selectable]="selectable"
-                placeholder="Food"
             >
                 @for (food of foods; track food) {
                     <kbq-tag [value]="food.value" [disabled]="food.disabled">
@@ -1373,10 +1373,10 @@ class MultiSelectionTagList {
         <kbq-form-field>
             <kbq-tag-list
                 #tagList1
+                placeholder="Food"
                 [multiple]="true"
                 [formControl]="control"
                 [required]="isRequired"
-                placeholder="Food"
             >
                 @for (food of foods; track food) {
                     <kbq-tag [value]="food.value" (removed)="remove(food)">
@@ -1385,11 +1385,11 @@ class MultiSelectionTagList {
                 }
             </kbq-tag-list>
             <input
+                placeholder="New food..."
                 [kbqTagInputFor]="tagList1"
                 [kbqTagInputSeparatorKeyCodes]="separatorKeyCodes"
                 [kbqTagInputAddOnBlur]="addOnBlur"
                 (kbqTagInputTokenEnd)="add($event)"
-                placeholder="New food..."
             />
         </kbq-form-field>
     `

--- a/packages/components/textarea/textarea.component.karma-spec.ts
+++ b/packages/components/textarea/textarea.component.karma-spec.ts
@@ -31,7 +31,7 @@ function createComponent<T>(component: Type<T>, imports: any[] = [], providers: 
 @Component({
     template: `
         <kbq-form-field>
-            <textarea [(ngModel)]="value" [placeholder]="placeholder" [disabled]="disabled" kbqTextarea></textarea>
+            <textarea kbqTextarea [placeholder]="placeholder" [disabled]="disabled" [(ngModel)]="value"></textarea>
         </kbq-form-field>
     `
 })
@@ -44,7 +44,7 @@ class KbqTextareaForBehaviors {
 @Component({
     template: `
         <kbq-form-field>
-            <textarea [(ngModel)]="value" [canGrow]="false" kbqTextarea></textarea>
+            <textarea kbqTextarea [canGrow]="false" [(ngModel)]="value"></textarea>
         </kbq-form-field>
     `
 })

--- a/packages/components/textarea/textarea.component.spec.ts
+++ b/packages/components/textarea/textarea.component.spec.ts
@@ -30,7 +30,7 @@ function createComponent<T>(component: Type<T>, imports: any[] = [], providers: 
 @Component({
     template: `
         <kbq-form-field>
-            <textarea [(ngModel)]="value" kbqTextarea required></textarea>
+            <textarea kbqTextarea required [(ngModel)]="value"></textarea>
         </kbq-form-field>
     `
 })
@@ -42,7 +42,7 @@ class KbqTextareaInvalid {
     template: `
         <form #form="ngForm">
             <kbq-form-field>
-                <textarea [(ngModel)]="value" kbqTextarea name="control" required></textarea>
+                <textarea kbqTextarea name="control" required [(ngModel)]="value"></textarea>
             </kbq-form-field>
 
             <button type="submit"></button>
@@ -58,7 +58,7 @@ class KbqFormFieldWithNgModelInForm {
 @Component({
     template: `
         <kbq-form-field>
-            <textarea class="kbq-textarea_monospace" [(ngModel)]="value" kbqTextarea></textarea>
+            <textarea class="kbq-textarea_monospace" kbqTextarea [(ngModel)]="value"></textarea>
         </kbq-form-field>
     `
 })
@@ -69,7 +69,7 @@ class KbqTextareaWithMonospace {
 @Component({
     template: `
         <kbq-form-field>
-            <textarea [(ngModel)]="value" [placeholder]="placeholder" [disabled]="disabled" kbqTextarea></textarea>
+            <textarea kbqTextarea [placeholder]="placeholder" [disabled]="disabled" [(ngModel)]="value"></textarea>
         </kbq-form-field>
     `
 })

--- a/packages/components/timepicker/timepicker.spec.ts
+++ b/packages/components/timepicker/timepicker.spec.ts
@@ -25,12 +25,12 @@ import {
             <i kbqPrefix kbq-icon="kbq-clock_16"></i>
             <input
                 #ngModel="ngModel"
-                [(ngModel)]="timeValue"
+                kbqTimepicker
                 [format]="timeFormat"
                 [min]="minTime"
                 [max]="maxTime"
                 [disabled]="isDisabled"
-                kbqTimepicker
+                [(ngModel)]="timeValue"
             />
         </kbq-form-field>
     `
@@ -577,7 +577,7 @@ describe('KbqTimepicker', () => {
     template: `
         <kbq-form-field>
             <i kbqPrefix kbq-icon="kbq-clock_16"></i>
-            <input [format]="timeFormat" [formControl]="formControl" kbqTimepicker />
+            <input kbqTimepicker [format]="timeFormat" [formControl]="formControl" />
         </kbq-form-field>
     `
 })
@@ -655,7 +655,7 @@ describe('KbqTimepicker with null formControl value', () => {
     template: `
         <kbq-form-field>
             <i kbqPrefix kbq-icon="kbq-clock_16"></i>
-            <input [(ngModel)]="model" [format]="timeFormat" kbqTimepicker />
+            <input kbqTimepicker [format]="timeFormat" [(ngModel)]="model" />
         </kbq-form-field>
     `
 })
@@ -732,7 +732,7 @@ describe('KbqTimepicker with null model value', () => {
     template: `
         <kbq-form-field>
             <i kbqPrefix kbq-icon="kbq-clock_16"></i>
-            <input [(ngModel)]="model" [format]="timeFormat" kbqTimepicker />
+            <input kbqTimepicker [format]="timeFormat" [(ngModel)]="model" />
         </kbq-form-field>
     `
 })

--- a/packages/components/timezone/timezone-select.component.html
+++ b/packages/components/timezone/timezone-select.component.html
@@ -70,8 +70,8 @@
         <div
             #optionsContainer
             class="kbq-select__content"
-            (@fadeInContent.done)="panelDoneAnimatingStream.next($event.toState)"
             [@fadeInContent]="'showing'"
+            (@fadeInContent.done)="panelDoneAnimatingStream.next($event.toState)"
         >
             @if (isEmptySearchResult) {
                 <div class="kbq-select__no-options-message">

--- a/packages/components/timezone/timezone-select.component.karma-spec.ts
+++ b/packages/components/timezone/timezone-select.component.karma-spec.ts
@@ -86,10 +86,10 @@ const groupedZones: KbqTimezoneGroup[] = [
         <div [style.height.px]="heightAbove"></div>
         <kbq-form-field>
             <kbq-timezone-select
+                placeholder="Timezones"
                 [formControl]="control"
                 [required]="isRequired"
                 [panelClass]="panelClass"
-                placeholder="Timezones"
             >
                 @for (group of zones; track group) {
                     <kbq-optgroup [label]="group.countryName">

--- a/packages/components/timezone/timezone-select.component.spec.ts
+++ b/packages/components/timezone/timezone-select.component.spec.ts
@@ -82,11 +82,11 @@ const groupedZones: KbqTimezoneGroup[] = [
         <div [style.height.px]="heightAbove"></div>
         <kbq-form-field>
             <kbq-timezone-select
+                placeholder="Timezones"
                 [formControl]="control"
                 [required]="isRequired"
                 [tabIndex]="tabIndexOverride"
                 [panelClass]="panelClass"
-                placeholder="Timezones"
             >
                 @for (group of zones; track group) {
                     <kbq-optgroup [label]="group.countryName">
@@ -125,7 +125,7 @@ class BasicTimezoneSelect {
             <kbq-timezone-select [(value)]="selected">
                 <kbq-form-field kbqFormFieldWithoutBorders kbqSelectSearch>
                     <i kbqPrefix kbq-icon="kbq-magnifying-glass_16"></i>
-                    <input [formControl]="searchCtrl" [placeholder]="'Город или часовой пояс'" kbqInput type="text" />
+                    <input kbqInput type="text" [formControl]="searchCtrl" [placeholder]="'Город или часовой пояс'" />
                     <kbq-cleaner />
                 </kbq-form-field>
 

--- a/packages/components/title/title.directive.karma-spec.ts
+++ b/packages/components/title/title.directive.karma-spec.ts
@@ -150,16 +150,16 @@ class BaseKbqTitleComponent {
     ],
     template: `
         <div id="parent1" style="max-width: 150px" kbq-title>
-            <div class="parent" #kbqTitleContainer>
-                <div class="child" #kbqTitleText>
+            <div #kbqTitleContainer class="parent">
+                <div #kbqTitleText class="child">
                     {{ longValue }}
                 </div>
             </div>
         </div>
 
         <div id="parent2" style="max-width: 600px" kbq-title>
-            <div class="parent" #kbqTitleContainer>
-                <div class="child" #kbqTitleText>
+            <div #kbqTitleContainer class="parent">
+                <div #kbqTitleText class="child">
                     {{ defaultValue }}
                 </div>
             </div>

--- a/packages/components/toggle/toggle.component.spec.ts
+++ b/packages/components/toggle/toggle.component.spec.ts
@@ -619,7 +619,7 @@ class SingleToggle {
     ],
     template: `
         <form>
-            <kbq-toggle [(ngModel)]="isGood" name="cb">Be good</kbq-toggle>
+            <kbq-toggle name="cb" [(ngModel)]="isGood">Be good</kbq-toggle>
         </form>
     `
 })

--- a/packages/components/tooltip/tooltip.component.html
+++ b/packages/components/tooltip/tooltip.component.html
@@ -3,9 +3,9 @@
     class="kbq-tooltip"
     [class.kbq-tooltip_arrowless]="!arrow"
     [ngClass]="classMap"
+    [@state]="visibility"
     (@state.done)="animationDone($event)"
     (@state.start)="animationStart()"
-    [@state]="visibility"
 >
     <div class="kbq-tooltip__inner">
         @if (arrow) {

--- a/packages/components/tooltip/tooltip.spec.ts
+++ b/packages/components/tooltip/tooltip.spec.ts
@@ -406,7 +406,7 @@ class KbqTooltipDisabledComponent {
         <ng-template #tooltipContent let-ctx>
             <div>{{ ctx.content }}</div>
         </ng-template>
-        <button #trigger [kbqTooltip]="tooltipContent" [kbqTooltipContext]="tooltipContext" kbqTrigger="click">
+        <button #trigger kbqTrigger="click" [kbqTooltip]="tooltipContent" [kbqTooltipContext]="tooltipContext">
             Button
         </button>
     `

--- a/packages/components/tree-select/tree-select.component.karma-spec.ts
+++ b/packages/components/tree-select/tree-select.component.karma-spec.ts
@@ -161,7 +161,7 @@ const getChildren = (node: FileNode): Observable<FileNode[]> => {
     template: `
         <div [style.height.px]="heightAbove"></div>
         <kbq-form-field style="width: 300px">
-            <kbq-tree-select [formControl]="control" [panelClass]="panelClass" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [formControl]="control" [panelClass]="panelClass">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -169,8 +169,8 @@ const getChildren = (node: FileNode): Observable<FileNode[]> => {
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
-                        [disabled]="node.name === 'Downloads'"
                         kbqTreeNodePadding
+                        [disabled]="node.name === 'Downloads'"
                     >
                         <i kbq-icon="kbq-chevron-down-s_16" kbqTreeNodeToggle></i>
                         {{ treeControl.getViewValue(node) }}
@@ -255,8 +255,8 @@ class TreeSelectWithPanelWidth {
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
-                        [disabled]="node.name === 'Downloads'"
                         kbqTreeNodePadding
+                        [disabled]="node.name === 'Downloads'"
                     >
                         <i kbq-icon="kbq-chevron-down-s_16" kbqTreeNodeToggle></i>
                         {{ treeControl.getViewValue(node) }}
@@ -295,7 +295,7 @@ class BasicEvents {
     selector: 'ng-model-select',
     template: `
         <kbq-form-field>
-            <kbq-tree-select [disabled]="isDisabled" placeholder="Food" ngModel>
+            <kbq-tree-select placeholder="Food" ngModel [disabled]="isDisabled">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -340,7 +340,7 @@ class NgModelSelect {
         @if (isShowing) {
             <div>
                 <kbq-form-field>
-                    <kbq-tree-select [formControl]="control" placeholder="Food I want to eat right now">
+                    <kbq-tree-select placeholder="Food I want to eat right now" [formControl]="control">
                         <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                             <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                                 {{ treeControl.getViewValue(node) }}
@@ -425,7 +425,7 @@ class SelectWithChangeEvent {
     selector: 'multi-select',
     template: `
         <kbq-form-field>
-            <kbq-tree-select [multiple]="true" [formControl]="control" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [multiple]="true" [formControl]="control">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}

--- a/packages/components/tree-select/tree-select.component.spec.ts
+++ b/packages/components/tree-select/tree-select.component.spec.ts
@@ -219,10 +219,10 @@ const getChildren = (node: FileNode): Observable<FileNode[]> => {
         <div [style.height.px]="heightAbove"></div>
         <kbq-form-field>
             <kbq-tree-select
+                placeholder="Food"
                 [formControl]="control"
                 [tabIndex]="tabIndexOverride"
                 [panelClass]="panelClass"
-                placeholder="Food"
             >
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
@@ -231,8 +231,8 @@ const getChildren = (node: FileNode): Observable<FileNode[]> => {
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
-                        [disabled]="node.name === 'Downloads'"
                         kbqTreeNodePadding
+                        [disabled]="node.name === 'Downloads'"
                     >
                         <i kbq-icon="kbq-chevron-down-s_16" kbqTreeNodeToggle></i>
                         {{ treeControl.getViewValue(node) }}
@@ -290,8 +290,8 @@ class BasicTreeSelect {
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
-                        [disabled]="node.name === 'Downloads'"
                         kbqTreeNodePadding
+                        [disabled]="node.name === 'Downloads'"
                     >
                         <i kbq-icon="kbq-chevron-down-s_16" kbqTreeNodeToggle></i>
                         {{ treeControl.getViewValue(node) }}
@@ -386,7 +386,7 @@ class ManySelects {
             <kbq-tree-select [formControl]="control">
                 <kbq-form-field kbqFormFieldWithoutBorders kbqSelectSearch>
                     <i kbqPrefix kbq-icon="kbq-magnifying-glass_16"></i>
-                    <input [formControl]="searchControl" kbqInput type="text" />
+                    <input kbqInput type="text" [formControl]="searchControl" />
                     <kbq-cleaner />
                 </kbq-form-field>
 
@@ -471,7 +471,7 @@ class SelectWithChangeEvent {
     selector: 'select-init-without-options',
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selected" [formControl]="control" placeholder="Food I want to eat right now">
+            <kbq-tree-select placeholder="Food I want to eat right now" [formControl]="control" [(ngModel)]="selected">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -580,7 +580,7 @@ class ThrowsErrorOnInit implements OnInit {
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-tree-select [formControl]="control" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [formControl]="control">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -621,7 +621,7 @@ class BasicSelectOnPush {
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-tree-select [formControl]="control" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [formControl]="control">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -661,7 +661,7 @@ class BasicSelectOnPushPreselected {
     selector: 'multi-select',
     template: `
         <kbq-form-field>
-            <kbq-tree-select [multiple]="true" [formControl]="control" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [multiple]="true" [formControl]="control">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -913,7 +913,7 @@ class SelectInsideFormGroup {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selectedFood" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [(ngModel)]="selectedFood">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -954,7 +954,7 @@ class BasicSelectWithoutForms {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selectedFood" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [(ngModel)]="selectedFood">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -997,7 +997,7 @@ class BasicSelectWithoutFormsPreselected {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selectedFoods" [multiple]="true" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [multiple]="true" [(ngModel)]="selectedFoods">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -1039,7 +1039,7 @@ class BasicSelectWithoutFormsMultiple {
     selector: 'select-with-custom-trigger',
     template: `
         <kbq-form-field>
-            <kbq-tree-select #select="kbqTreeSelect" [formControl]="control" placeholder="Food">
+            <kbq-tree-select #select="kbqTreeSelect" placeholder="Food" [formControl]="control">
                 <kbq-select-trigger>
                     {{ select.triggerValue?.split('').reverse().join('') }}
                 </kbq-select-trigger>
@@ -1133,7 +1133,7 @@ class NgModelCompareWithFlatTreeControl {
 
 @Component({
     template: `
-        <kbq-tree-select [formControl]="control" [errorStateMatcher]="errorStateMatcher" placeholder="Food">
+        <kbq-tree-select placeholder="Food" [formControl]="control" [errorStateMatcher]="errorStateMatcher">
             <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                 <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                     {{ treeControl.getViewValue(node) }}
@@ -1175,7 +1175,7 @@ class CustomErrorBehaviorSelect {
 @Component({
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selectedFood" placeholder="Food">
+            <kbq-tree-select placeholder="Food" [(ngModel)]="selectedFood">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -1241,17 +1241,17 @@ class SelectWithFormFieldLabel {
         <kbq-form-field>
             <kbq-tree-select [multiple]="true" [formControl]="control" (selectionChange)="onSelectionChange($event)">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
-                    <kbq-tree-option #option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
+                    <kbq-tree-option *kbqTreeNodeDef="let node" #option kbqTreeNodePadding>
                         <kbq-pseudo-checkbox [state]="pseudoCheckboxState(option)" />
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>
 
-                    <kbq-tree-option #option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
+                    <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" #option kbqTreeNodePadding>
                         <kbq-pseudo-checkbox [state]="pseudoCheckboxState(option)" />
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>
@@ -1345,11 +1345,11 @@ class ChildSelection {
     template: `
         <kbq-form-field style="width: 300px;">
             <kbq-tree-select
+                placeholder="Food"
                 [multiple]="true"
                 [formControl]="control"
                 [tabIndex]="tabIndexOverride"
                 [panelClass]="panelClass"
-                placeholder="Food"
             >
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
@@ -1358,8 +1358,8 @@ class ChildSelection {
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
-                        [disabled]="node.name === 'Downloads'"
                         kbqTreeNodePadding
+                        [disabled]="node.name === 'Downloads'"
                     >
                         <i kbq-icon="kbq-chevron-down-s_16" kbqTreeNodeToggle></i>
                         {{ treeControl.getViewValue(node) }}

--- a/packages/components/tree-select/tree-select.html
+++ b/packages/components/tree-select/tree-select.html
@@ -122,8 +122,8 @@
         <div
             #optionsContainer
             class="kbq-tree-select__content kbq-scrollbar"
-            (@fadeInContent.done)="panelDoneAnimatingStream.next($event.toState)"
             [@fadeInContent]="'showing'"
+            (@fadeInContent.done)="panelDoneAnimatingStream.next($event.toState)"
         >
             @if (isEmptySearchResult) {
                 <div class="kbq-select__no-options-message">

--- a/packages/components/tree/tree-selection.component.spec.ts
+++ b/packages/components/tree/tree-selection.component.spec.ts
@@ -822,11 +822,11 @@ function expectFlatTreeToMatch(treeElement: Element, expectedPaddingIndent: numb
     template: `
         <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
             <kbq-tree-option
-                class="customNodeClass"
                 *kbqTreeNodeDef="let node"
-                [kbqTreeNodePaddingIndent]="28"
+                class="customNodeClass"
                 kbqTreeNodePadding
                 kbqTreeNodeToggle
+                [kbqTreeNodePaddingIndent]="28"
             >
                 {{ node.name }}
             </kbq-tree-option>
@@ -938,10 +938,10 @@ class TreeSelectionFocusStates extends TreeParams {}
 @Component({
     template: `
         <kbq-tree-selection
-            [(ngModel)]="modelValue"
+            multiple="keyboard"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
-            multiple="keyboard"
+            [(ngModel)]="modelValue"
         >
             <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                 {{ node.name }}
@@ -963,11 +963,11 @@ class KbqTreeAppMultiple extends TreeParams {
 @Component({
     template: `
         <kbq-tree-selection
+            multiple="checkbox"
             [ngModel]="modelValue"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
             (ngModelChange)="onModelValueChange($event)"
-            multiple="checkbox"
         >
             <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                 {{ node.name }}

--- a/packages/docs-examples/components/actions-panel/actions-panel-adaptive/actions-panel-adaptive-example.ts
+++ b/packages/docs-examples/components/actions-panel/actions-panel-adaptive/actions-panel-adaptive-example.ts
@@ -32,28 +32,28 @@ type ExampleAction = {
     providers: [KbqActionsPanel],
     selector: 'example-actions-panel',
     template: `
-        <button (click)="open()" kbq-button>open</button>
+        <button kbq-button (click)="open()">open</button>
 
         <ng-template let-data>
             <div
                 #kbqOverflowItems="kbqOverflowItems"
-                [additionalResizeObserverTargets]="additionalResizeObserverTargets"
                 kbqOverflowItems
+                [additionalResizeObserverTargets]="additionalResizeObserverTargets"
             >
-                <div [kbqOverflowItem]="action.Counter" order="99">
+                <div order="99" [kbqOverflowItem]="action.Counter">
                     <div class="example-counter">Selected: {{ data.length }}</div>
                     <kbq-divider class="example-divider-vertical" [vertical]="true" />
                 </div>
 
                 @for (action of actions; track action.id) {
                     <button
+                        color="contrast"
+                        kbq-button
                         [kbqOverflowItem]="action.id"
                         [class.layout-margin-left-xxs]="!$first"
                         (click)="onAction(action)"
-                        color="contrast"
-                        kbq-button
                     >
-                        <i [class]="action.icon" kbq-icon></i>
+                        <i kbq-icon [class]="action.icon"></i>
                         {{ action.id }}
                     </button>
                 }
@@ -61,7 +61,7 @@ type ExampleAction = {
                 @let hiddenItemIDs = kbqOverflowItems.hiddenItemIDs();
                 <!-- ignores when only action.Counter is hidden -->
                 @if (hiddenItemIDs.size > 1) {
-                    <button [kbqDropdownTriggerFor]="dropdown" kbqOverflowItemsResult color="contrast" kbq-button>
+                    <button kbqOverflowItemsResult color="contrast" kbq-button [kbqDropdownTriggerFor]="dropdown">
                         <i kbq-icon="kbq-ellipsis-vertical_16"></i>
                     </button>
                 }
@@ -72,8 +72,8 @@ type ExampleAction = {
 
                     @for (action of actions; track action.id) {
                         @if (hiddenItemIDs.has(action.id)) {
-                            <button (click)="onAction(action)" kbq-dropdown-item>
-                                <i [class]="action.icon" kbq-icon></i>
+                            <button kbq-dropdown-item (click)="onAction(action)">
+                                <i kbq-icon [class]="action.icon"></i>
                                 {{ action.id }}
                             </button>
                         }

--- a/packages/docs-examples/components/actions-panel/actions-panel-close/actions-panel-close-example.ts
+++ b/packages/docs-examples/components/actions-panel/actions-panel-close/actions-panel-close-example.ts
@@ -21,10 +21,10 @@ import { KbqToastService } from '@koobiq/components/toast';
     providers: [KbqActionsPanel],
     selector: 'actions-panel-close-example',
     template: `
-        <button (click)="open()" kbq-button>open</button>
+        <button kbq-button (click)="open()">open</button>
 
         <ng-template let-data>
-            <button (click)="onAction('Execute and close')" color="contrast" kbq-button>
+            <button color="contrast" kbq-button (click)="onAction('Execute and close')">
                 <i kbq-icon="kbq-user_16"></i>
                 Execute and close
             </button>

--- a/packages/docs-examples/components/actions-panel/actions-panel-custom-counter/actions-panel-custom-counter-example.ts
+++ b/packages/docs-examples/components/actions-panel/actions-panel-custom-counter/actions-panel-custom-counter-example.ts
@@ -38,14 +38,14 @@ type ExampleAction = {
     providers: [KbqActionsPanel],
     selector: 'actions-panel-custom-counter-example',
     template: `
-        <button (click)="open()" kbq-button>open</button>
+        <button kbq-button (click)="open()">open</button>
 
         <ng-template let-data>
             <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
-                <div [kbqOverflowItem]="action.Counter" order="99">
+                <div order="99" [kbqOverflowItem]="action.Counter">
                     <div class="example-counter">
                         <div>Selected: {{ data.selected }}</div>
-                        <kbq-badge [outline]="true" badgeColor="fade-contrast">+{{ data.counter }}</kbq-badge>
+                        <kbq-badge badgeColor="fade-contrast" [outline]="true">+{{ data.counter }}</kbq-badge>
                     </div>
                     <kbq-divider class="example-divider-vertical" [vertical]="true" />
                 </div>
@@ -56,12 +56,12 @@ type ExampleAction = {
                             <kbq-divider class="example-divider-vertical" [vertical]="true" />
                         }
                         <button
-                            [class.layout-margin-left-xxs]="!$first"
-                            (click)="onAction(action)"
                             color="contrast"
                             kbq-button
+                            [class.layout-margin-left-xxs]="!$first"
+                            (click)="onAction(action)"
                         >
-                            <i [class]="action.icon" kbq-icon></i>
+                            <i kbq-icon [class]="action.icon"></i>
                             {{ action.id }}
                         </button>
                     </div>
@@ -71,7 +71,7 @@ type ExampleAction = {
             @let hiddenItemIDs = kbqOverflowItems.hiddenItemIDs();
             <!-- ignores when only action.Counter is hidden -->
             @if (hiddenItemIDs.size > 1) {
-                <button [kbqDropdownTriggerFor]="dropdown" kbqOverflowItemsResult color="contrast" kbq-button>
+                <button kbqOverflowItemsResult color="contrast" kbq-button [kbqDropdownTriggerFor]="dropdown">
                     <i kbq-icon="kbq-ellipsis-vertical_16"></i>
                 </button>
             }
@@ -88,8 +88,8 @@ type ExampleAction = {
                         @if (action.divider && hiddenItemIDs.has(actions[$index - 1].id)) {
                             <kbq-divider />
                         }
-                        <button (click)="onAction(action)" kbq-dropdown-item>
-                            <i [class]="action.icon" kbq-icon></i>
+                        <button kbq-dropdown-item (click)="onAction(action)">
+                            <i kbq-icon [class]="action.icon"></i>
                             {{ action.id }}
                         </button>
                     }

--- a/packages/docs-examples/components/actions-panel/actions-panel-overview/actions-panel-overview-example.ts
+++ b/packages/docs-examples/components/actions-panel/actions-panel-overview/actions-panel-overview-example.ts
@@ -132,7 +132,7 @@ export class ExampleTable {
     selector: 'example-actions-panel',
     template: `
         <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
-            <div [kbqOverflowItem]="action.Counter" order="99">
+            <div order="99" [kbqOverflowItem]="action.Counter">
                 <div class="example-counter">Selected: {{ data().length }}</div>
                 <kbq-divider class="example-divider-vertical" [vertical]="true" />
             </div>
@@ -143,12 +143,12 @@ export class ExampleTable {
                         <kbq-divider class="example-divider-vertical" [vertical]="true" />
                     }
                     <button
-                        [class.layout-margin-left-xxs]="!$first"
-                        (click)="onAction(action)"
                         color="contrast"
                         kbq-button
+                        [class.layout-margin-left-xxs]="!$first"
+                        (click)="onAction(action)"
                     >
-                        <i [class]="action.icon" kbq-icon></i>
+                        <i kbq-icon [class]="action.icon"></i>
                         {{ action.id }}
                     </button>
                 </div>
@@ -157,7 +157,7 @@ export class ExampleTable {
             @let hiddenItemIDs = kbqOverflowItems.hiddenItemIDs();
             <!-- ignores when only action.Counter is hidden -->
             @if (hiddenItemIDs.size > 1) {
-                <button [kbqDropdownTriggerFor]="dropdown" kbqOverflowItemsResult color="contrast" kbq-button>
+                <button kbqOverflowItemsResult color="contrast" kbq-button [kbqDropdownTriggerFor]="dropdown">
                     <i kbq-icon="kbq-ellipsis-vertical_16"></i>
                 </button>
             }
@@ -171,8 +171,8 @@ export class ExampleTable {
                         @if (action.divider && hiddenItemIDs.has(actions[$index - 1].id)) {
                             <kbq-divider />
                         }
-                        <button (click)="onAction(action)" kbq-dropdown-item>
-                            <i [class]="action.icon" kbq-icon></i>
+                        <button kbq-dropdown-item (click)="onAction(action)">
+                            <i kbq-icon [class]="action.icon"></i>
                             {{ action.id }}
                         </button>
                     }

--- a/packages/docs-examples/components/ag-grid/ag-grid-overview/ag-grid-overview-example.ts
+++ b/packages/docs-examples/components/ag-grid/ag-grid-overview/ag-grid-overview-example.ts
@@ -53,15 +53,15 @@ export class ExampleLinkCellRenderer implements ICellRendererAngularComp {
     selector: 'ag-grid-overview-example',
     template: `
         <ag-grid-angular
+            rowSelection="multiple"
+            kbqAgGridTheme
+            disableCellFocusStyles
             [style.height.px]="300"
             [columnDefs]="columnDefs"
             [defaultColDef]="defaultColDef"
             [rowData]="rowData"
             [suppressRowClickSelection]="true"
             (firstDataRendered)="onFirstDataRendered($event)"
-            rowSelection="multiple"
-            kbqAgGridTheme
-            disableCellFocusStyles
         />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/docs-examples/components/ag-grid/ag-grid-row-dragging/ag-grid-row-dragging-example.ts
+++ b/packages/docs-examples/components/ag-grid/ag-grid-row-dragging/ag-grid-row-dragging-example.ts
@@ -25,6 +25,9 @@ type ExampleRowData = {
     selector: 'ag-grid-row-dragging-example',
     template: `
         <ag-grid-angular
+            rowSelection="multiple"
+            kbqAgGridTheme
+            disableCellFocusStyles
             [style.height.px]="300"
             [columnDefs]="columnDefs"
             [defaultColDef]="defaultColDef"
@@ -34,9 +37,6 @@ type ExampleRowData = {
             [suppressMoveWhenRowDragging]="true"
             [suppressRowClickSelection]="true"
             (firstDataRendered)="onFirstDataRendered($event)"
-            rowSelection="multiple"
-            kbqAgGridTheme
-            disableCellFocusStyles
         />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/docs-examples/components/alert/alert-close/alert-close-example.ts
+++ b/packages/docs-examples/components/alert/alert-close/alert-close-example.ts
@@ -29,10 +29,10 @@ import { KbqIconModule } from '@koobiq/components/icon';
             <i kbq-icon="kbq-info-circle_16"></i>
             Блок скрывается по крестику в углу, не дублируйте эту возможность с помощью кнопки под текстом сообщения
             <i
-                [color]="colors.ContrastFade"
-                (click)="state = !state"
                 kbq-alert-close-button
                 kbq-icon-button="kbq-xmark-s_16"
+                [color]="colors.ContrastFade"
+                (click)="state = !state"
             ></i>
         </kbq-alert>
     `

--- a/packages/docs-examples/components/alert/alert-variants/alert-variants-example.ts
+++ b/packages/docs-examples/components/alert/alert-variants/alert-variants-example.ts
@@ -29,14 +29,14 @@ import { KbqIconModule } from '@koobiq/components/icon';
         <div class="layout-row example-row layout-gap-l flex-100">
             <div class="layout-column example-column">
                 <kbq-alert [alertColor]="alertColors.Error">
-                    <i [color]="colors.Error" kbq-icon-item="kbq-exclamation-triangle_16"></i>
+                    <i kbq-icon-item="kbq-exclamation-triangle_16" [color]="colors.Error"></i>
                     <div kbq-alert-title>Default</div>
                     {{ text }}
                 </kbq-alert>
             </div>
             <div class="layout-column example-column">
                 <kbq-alert [alertColor]="alertColors.Error" [alertStyle]="alertStyles.Colored" [compact]="true">
-                    <i [color]="colors.Error" kbq-icon="kbq-exclamation-triangle_16"></i>
+                    <i kbq-icon="kbq-exclamation-triangle_16" [color]="colors.Error"></i>
                     <div kbq-alert-title>Colored</div>
                     {{ text }}
                 </kbq-alert>

--- a/packages/docs-examples/components/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
+++ b/packages/docs-examples/components/autocomplete/autocomplete-overview/autocomplete-overview-example.ts
@@ -28,7 +28,7 @@ import { map, startWith } from 'rxjs/operators';
             <div class="kbq-form__row">
                 <label class="kbq-form__label">Enter countries to see autocomplete</label>
                 <kbq-form-field>
-                    <input [formControl]="control" [kbqAutocomplete]="auto" kbqInput type="text" />
+                    <input kbqInput type="text" [formControl]="control" [kbqAutocomplete]="auto" />
 
                     <kbq-autocomplete #auto="kbqAutocomplete">
                         @for (option of filteredOptions | async; track option) {

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-custom-template/breadcrumbs-custom-template-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-custom-template/breadcrumbs-custom-template-example.ts
@@ -14,8 +14,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
         <nav kbq-breadcrumbs>
             @for (breadcrumb of breadcrumbs; track breadcrumb; let last = $last) {
                 <kbq-breadcrumb-item [routerLink]="breadcrumb.url" [text]="breadcrumb.label">
-                    <a *kbqBreadcrumbView [routerLink]="breadcrumb.url" tabindex="-1">
-                        <button [disabled]="last" [attr.aria-current]="last ? 'page' : null" kbq-button kbqBreadcrumb>
+                    <a *kbqBreadcrumbView tabindex="-1" [routerLink]="breadcrumb.url">
+                        <button kbq-button kbqBreadcrumb [disabled]="last" [attr.aria-current]="last ? 'page' : null">
                             {{ breadcrumb.label }}
                             <i kbq-icon="kbq-file-code-o_16"></i>
                         </button>

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-dropdown/breadcrumbs-dropdown-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-dropdown/breadcrumbs-dropdown-example.ts
@@ -14,33 +14,33 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <nav kbq-breadcrumbs>
             <kbq-breadcrumb-item
-                [queryParams]="{ queryParams: 'queryParams' }"
-                [fragment]="'fragment'"
                 routerLink="./info-sec"
                 text="Information Security"
+                [queryParams]="{ queryParams: 'queryParams' }"
+                [fragment]="'fragment'"
             />
 
             <kbq-breadcrumb-item
-                [queryParams]="{ queryParams: 'queryParams' }"
-                [fragment]="'fragment'"
                 routerLink="./access-control"
                 text="Access Control"
+                [queryParams]="{ queryParams: 'queryParams' }"
+                [fragment]="'fragment'"
             />
 
             <kbq-breadcrumb-item
-                [queryParams]="{ queryParams: 'queryParams' }"
-                [fragment]="'fragment'"
                 routerLink="./authorization"
                 text="Authorization"
+                [queryParams]="{ queryParams: 'queryParams' }"
+                [fragment]="'fragment'"
             />
 
             <kbq-breadcrumb-item>
                 <div *kbqBreadcrumbView>
                     <button
-                        [kbqDropdownTriggerFor]="siblingsListDropdown"
-                        [openByArrowDown]="false"
                         kbq-button
                         kbqBreadcrumb
+                        [kbqDropdownTriggerFor]="siblingsListDropdown"
+                        [openByArrowDown]="false"
                     >
                         Access Control
                         <i kbq-icon="kbq-chevron-down-s_16"></i>

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-size/breadcrumbs-size-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-size/breadcrumbs-size-example.ts
@@ -16,7 +16,7 @@ import { KbqDlModule } from '@koobiq/components/dl';
             @for (size of sizes; track size) {
                 <kbq-dt class="kbq-text-normal">{{ size | titlecase }}</kbq-dt>
                 <kbq-dd>
-                    <nav [size]="size" kbq-breadcrumbs>
+                    <nav kbq-breadcrumbs [size]="size">
                         @for (breadcrumb of breadcrumbs; track breadcrumb; let last = $last) {
                             <kbq-breadcrumb-item
                                 [routerLink]="breadcrumb.url"

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-truncate-by-abbrev-items/breadcrumbs-truncate-by-abbrev-items-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-truncate-by-abbrev-items/breadcrumbs-truncate-by-abbrev-items-example.ts
@@ -20,16 +20,16 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
                     [fragment]="breadcrumb.longText"
                     [text]="breadcrumb.longText"
                 >
-                    <a *kbqBreadcrumbView [routerLink]="breadcrumb.url" tabindex="-1">
+                    <a *kbqBreadcrumbView tabindex="-1" [routerLink]="breadcrumb.url">
                         <button
+                            kbq-button
+                            kbqBreadcrumb
                             [attr.aria-current]="last ? 'page' : null"
                             [disabled]="last"
                             [kbqPlacementPriority]="PopUpPlacements.Bottom"
                             [kbqTooltipArrow]="false"
                             [kbqTooltip]="breadcrumb.longText"
                             [kbqTooltipDisabled]="!breadcrumb.shortText"
-                            kbq-button
-                            kbqBreadcrumb
                         >
                             {{ breadcrumb.shortText || breadcrumb.longText }}
                         </button>

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-truncate-center-items/breadcrumbs-truncate-center-items-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-truncate-center-items/breadcrumbs-truncate-center-items-example.ts
@@ -22,11 +22,11 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
                     <a routerLink="./report" tabindex="-1">
                         <button aria-current="page" disabled kbq-button kbqBreadcrumb>
                             <span
+                                kbqEllipsisCenter="Report dated 28.08.2018"
                                 [minVisibleLength]="15"
                                 [charWidth]="5"
                                 [kbqPlacementPriority]="PopUpPlacements.Bottom"
                                 [kbqTooltipArrow]="false"
-                                kbqEllipsisCenter="Report dated 28.08.2018"
                             ></span>
                         </button>
                     </a>

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-with-auto-wrap-adaptive/breadcrumbs-with-auto-wrap-adaptive-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-with-auto-wrap-adaptive/breadcrumbs-with-auto-wrap-adaptive-example.ts
@@ -5,7 +5,7 @@ import { KbqBreadcrumbsModule } from '@koobiq/components/breadcrumbs';
     standalone: true,
     selector: 'example-breadcrumbs',
     template: `
-        <nav [max]="null" wrapMode="auto" kbq-breadcrumbs>
+        <nav wrapMode="auto" kbq-breadcrumbs [max]="null">
             @for (breadcrumb of breadcrumbs; track breadcrumb; let last = $last) {
                 <kbq-breadcrumb-item [text]="breadcrumb.label" />
             }

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-with-wrap/breadcrumbs-with-wrap-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-with-wrap/breadcrumbs-with-wrap-example.ts
@@ -9,7 +9,7 @@ import { KbqBreadcrumbsModule } from '@koobiq/components/breadcrumbs';
     selector: 'breadcrumbs-with-wrap-example',
     template: `
         <div [style.max-width.px]="320">
-            <nav [firstItemNegativeMargin]="false" wrapMode="wrap" kbq-breadcrumbs>
+            <nav wrapMode="wrap" kbq-breadcrumbs [firstItemNegativeMargin]="false">
                 @for (breadcrumb of breadcrumbs; track breadcrumb) {
                     <kbq-breadcrumb-item [text]="breadcrumb.label" />
                 }

--- a/packages/docs-examples/components/button/button-content/button-content-example.ts
+++ b/packages/docs-examples/components/button/button-content/button-content-example.ts
@@ -19,25 +19,25 @@ import { KbqIconModule } from '@koobiq/components/icon';
         <div class="example-content__button-group">
             <div class="example-button">
                 <div class="example-label kbq-text-compact">Text</div>
-                <button [color]="colors.Contrast" kbq-button>Кнопка</button>
+                <button kbq-button [color]="colors.Contrast">Кнопка</button>
             </div>
             <div class="example-button">
                 <div class="example-label kbq-text-compact">Icon+Text</div>
-                <button [color]="colors.Contrast" kbq-button>
+                <button kbq-button [color]="colors.Contrast">
                     <i kbq-icon="kbq-plus_16"></i>
                     Кнопка
                 </button>
             </div>
             <div class="example-button">
                 <div class="example-label kbq-text-compact">Text+Icon</div>
-                <button [color]="colors.Contrast" kbq-button>
+                <button kbq-button [color]="colors.Contrast">
                     Кнопка
                     <i kbq-icon="kbq-plus_16"></i>
                 </button>
             </div>
             <div class="example-button">
                 <div class="example-label kbq-text-compact">Icon+Text+Icon</div>
-                <button [color]="colors.Contrast" kbq-button>
+                <button kbq-button [color]="colors.Contrast">
                     <i kbq-icon="kbq-plus_16"></i>
                     Кнопка
                     <i kbq-icon="kbq-plus_16"></i>

--- a/packages/docs-examples/components/button/button-fill-content/button-fill-content-example.ts
+++ b/packages/docs-examples/components/button/button-fill-content/button-fill-content-example.ts
@@ -14,7 +14,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
         KbqButtonModule
     ],
     template: `
-        <button class="example-fill-content__button" [color]="colors.Contrast" kbq-button>
+        <button class="example-fill-content__button" kbq-button [color]="colors.Contrast">
             Очень длинный текст кнопки, который не умеет обрезаться по ширине
         </button>
     `

--- a/packages/docs-examples/components/button/button-fixed-content/button-fixed-content-example.ts
+++ b/packages/docs-examples/components/button/button-fixed-content/button-fixed-content-example.ts
@@ -15,10 +15,10 @@ import { KbqComponentColors } from '@koobiq/components/core';
     ],
     template: `
         <div class="example-fixed-content__button-group">
-            <button class="example-fixed-content__button" [color]="colors.Contrast" kbq-button>Текст кнопки</button>
+            <button class="example-fixed-content__button" kbq-button [color]="colors.Contrast">Текст кнопки</button>
             &nbsp;
             <br />
-            <button class="example-fixed-content__button" [color]="colors.Contrast" kbq-button>
+            <button class="example-fixed-content__button" kbq-button [color]="colors.Contrast">
                 Очень длинный текст кнопки
             </button>
             &nbsp;

--- a/packages/docs-examples/components/button/button-hug-content/button-hug-content-example.ts
+++ b/packages/docs-examples/components/button/button-hug-content/button-hug-content-example.ts
@@ -14,10 +14,10 @@ import { KbqComponentColors } from '@koobiq/components/core';
         KbqButtonModule
     ],
     template: `
-        <button class="example-hug-content__button" [color]="colors.Contrast" kbq-button>Текст кнопки</button>
+        <button class="example-hug-content__button" kbq-button [color]="colors.Contrast">Текст кнопки</button>
         &nbsp;
         <br />
-        <button class="example-hug-content__button" [color]="colors.Contrast" kbq-button>
+        <button class="example-hug-content__button" kbq-button [color]="colors.Contrast">
             Очень длинный текст кнопки
         </button>
         &nbsp;

--- a/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.ts
+++ b/packages/docs-examples/components/button/button-loading-state/button-loading-state-example.ts
@@ -13,7 +13,7 @@ import { KbqComponentColors } from '@koobiq/components/core';
         KbqButtonModule
     ],
     template: `
-        <button class="kbq-progress" [color]="colors.Contrast" kbq-button>Кнопка</button>
+        <button class="kbq-progress" kbq-button [color]="colors.Contrast">Кнопка</button>
         &nbsp;
     `
 })

--- a/packages/docs-examples/components/button/button-overview/button-overview-example.ts
+++ b/packages/docs-examples/components/button/button-overview/button-overview-example.ts
@@ -20,10 +20,10 @@ import { KbqComponentColors } from '@koobiq/components/core';
     template: `
         <button
             class="example-overview__button"
+            kbq-button
             [class.kbq-progress]="hasProgress"
             [color]="colors.Contrast"
             [disabled]="isDisabled"
-            kbq-button
         >
             Кнопка
         </button>

--- a/packages/docs-examples/components/code-block/code-block-with-custom-locale-configuration/code-block-with-custom-locale-configuration-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-custom-locale-configuration/code-block-with-custom-locale-configuration-example.ts
@@ -28,7 +28,7 @@ import { KBQ_LOCALE_SERVICE } from '@koobiq/components/core';
         })
     ],
     template: `
-        <kbq-code-block [files]="files" canToggleSoftWrap maxHeight="200" lineNumbers canDownload />
+        <kbq-code-block canToggleSoftWrap maxHeight="200" lineNumbers canDownload [files]="files" />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/code-block/code-block-with-line-numbers/code-block-with-line-numbers-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-line-numbers/code-block-with-line-numbers-example.ts
@@ -16,7 +16,7 @@ import { KbqToggleModule } from '@koobiq/components/toggle';
     ],
     template: `
         <kbq-toggle class="layout-margin-bottom-m" [(ngModel)]="lineNumbers">Line numbers</kbq-toggle>
-        <kbq-code-block [files]="files" [lineNumbers]="lineNumbers" canToggleSoftWrap />
+        <kbq-code-block canToggleSoftWrap [files]="files" [lineNumbers]="lineNumbers" />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/code-block/code-block-with-link/code-block-with-link-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-link/code-block-with-link-example.ts
@@ -9,7 +9,7 @@ import { KbqCodeBlockFile, KbqCodeBlockModule } from '@koobiq/components/code-bl
     selector: 'code-block-with-link-example',
     imports: [KbqCodeBlockModule],
     template: `
-        <kbq-code-block [files]="files" lineNumbers canCopy="false" />
+        <kbq-code-block lineNumbers canCopy="false" [files]="files" />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/code-block/code-block-with-max-height/code-block-with-max-height-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-max-height/code-block-with-max-height-example.ts
@@ -19,12 +19,12 @@ import { KbqToggleModule } from '@koobiq/components/toggle';
         <kbq-toggle [(ngModel)]="filled">Filled</kbq-toggle>
 
         <kbq-code-block
-            [(viewAll)]="viewAll"
-            [filled]="filled()"
-            [files]="files"
             canToggleSoftWrap
             maxHeight="200"
             lineNumbers
+            [filled]="filled()"
+            [files]="files"
+            [(viewAll)]="viewAll"
         />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/docs-examples/components/code-block/code-block-with-no-border/code-block-with-no-border-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-no-border/code-block-with-no-border-example.ts
@@ -15,9 +15,9 @@ import { KbqSidepanelModule, KbqSidepanelService } from '@koobiq/components/side
         KbqButtonModule
     ],
     template: `
-        <button (click)="sidepanel.open(template)" kbq-button>Open sidepanel</button>
+        <button kbq-button (click)="sidepanel.open(template)">Open sidepanel</button>
         <ng-template #template>
-            <kbq-code-block [files]="files" canToggleSoftWrap noBorder lineNumbers />
+            <kbq-code-block canToggleSoftWrap noBorder lineNumbers [files]="files" />
         </ng-template>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/docs-examples/components/code-block/code-block-with-soft-wrap/code-block-with-soft-wrap-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-soft-wrap/code-block-with-soft-wrap-example.ts
@@ -16,7 +16,7 @@ import { KbqToggleModule } from '@koobiq/components/toggle';
     ],
     template: `
         <kbq-toggle class="layout-margin-bottom-m" [(ngModel)]="softWrap">Word wrap</kbq-toggle>
-        <kbq-code-block [(softWrap)]="softWrap" [files]="files" canToggleSoftWrap lineNumbers />
+        <kbq-code-block canToggleSoftWrap lineNumbers [files]="files" [(softWrap)]="softWrap" />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/code-block/code-block-with-tabs-and-shadow/code-block-with-tabs-and-shadow-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-tabs-and-shadow/code-block-with-tabs-and-shadow-example.ts
@@ -10,12 +10,12 @@ import { KbqCodeBlock, KbqCodeBlockFile, KbqCodeBlockModule } from '@koobiq/comp
     imports: [KbqCodeBlockModule],
     template: `
         <kbq-code-block
-            [files]="files"
-            [style.height.px]="350"
             activeFileIndex="2"
             lineNumbers
             canToggleSoftWrap
             softWrap
+            [files]="files"
+            [style.height.px]="350"
         />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/docs-examples/components/code-block/code-block-with-tabs/code-block-with-tabs-example.ts
+++ b/packages/docs-examples/components/code-block/code-block-with-tabs/code-block-with-tabs-example.ts
@@ -20,13 +20,13 @@ import { KbqToggleModule } from '@koobiq/components/toggle';
         <kbq-toggle [(ngModel)]="lineNumbers">Line numbers</kbq-toggle>
 
         <kbq-code-block
+            activeFileIndex="1"
+            canToggleSoftWrap
+            canDownload
             [files]="files"
             [hideTabs]="hideTabs()"
             [filled]="filled()"
             [lineNumbers]="lineNumbers()"
-            activeFileIndex="1"
-            canToggleSoftWrap
-            canDownload
         />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/docs-examples/components/content-panel/content-panel-overview/content-panel-overview-example.ts
+++ b/packages/docs-examples/components/content-panel/content-panel-overview/content-panel-overview-example.ts
@@ -14,19 +14,19 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <kbq-content-panel-container #panel="kbqContentPanelContainer" width="350" maxWidth="450" minWidth="250">
             <div class="example-content-panel-container__content">
-                <button (click)="panel.toggle()" kbq-button>Toggle</button>
-                <button [disabled]="panel.isOpened()" (click)="panel.open()" kbq-button>Open</button>
-                <button [disabled]="!panel.isOpened()" (click)="panel.close()" kbq-button>Close</button>
+                <button kbq-button (click)="panel.toggle()">Toggle</button>
+                <button kbq-button [disabled]="panel.isOpened()" (click)="panel.open()">Open</button>
+                <button kbq-button [disabled]="!panel.isOpened()" (click)="panel.close()">Close</button>
             </div>
 
             <kbq-content-panel>
                 <kbq-content-panel-header>
                     <div kbqContentPanelHeaderTitle>Title</div>
                     <div kbqContentPanelHeaderActions>
-                        <button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent" kbq-button>
+                        <button kbq-button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent">
                             <i kbq-icon="kbq-link_16"></i>
                         </button>
-                        <button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent" kbq-button>
+                        <button kbq-button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent">
                             <i kbq-icon="kbq-arrows-expand-diagonal_16"></i>
                         </button>
                     </div>
@@ -47,8 +47,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
                     }
                 </kbq-content-panel-body>
                 <kbq-content-panel-footer>
-                    <button [color]="componentColors.Contrast" kbq-button>Button 1</button>
-                    <button [color]="componentColors.ContrastFade" kbq-button>Button 2</button>
+                    <button kbq-button [color]="componentColors.Contrast">Button 1</button>
+                    <button kbq-button [color]="componentColors.ContrastFade">Button 2</button>
                 </kbq-content-panel-footer>
             </kbq-content-panel>
         </kbq-content-panel-container>

--- a/packages/docs-examples/components/content-panel/content-panel-with-grid/content-panel-with-grid-example.ts
+++ b/packages/docs-examples/components/content-panel/content-panel-with-grid/content-panel-with-grid-example.ts
@@ -26,6 +26,9 @@ type ExampleRowData = Record<string, string>;
     selector: 'example-grid',
     template: `
         <ag-grid-angular
+            rowSelection="multiple"
+            kbqAgGridTheme
+            disableCellFocusStyles
             [style.height]="'100%'"
             [columnDefs]="columnDefs"
             [defaultColDef]="defaultColDef"
@@ -35,9 +38,6 @@ type ExampleRowData = Record<string, string>;
             (cellClicked)="cellClicked.emit($event)"
             (cellFocused)="cellFocused.emit($event)"
             (cellKeyDown)="cellKeyDown.emit($event)"
-            rowSelection="multiple"
-            kbqAgGridTheme
-            disableCellFocusStyles
         />
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -108,8 +108,8 @@ export class ExampleGrid {
         <kbq-modal-title class="example-modal-title">
             <div>Click any table row to open Content panel</div>
             <div class="example-modal-title-actions">
-                <button [color]="componentColors.Contrast" (click)="modalRef.close()" kbq-button>Close window</button>
-                <button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent" kbq-button>
+                <button kbq-button [color]="componentColors.Contrast" (click)="modalRef.close()">Close window</button>
+                <button kbq-button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent">
                     <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                 </button>
             </div>
@@ -125,10 +125,10 @@ export class ExampleGrid {
                     <kbq-content-panel-aside>
                         @for (_i of [0, 1, 2, 3]; track $index) {
                             <button
+                                kbq-button
                                 [class.kbq-active]="$index === 0"
                                 [color]="componentColors.Contrast"
                                 [kbqStyle]="buttonStyles.Transparent"
-                                kbq-button
                             >
                                 <i kbq-icon="kbq-bug_16"></i>
                             </button>
@@ -141,27 +141,27 @@ export class ExampleGrid {
                             <a kbq-link pseudo>July 21, 2025 2:29 PM</a>
                         </div>
                         <div class="example-content-header-actions" kbqContentPanelHeaderActions>
-                            <button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent" kbq-button>
+                            <button kbq-button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent">
                                 <i kbq-icon="kbq-link_16"></i>
                             </button>
-                            <button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent" kbq-button>
+                            <button kbq-button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent">
                                 <i kbq-icon="kbq-arrows-expand-diagonal_16"></i>
                             </button>
-                            <button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent" kbq-button>
+                            <button kbq-button [color]="componentColors.Contrast" [kbqStyle]="buttonStyles.Transparent">
                                 <i kbq-icon="kbq-ellipsis-vertical_16"></i>
                             </button>
                         </div>
                         <div class="example-content-header-caption">Caption</div>
                         <div class="example-content-header-buttons">
-                            <button [color]="componentColors.ContrastFade" kbq-button>
+                            <button kbq-button [color]="componentColors.ContrastFade">
                                 <i kbq-icon="kbq-pencil_16"></i>
                                 Edit
                             </button>
-                            <button [color]="componentColors.ContrastFade" kbq-button>
+                            <button kbq-button [color]="componentColors.ContrastFade">
                                 <i kbq-icon="kbq-square-multiple-o_16"></i>
                                 Copy
                             </button>
-                            <button [color]="componentColors.ContrastFade" kbq-button>
+                            <button kbq-button [color]="componentColors.ContrastFade">
                                 <i kbq-icon="kbq-trash_16"></i>
                                 Delete
                             </button>
@@ -183,9 +183,9 @@ export class ExampleGrid {
                         }
                     </kbq-content-panel-body>
                     <kbq-content-panel-footer>
-                        <button [color]="componentColors.Contrast" kbq-button>Button 1</button>
-                        <button [color]="componentColors.ContrastFade" kbq-button>Button 2</button>
-                        <button [color]="componentColors.ContrastFade" kbq-button>Button 3</button>
+                        <button kbq-button [color]="componentColors.Contrast">Button 1</button>
+                        <button kbq-button [color]="componentColors.ContrastFade">Button 2</button>
+                        <button kbq-button [color]="componentColors.ContrastFade">Button 3</button>
                     </kbq-content-panel-footer>
                 </kbq-content-panel>
             </kbq-content-panel-container>
@@ -294,7 +294,7 @@ export class ExampleContentPanel {
     imports: [KbqButtonModule, KbqModalModule],
     selector: 'content-panel-with-grid-example',
     template: `
-        <button (click)="openModal()" kbq-button>Show example</button>
+        <button kbq-button (click)="openModal()">Show example</button>
     `,
     styles: `
         :host {

--- a/packages/docs-examples/components/datepicker/datepicker-and-timepicker/datepicker-and-timepicker-example.ts
+++ b/packages/docs-examples/components/datepicker/datepicker-and-timepicker/datepicker-and-timepicker-example.ts
@@ -32,13 +32,13 @@ import { DateTime } from 'luxon';
                     <div>
                         <kbq-form-field class="layout-margin-right-s" (click)="datepicker.toggle()">
                             <input [kbqDatepicker]="datepicker" [ngModel]="selectedDateTime" />
-                            <kbq-datepicker-toggle-icon [for]="datepicker" kbqSuffix />
+                            <kbq-datepicker-toggle-icon kbqSuffix [for]="datepicker" />
                             <kbq-datepicker #datepicker />
                         </kbq-form-field>
 
                         <kbq-form-field>
                             <i kbq-icon="kbq-clock_16" kbqPrefix></i>
-                            <input [ngModel]="selectedDateTime" kbqTimepicker />
+                            <input kbqTimepicker [ngModel]="selectedDateTime" />
                         </kbq-form-field>
                     </div>
                 </div>

--- a/packages/docs-examples/components/datepicker/datepicker-inactive/datepicker-inactive-example.ts
+++ b/packages/docs-examples/components/datepicker/datepicker-inactive/datepicker-inactive-example.ts
@@ -28,7 +28,7 @@ import { DateTime } from 'luxon';
                 <label class="kbq-form__label">Disabled empty field</label>
                 <kbq-form-field>
                     <input [disabled]="true" [kbqDatepicker]="emptyDatepicker" [placeholder]="''" />
-                    <kbq-datepicker-toggle-icon [for]="emptyDatepicker" kbqSuffix />
+                    <kbq-datepicker-toggle-icon kbqSuffix [for]="emptyDatepicker" />
                     <kbq-datepicker #emptyDatepicker />
                 </kbq-form-field>
             </div>
@@ -39,7 +39,7 @@ import { DateTime } from 'luxon';
                 <label class="kbq-form__label">Read-only field with data</label>
                 <kbq-form-field>
                     <input [disabled]="true" [kbqDatepicker]="datepicker" [ngModel]="selectedDate" />
-                    <kbq-datepicker-toggle-icon [for]="datepicker" kbqSuffix />
+                    <kbq-datepicker-toggle-icon kbqSuffix [for]="datepicker" />
                     <kbq-datepicker #datepicker />
                 </kbq-form-field>
             </div>

--- a/packages/docs-examples/components/datepicker/datepicker-minimax/datepicker-minimax-example.ts
+++ b/packages/docs-examples/components/datepicker/datepicker-minimax/datepicker-minimax-example.ts
@@ -40,7 +40,7 @@ import { DateTime } from 'luxon';
                             [max]="maxDate"
                             [min]="minDate"
                         />
-                        <kbq-datepicker-toggle-icon [for]="datepicker" kbqSuffix />
+                        <kbq-datepicker-toggle-icon kbqSuffix [for]="datepicker" />
                         <kbq-datepicker #datepicker [maxDate]="maxDate" [minDate]="minDate" />
                     </kbq-form-field>
                 </div>

--- a/packages/docs-examples/components/datepicker/datepicker-overview/datepicker-overview-example.ts
+++ b/packages/docs-examples/components/datepicker/datepicker-overview/datepicker-overview-example.ts
@@ -23,8 +23,8 @@ import { DateTime } from 'luxon';
     template: `
         <div class="docs-example__datepicker-overview">
             <kbq-form-field (click)="datepicker.toggle()">
-                <input [(ngModel)]="date" [kbqDatepicker]="datepicker" />
-                <kbq-datepicker-toggle-icon [for]="datepicker" kbqSuffix />
+                <input [kbqDatepicker]="datepicker" [(ngModel)]="date" />
+                <kbq-datepicker-toggle-icon kbqSuffix [for]="datepicker" />
                 <kbq-datepicker #datepicker />
             </kbq-form-field>
         </div>

--- a/packages/docs-examples/components/datepicker/datepicker-range/datepicker-range-example.ts
+++ b/packages/docs-examples/components/datepicker/datepicker-range/datepicker-range-example.ts
@@ -28,13 +28,13 @@ import { DateTime } from 'luxon';
                     <div>
                         <kbq-form-field class="layout-margin-right-s" (click)="datepicker.toggle()">
                             <input [kbqDatepicker]="datepicker" />
-                            <kbq-datepicker-toggle-icon [for]="datepicker" kbqSuffix />
+                            <kbq-datepicker-toggle-icon kbqSuffix [for]="datepicker" />
                             <kbq-datepicker #datepicker />
                         </kbq-form-field>
 
                         <kbq-form-field (click)="datepicker2.toggle()">
                             <input [kbqDatepicker]="datepicker2" />
-                            <kbq-datepicker-toggle-icon [for]="datepicker2" kbqSuffix />
+                            <kbq-datepicker-toggle-icon kbqSuffix [for]="datepicker2" />
                             <kbq-datepicker #datepicker2 />
                         </kbq-form-field>
                     </div>

--- a/packages/docs-examples/components/datepicker/datepicker-required/datepicker-required-example.ts
+++ b/packages/docs-examples/components/datepicker/datepicker-required/datepicker-required-example.ts
@@ -23,8 +23,8 @@ import { DateTime } from 'luxon';
     template: `
         <div class="docs-example__datepicker-required">
             <kbq-form-field (click)="datepicker.toggle()">
-                <input [(ngModel)]="date" [kbqDatepicker]="datepicker" [required]="true" />
-                <kbq-datepicker-toggle-icon [for]="datepicker" kbqSuffix />
+                <input [kbqDatepicker]="datepicker" [required]="true" [(ngModel)]="date" />
+                <kbq-datepicker-toggle-icon kbqSuffix [for]="datepicker" />
                 <kbq-datepicker #datepicker />
             </kbq-form-field>
         </div>

--- a/packages/docs-examples/components/divider/divider-vertical/divider-vertical-example.ts
+++ b/packages/docs-examples/components/divider/divider-vertical/divider-vertical-example.ts
@@ -12,7 +12,7 @@ import { KbqDividerModule } from '@koobiq/components/divider';
         KbqDividerModule
     ],
     template: `
-        <kbq-divider [vertical]="true" style="margin: 20px; height: 50px" />
+        <kbq-divider style="margin: 20px; height: 50px" [vertical]="true" />
     `
 })
 export class DividerVerticalExample {}

--- a/packages/docs-examples/components/dropdown/dropdown-lazyload-data/dropdown-lazyload-data-example.html
+++ b/packages/docs-examples/components/dropdown/dropdown-lazyload-data/dropdown-lazyload-data-example.html
@@ -8,7 +8,7 @@
 </button>
 
 <kbq-dropdown #appDropdownLazy="kbqDropdown">
-    <ng-template kbqDropdownContent let-someValue="someValue">
+    <ng-template let-someValue="someValue" kbqDropdownContent>
         <button kbq-dropdown-item>dropdown</button>
         <button kbq-dropdown-item>
             Point 1

--- a/packages/docs-examples/components/dropdown/dropdown-recursive-template/dropdown-recursive-template-example.ts
+++ b/packages/docs-examples/components/dropdown/dropdown-recursive-template/dropdown-recursive-template-example.ts
@@ -57,7 +57,7 @@ export class ExampleDropdownPortal implements OnInit {
         ExampleDropdownPortal
     ],
     template: `
-        <button [kbqDropdownTriggerFor]="egDropdown" kbq-button>
+        <button kbq-button [kbqDropdownTriggerFor]="egDropdown">
             dropdown
             <i kbq-icon="kbq-chevron-down-s_16"></i>
         </button>
@@ -72,7 +72,7 @@ export class ExampleDropdownPortal implements OnInit {
 
             <ng-template #dropdownItemTpl let-item="item">
                 @if (item.children) {
-                    <button [kbqDropdownTriggerFor]="egDropdownNested" kbq-dropdown-item>
+                    <button kbq-dropdown-item [kbqDropdownTriggerFor]="egDropdownNested">
                         {{ item.label }}
                     </button>
 

--- a/packages/docs-examples/components/empty-state/empty-state-actions/empty-state-actions-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-actions/empty-state-actions-example.ts
@@ -18,11 +18,11 @@ import { KbqEmptyStateModule } from '@koobiq/components/empty-state';
         <kbq-empty-state style="min-height: 216px">
             <div kbq-empty-state-text>{{ emptyStateText }}</div>
             <div class="layout-row layout-align-center" kbq-empty-state-actions style="min-width: 340px">
-                <button class="layout-margin-right-s" [color]="colors.Contrast" [kbqStyle]="styles.Filled" kbq-button>
+                <button class="layout-margin-right-s" kbq-button [color]="colors.Contrast" [kbqStyle]="styles.Filled">
                     {{ buttonText }}
                 </button>
 
-                <button [color]="colors.ContrastFade" [kbqStyle]="styles.Filled" kbq-button>Объединить группы</button>
+                <button kbq-button [color]="colors.ContrastFade" [kbqStyle]="styles.Filled">Объединить группы</button>
             </div>
         </kbq-empty-state>
     `

--- a/packages/docs-examples/components/empty-state/empty-state-actions2/empty-state-actions2-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-actions2/empty-state-actions2-example.ts
@@ -18,9 +18,9 @@ import { KbqEmptyStateModule } from '@koobiq/components/empty-state';
         <kbq-empty-state style="min-height: 216px">
             <div kbq-empty-state-text>{{ emptyStateText }}</div>
             <div kbq-empty-state-actions>
-                <button [color]="colors.Theme" [kbqStyle]="styles.Transparent" kbq-button>Action 1</button>
-                <button [color]="colors.Theme" [kbqStyle]="styles.Transparent" kbq-button>Action 2</button>
-                <button [color]="colors.Theme" [kbqStyle]="styles.Transparent" kbq-button>Action 3</button>
+                <button kbq-button [color]="colors.Theme" [kbqStyle]="styles.Transparent">Action 1</button>
+                <button kbq-button [color]="colors.Theme" [kbqStyle]="styles.Transparent">Action 2</button>
+                <button kbq-button [color]="colors.Theme" [kbqStyle]="styles.Transparent">Action 3</button>
             </div>
         </kbq-empty-state>
     `

--- a/packages/docs-examples/components/empty-state/empty-state-align/empty-state-align-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-align/empty-state-align-example.ts
@@ -22,19 +22,19 @@ import { KbqIconModule } from '@koobiq/components/icon';
                 <div kbq-empty-state-title>Нет групп</div>
                 <div kbq-empty-state-text>{{ emptyStateText }}</div>
                 <div kbq-empty-state-actions>
-                    <button [color]="colors.Theme" [kbqStyle]="styles.Transparent" kbq-button>
-                        <i [color]="'theme'" kbq-icon="kbq-plus_16"></i>
+                    <button kbq-button [color]="colors.Theme" [kbqStyle]="styles.Transparent">
+                        <i kbq-icon="kbq-plus_16" [color]="'theme'"></i>
                         {{ buttonText }}
                     </button>
                 </div>
             </kbq-empty-state>
 
-            <kbq-empty-state class="flex" [alignTop]="true" style="min-height: 216px">
+            <kbq-empty-state class="flex" style="min-height: 216px" [alignTop]="true">
                 <div kbq-empty-state-title>Нет групп</div>
                 <div kbq-empty-state-text>{{ emptyStateText }}</div>
                 <div kbq-empty-state-actions>
-                    <button [color]="colors.Theme" [kbqStyle]="styles.Transparent" kbq-button>
-                        <i [color]="'theme'" kbq-icon="kbq-plus_16"></i>
+                    <button kbq-button [color]="colors.Theme" [kbqStyle]="styles.Transparent">
+                        <i kbq-icon="kbq-plus_16" [color]="'theme'"></i>
                         {{ buttonText }}
                     </button>
                 </div>

--- a/packages/docs-examples/components/empty-state/empty-state-big/empty-state-big-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-big/empty-state-big-example.ts
@@ -20,8 +20,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
             <div kbq-empty-state-title>Нет групп</div>
             <div kbq-empty-state-text>{{ emptyStateText }}</div>
             <div kbq-empty-state-actions>
-                <button [color]="'theme'" [kbqStyle]="'transparent'" kbq-button>
-                    <i [color]="'theme'" kbq-icon="kbq-plus_16"></i>
+                <button kbq-button [color]="'theme'" [kbqStyle]="'transparent'">
+                    <i kbq-icon="kbq-plus_16" [color]="'theme'"></i>
                     {{ buttonText }}
                 </button>
             </div>

--- a/packages/docs-examples/components/empty-state/empty-state-content/empty-state-content-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-content/empty-state-content-example.ts
@@ -24,18 +24,18 @@ import { map } from 'rxjs/operators';
             <kbq-empty-state class="flex" size="big" style="min-height: 216px">
                 <div kbq-empty-state-icon>
                     <img
-                        [srcset]="srcSet()"
                         alt="Empty state"
                         height="192"
-                        src="assets/images/{{ currentTheme() }}/empty_192.png"
                         width="192"
+                        [srcset]="srcSet()"
+                        src="assets/images/{{ currentTheme() }}/empty_192.png"
                     />
                 </div>
                 <div kbq-empty-state-title>Нет групп</div>
                 <div kbq-empty-state-text>{{ emptyStateText }}</div>
                 <div kbq-empty-state-actions>
-                    <button [color]="colors.Theme" [kbqStyle]="styles.Transparent" kbq-button>
-                        <i [color]="'theme'" kbq-icon="kbq-plus_16"></i>
+                    <button kbq-button [color]="colors.Theme" [kbqStyle]="styles.Transparent">
+                        <i kbq-icon="kbq-plus_16" [color]="'theme'"></i>
                         {{ buttonText }}
                     </button>
                 </div>
@@ -44,18 +44,18 @@ import { map } from 'rxjs/operators';
             <kbq-empty-state class="flex" style="min-height: 216px">
                 <div kbq-empty-state-icon>
                     <img
-                        [srcset]="srcSet()"
-                        src="assets/images/{{ currentTheme() }}/empty_192.png"
                         alt="Empty state"
                         width="80"
                         height="80"
+                        [srcset]="srcSet()"
+                        src="assets/images/{{ currentTheme() }}/empty_192.png"
                     />
                 </div>
                 <div kbq-empty-state-title>Нет групп</div>
                 <div kbq-empty-state-text>{{ emptyStateText }}</div>
                 <div kbq-empty-state-actions>
-                    <button [color]="colors.Theme" [kbqStyle]="styles.Transparent" kbq-button>
-                        <i [color]="'theme'" kbq-icon="kbq-plus_16"></i>
+                    <button kbq-button [color]="colors.Theme" [kbqStyle]="styles.Transparent">
+                        <i kbq-icon="kbq-plus_16" [color]="'theme'"></i>
                         {{ buttonText }}
                     </button>
                 </div>

--- a/packages/docs-examples/components/empty-state/empty-state-default/empty-state-default-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-default/empty-state-default-example.ts
@@ -20,8 +20,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
             <div kbq-empty-state-title>Нет групп</div>
             <div kbq-empty-state-text>{{ emptyStateText }}</div>
             <div kbq-empty-state-actions>
-                <button [color]="'theme'" [kbqStyle]="'transparent'" kbq-button>
-                    <i [color]="'theme'" kbq-icon="kbq-plus_16"></i>
+                <button kbq-button [color]="'theme'" [kbqStyle]="'transparent'">
+                    <i kbq-icon="kbq-plus_16" [color]="'theme'"></i>
                     {{ buttonText }}
                 </button>
             </div>

--- a/packages/docs-examples/components/empty-state/empty-state-error/empty-state-error-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-error/empty-state-error-example.ts
@@ -16,20 +16,20 @@ import { KbqIconModule } from '@koobiq/components/icon';
         KbqIconModule
     ],
     template: `
-        <kbq-empty-state [errorColor]="true" style="min-height: 216px">
+        <kbq-empty-state style="min-height: 216px" [errorColor]="true">
             <i
+                kbq-empty-state-icon
+                kbq-icon-item="kbq-exclamation-triangle_16"
                 [big]="true"
                 [color]="'contrast'"
                 [fade]="true"
-                kbq-empty-state-icon
-                kbq-icon-item="kbq-exclamation-triangle_16"
             ></i>
             <div kbq-empty-state-title>Не удалось показать записи</div>
             <div kbq-empty-state-text>
                 {{ emptyStateText }}
             </div>
             <div kbq-empty-state-actions>
-                <button [color]="'theme'" [kbqStyle]="'transparent'" kbq-button>Обновить</button>
+                <button kbq-button [color]="'theme'" [kbqStyle]="'transparent'">Обновить</button>
             </div>
         </kbq-empty-state>
     `

--- a/packages/docs-examples/components/empty-state/empty-state-icon/empty-state-icon-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-icon/empty-state-icon-example.ts
@@ -16,7 +16,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <kbq-empty-state style="min-height: 216px">
             <div kbq-empty-state-icon>
-                <i [big]="true" [color]="'contrast'" [fade]="true" kbq-icon-item="kbq-info-circle_16"></i>
+                <i kbq-icon-item="kbq-info-circle_16" [big]="true" [color]="'contrast'" [fade]="true"></i>
             </div>
             <div kbq-empty-state-text>
                 This should detail the actions you can take on this screen, as well as why it’s valuable.

--- a/packages/docs-examples/components/empty-state/empty-state-size/empty-state-size-example.ts
+++ b/packages/docs-examples/components/empty-state/empty-state-size/empty-state-size-example.ts
@@ -29,12 +29,12 @@ import { KbqIconModule } from '@koobiq/components/icon';
             </kbq-button-toggle-group>
         </div>
 
-        <kbq-empty-state [size]="size()" style="min-height: 216px">
+        <kbq-empty-state style="min-height: 216px" [size]="size()">
             <div kbq-empty-state-title>No Groups</div>
             <div kbq-empty-state-text>{{ emptyStateText }}</div>
             <div kbq-empty-state-actions>
-                <button [color]="'theme'" [kbqStyle]="'transparent'" kbq-button>
-                    <i [color]="'theme'" kbq-icon="kbq-plus_16"></i>
+                <button kbq-button [color]="'theme'" [kbqStyle]="'transparent'">
+                    <i kbq-icon="kbq-plus_16" [color]="'theme'"></i>
                     {{ buttonText }}
                 </button>
             </div>

--- a/packages/docs-examples/components/experimental-form-field/experimental-form-field-password-overview/experimental-form-field-password-overview-example.ts
+++ b/packages/docs-examples/components/experimental-form-field/experimental-form-field-password-overview/experimental-form-field-password-overview-example.ts
@@ -15,7 +15,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     ],
     template: `
         <kbq-form-field>
-            <input [formControl]="formControl" placeholder="Password" kbqInputPassword />
+            <input placeholder="Password" kbqInputPassword [formControl]="formControl" />
 
             <kbq-password-toggle />
 

--- a/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-cleaner/experimental-form-field-with-cleaner-example.ts
+++ b/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-cleaner/experimental-form-field-with-cleaner-example.ts
@@ -14,7 +14,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     ],
     template: `
         <kbq-form-field>
-            <input [formControl]="formControl" kbqInput placeholder="Enter some input" />
+            <input kbqInput placeholder="Enter some input" [formControl]="formControl" />
             <kbq-cleaner />
         </kbq-form-field>
     `,

--- a/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-custom-error-state-matcher-set-by-attribute/experimental-form-field-with-custom-error-state-matcher-set-by-attribute-example.ts
+++ b/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-custom-error-state-matcher-set-by-attribute/experimental-form-field-with-custom-error-state-matcher-set-by-attribute-example.ts
@@ -38,10 +38,10 @@ class CustomErrorStateMatcher implements ErrorStateMatcher {
             <kbq-form-field>
                 <kbq-label>Email</kbq-label>
                 <input
-                    [errorStateMatcher]="customErrorStateMatcher"
                     formControlName="email"
                     kbqInput
                     placeholder="mail@koobiq.io"
+                    [errorStateMatcher]="customErrorStateMatcher"
                 />
                 <kbq-hint>Enter email</kbq-hint>
                 <kbq-error>

--- a/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-error/experimental-form-field-with-error-example.ts
+++ b/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-error/experimental-form-field-with-error-example.ts
@@ -15,7 +15,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     template: `
         <kbq-form-field>
             <kbq-label>Email</kbq-label>
-            <input [formControl]="formControl" kbqInput placeholder="mail@koobiq.io" />
+            <input kbqInput placeholder="mail@koobiq.io" [formControl]="formControl" />
             <kbq-hint>Enter email</kbq-hint>
             <kbq-error>
                 @if (formControl.hasError('required')) {

--- a/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-hint/experimental-form-field-with-hint-example.ts
+++ b/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-hint/experimental-form-field-with-hint-example.ts
@@ -13,7 +13,7 @@ import { map } from 'rxjs';
     template: `
         <kbq-form-field>
             <kbq-label>Article title</kbq-label>
-            <input [formControl]="formControl" [maxlength]="maxLength" kbqInput placeholder="Article title" />
+            <input kbqInput placeholder="Article title" [formControl]="formControl" [maxlength]="maxLength" />
             <kbq-hint>Max {{ maxLength }} chars ({{ count() }}/{{ maxLength }})</kbq-hint>
         </kbq-form-field>
     `,

--- a/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-prefix-and-suffix/experimental-form-field-with-prefix-and-suffix-example.ts
+++ b/packages/docs-examples/components/experimental-form-field/experimental-form-field-with-prefix-and-suffix/experimental-form-field-with-prefix-and-suffix-example.ts
@@ -17,7 +17,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     template: `
         <kbq-form-field>
             <i kbqPrefix kbq-icon="kbq-magnifying-glass_16"></i>
-            <input [formControl]="formControl" kbqInput placeholder="Search" />
+            <input kbqInput placeholder="Search" [formControl]="formControl" />
             <i kbqSuffix kbq-icon="kbq-info-circle_16"></i>
             <kbq-cleaner />
         </kbq-form-field>

--- a/packages/docs-examples/components/experimental-form-field/experimental-form-field-without-borders/experimental-form-field-without-borders-example.ts
+++ b/packages/docs-examples/components/experimental-form-field/experimental-form-field-without-borders/experimental-form-field-without-borders-example.ts
@@ -14,7 +14,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     ],
     template: `
         <kbq-form-field noBorders>
-            <input [formControl]="formControl" placeholder="Form field without borders" kbqInput />
+            <input placeholder="Form field without borders" kbqInput [formControl]="formControl" />
             <kbq-error>Should enter a value</kbq-error>
         </kbq-form-field>
     `,

--- a/packages/docs-examples/components/file-upload/file-upload-indeterminate-loading-overview/file-upload-indeterminate-loading-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-indeterminate-loading-overview/file-upload-indeterminate-loading-overview-example.ts
@@ -16,11 +16,11 @@ import { take } from 'rxjs/operators';
         KbqIconModule
     ],
     template: `
-        <kbq-file-upload (fileQueueChange)="onFileChange($event)" progressMode="indeterminate">
+        <kbq-file-upload progressMode="indeterminate" (fileQueueChange)="onFileChange($event)">
             <i kbq-icon="kbq-file-o_16"></i>
         </kbq-file-upload>
 
-        <kbq-file-upload (fileQueueChanged)="onFilesChange($event)" multiple progressMode="indeterminate">
+        <kbq-file-upload multiple progressMode="indeterminate" (fileQueueChanged)="onFilesChange($event)">
             <ng-template #kbqFileIcon>
                 <i kbq-icon="kbq-file-o_16"></i>
             </ng-template>

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-accept-validation/file-upload-multiple-accept-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-accept-validation/file-upload-multiple-accept-validation-example.ts
@@ -13,7 +13,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
     standalone: true,
     selector: 'file-upload-multiple-accept-validation-example',
     template: `
-        <kbq-file-upload (fileRemoved)="onFileRemoved($event)" (filesAdded)="onFilesAdded($event)" multiple>
+        <kbq-file-upload multiple (fileRemoved)="onFileRemoved($event)" (filesAdded)="onFilesAdded($event)">
             <ng-template #kbqFileIcon let-file>
                 @if (!file.hasError) {
                     <i kbq-icon="kbq-file-o_16"></i>

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-default-validation-reactive-forms-overview/file-upload-multiple-default-validation-reactive-forms-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-default-validation-reactive-forms-overview/file-upload-multiple-default-validation-reactive-forms-overview-example.ts
@@ -16,10 +16,10 @@ const MAX_FILE_SIZE = 5 * 2 ** 20;
     selector: 'file-upload-multiple-default-validation-reactive-forms-overview-example',
     template: `
         <kbq-file-upload
+            multiple
             [progressMode]="'indeterminate'"
             (fileRemoved)="onFileRemoved($event)"
             (filesAdded)="onFilesAdded($event)"
-            multiple
         >
             <ng-template #kbqFileIcon let-file>
                 @if (!file.hasError) {

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-error-overview/file-upload-multiple-error-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-error-overview/file-upload-multiple-error-overview-example.ts
@@ -17,7 +17,7 @@ const maxFileExceeded = (file: File): string | null => {
     standalone: true,
     selector: 'file-upload-multiple-error-overview-example',
     template: `
-        <kbq-multiple-file-upload (fileQueueChanged)="onChange($event)" inputId="file-upload-multiple-error-overview">
+        <kbq-multiple-file-upload inputId="file-upload-multiple-error-overview" (fileQueueChanged)="onChange($event)">
             <ng-template #kbqFileIcon let-file>
                 @if (!file.hasError) {
                     <i kbq-icon="kbq-file-o_16"></i>

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-required-reactive-validation/file-upload-multiple-required-reactive-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-required-reactive-validation/file-upload-multiple-required-reactive-validation-example.ts
@@ -15,11 +15,11 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <form [formGroup]="formMultiple" (ngSubmit)="onSubmit()">
             <kbq-file-upload
-                class="layout-margin-bottom-s"
                 #kbqFileUpload
-                [progressMode]="'indeterminate'"
+                class="layout-margin-bottom-s"
                 formControlName="fileUpload"
                 multiple
+                [progressMode]="'indeterminate'"
             >
                 <ng-template #kbqFileIcon>
                     <i kbq-icon="kbq-file-o_16"></i>

--- a/packages/docs-examples/components/file-upload/file-upload-single-accept-validation/file-upload-single-accept-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-accept-validation/file-upload-single-accept-validation-example.ts
@@ -14,7 +14,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
     selector: 'file-upload-single-accept-validation-example',
     template: `
         <form [formGroup]="formGroup">
-            <kbq-file-upload class="layout-margin-bottom-s" [accept]="accept" formControlName="fileControl">
+            <kbq-file-upload class="layout-margin-bottom-s" formControlName="fileControl" [accept]="accept">
                 @if (!formGroup.get('fileControl')?.errors) {
                     <i kbq-icon="kbq-file-o_16"></i>
                 }

--- a/packages/docs-examples/components/file-upload/file-upload-single-error-overview/file-upload-single-error-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-error-overview/file-upload-single-error-overview-example.ts
@@ -12,9 +12,9 @@ import { KbqIconModule } from '@koobiq/components/icon';
     selector: 'file-upload-single-error-overview-example',
     template: `
         <kbq-single-file-upload
+            inputId="file-upload-single-error-overview"
             [file]="file"
             (fileQueueChange)="onChange($event)"
-            inputId="file-upload-single-error-overview"
         >
             @if (!errors.length) {
                 <i kbq-icon="kbq-file-o_16"></i>

--- a/packages/docs-examples/components/file-upload/file-upload-single-required-reactive-validation/file-upload-single-required-reactive-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-required-reactive-validation/file-upload-single-required-reactive-validation-example.ts
@@ -15,10 +15,10 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <form [formGroup]="formMultiple" (ngSubmit)="onSubmit()">
             <kbq-file-upload
-                class="layout-margin-bottom-s"
                 #kbqFileUpload
-                [progressMode]="'indeterminate'"
+                class="layout-margin-bottom-s"
                 formControlName="fileUpload"
+                [progressMode]="'indeterminate'"
             >
                 <i kbq-icon="kbq-file-o_16"></i>
                 @if (formMultiple.controls.fileUpload.invalid && kbqFileUpload.invalid) {

--- a/packages/docs-examples/components/file-upload/file-upload-single-with-signal/file-upload-single-with-signal-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-with-signal/file-upload-single-with-signal-example.ts
@@ -16,7 +16,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
             </kbq-file-upload>
         </div>
 
-        <kbq-file-upload [files]="files()" (fileQueueChanged)="onMultipleChange($event)" multiple>
+        <kbq-file-upload multiple [files]="files()" (fileQueueChanged)="onMultipleChange($event)">
             <i kbq-icon="kbq-file-o_16"></i>
         </kbq-file-upload>
     `,

--- a/packages/docs-examples/components/filesize-formatter/filesize-formatter-overview/filesize-formatter-overview-example.ts
+++ b/packages/docs-examples/components/filesize-formatter/filesize-formatter-overview/filesize-formatter-overview-example.ts
@@ -42,7 +42,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
                 <div class="kbq-form__row">
                     <label class="kbq-form__label">Size in bits</label>
                     <kbq-form-field class="kbq-form__control">
-                        <input [min]="0" [formControl]="bytesControl" kbqNumberInput kbqNormalizeWhitespace />
+                        <input kbqNumberInput kbqNormalizeWhitespace [min]="0" [formControl]="bytesControl" />
                         <kbq-stepper />
                     </kbq-form-field>
                 </div>
@@ -64,11 +64,11 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
                     <label class="kbq-form__label">
                         Base
                         <i
+                            kbq-icon="kbq-question-circle_16"
                             [color]="'contrast-fade'"
                             [style.cursor]="'help'"
                             [kbqPlacement]="popUpPlacements.Right"
                             [kbqTooltip]="tooltipText"
-                            kbq-icon="kbq-question-circle_16"
                         ></i>
                     </label>
                     <kbq-form-field class="kbq-form__control">

--- a/packages/docs-examples/components/filter-bar/filter-bar-complete-functions/filter-bar-complete-functions-example.ts
+++ b/packages/docs-examples/components/filter-bar/filter-bar-complete-functions/filter-bar-complete-functions-example.ts
@@ -44,7 +44,7 @@ import { DateTime } from 'luxon';
         </kbq-filter-bar>
 
         <ng-template #optionTemplate let-option="option">
-            <i [color]="option.type" kbq-icon="kbq-square_16"></i>
+            <i kbq-icon="kbq-square_16" [color]="option.type"></i>
             {{ option.name }}
         </ng-template>
     `

--- a/packages/docs-examples/components/filter-bar/filter-bar-custom-pipe/filter-bar-custom-pipe-example.ts
+++ b/packages/docs-examples/components/filter-bar/filter-bar-custom-pipe/filter-bar-custom-pipe-example.ts
@@ -29,6 +29,8 @@ import { KbqTitleModule } from '@koobiq/components/title';
     selector: 'color-pipe',
     template: `
         <button
+            kbq-button
+            kbqPopover
             [disabled]="data.disabled"
             [kbqPipeState]="data"
             [kbqPipeTitle]="pipeTooltip"
@@ -38,11 +40,9 @@ import { KbqTitleModule } from '@koobiq/components/title';
             [kbqPopoverOffset]="4"
             [kbqPopoverPlacement]="placements.BottomLeft"
             [ngClass]="{ 'kbq-active': popover?.isOpen }"
-            kbq-button
-            kbqPopover
         >
-            <span class="kbq-pipe__name" #kbqTitleText kbqPipeMinWidth>{{ data.name }}</span>
-            <span class="kbq-pipe__value" #kbqTitleText [class.kbq-pipe__value_empty]="!data.value" kbqPipeMinWidth>
+            <span #kbqTitleText class="kbq-pipe__name" kbqPipeMinWidth>{{ data.name }}</span>
+            <span #kbqTitleText class="kbq-pipe__value" kbqPipeMinWidth [class.kbq-pipe__value_empty]="!data.value">
                 {{ data.value }}
             </span>
         </button>
@@ -54,10 +54,10 @@ import { KbqTitleModule } from '@koobiq/components/title';
         <ng-template #content>
             <input
                 class="layout-margin-bottom-s"
-                [(ngModel)]="data.value"
-                (keydown.enter)="popover.hide()"
                 type="color"
                 style="width:100%;"
+                [(ngModel)]="data.value"
+                (keydown.enter)="popover.hide()"
             />
         </ng-template>
 

--- a/packages/docs-examples/components/filter-bar/filter-bar-overview/filter-bar-overview-example.ts
+++ b/packages/docs-examples/components/filter-bar/filter-bar-overview/filter-bar-overview-example.ts
@@ -23,8 +23,8 @@ import {
     ],
     template: `
         <kbq-filter-bar
-            [(filter)]="activeFilter"
             [pipeTemplates]="pipeTemplates"
+            [(filter)]="activeFilter"
             (filterChange)="onFilterChange($event)"
         >
             <kbq-filters

--- a/packages/docs-examples/components/filter-bar/filter-bar-readonly-pipes/filter-bar-readonly-pipes-example.ts
+++ b/packages/docs-examples/components/filter-bar/filter-bar-readonly-pipes/filter-bar-readonly-pipes-example.ts
@@ -35,12 +35,12 @@ import { KbqLinkModule } from '@koobiq/components/link';
 
         <kbq-dl [minWidth]="590">
             <kbq-dt>Пользователь</kbq-dt>
-            <kbq-dd><span (click)="setUser('Пользователь', 'rturov')" kbq-link pseudo>rturov</span></kbq-dd>
+            <kbq-dd><span kbq-link pseudo (click)="setUser('Пользователь', 'rturov')">rturov</span></kbq-dd>
 
             @for (item of readonlyPipes; track item) {
                 <kbq-dt>{{ item.name }}</kbq-dt>
                 <kbq-dd>
-                    <span (click)="addPipe(item.name, item.value)" kbq-link pseudo>{{ item.value }}</span>
+                    <span kbq-link pseudo (click)="addPipe(item.name, item.value)">{{ item.value }}</span>
                 </kbq-dd>
             }
         </kbq-dl>

--- a/packages/docs-examples/components/form-field/form-field-password-overview/form-field-password-overview-example.ts
+++ b/packages/docs-examples/components/form-field/form-field-password-overview/form-field-password-overview-example.ts
@@ -12,7 +12,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     providers: [kbqDisableLegacyValidationDirectiveProvider()],
     template: `
         <kbq-form-field>
-            <input [formControl]="formControl" placeholder="Password" kbqInputPassword />
+            <input placeholder="Password" kbqInputPassword [formControl]="formControl" />
 
             <kbq-password-toggle />
 

--- a/packages/docs-examples/components/form-field/form-field-with-cleaner/form-field-with-cleaner-example.ts
+++ b/packages/docs-examples/components/form-field/form-field-with-cleaner/form-field-with-cleaner-example.ts
@@ -13,12 +13,12 @@ import { KbqSelectModule } from '@koobiq/components/select';
     providers: [kbqDisableLegacyValidationDirectiveProvider()],
     template: `
         <kbq-form-field class="layout-margin-bottom-m">
-            <input [formControl]="inputFormControl" kbqInput placeholder="Enter some input" />
+            <input kbqInput placeholder="Enter some input" [formControl]="inputFormControl" />
             <kbq-cleaner />
         </kbq-form-field>
 
         <kbq-form-field>
-            <kbq-select [formControl]="selectFormControl" placeholder="Select an option">
+            <kbq-select placeholder="Select an option" [formControl]="selectFormControl">
                 <kbq-cleaner #kbqSelectCleaner />
                 <kbq-option value="1">Option #1</kbq-option>
                 <kbq-option value="2">Option #2</kbq-option>

--- a/packages/docs-examples/components/form-field/form-field-with-custom-error-state-matcher-set-by-attribute/form-field-with-custom-error-state-matcher-set-by-attribute-example.ts
+++ b/packages/docs-examples/components/form-field/form-field-with-custom-error-state-matcher-set-by-attribute/form-field-with-custom-error-state-matcher-set-by-attribute-example.ts
@@ -34,10 +34,10 @@ class CustomErrorStateMatcher implements ErrorStateMatcher {
             <kbq-form-field>
                 <kbq-label>Email</kbq-label>
                 <input
-                    [errorStateMatcher]="customErrorStateMatcher"
                     formControlName="email"
                     kbqInput
                     placeholder="mail@koobiq.io"
+                    [errorStateMatcher]="customErrorStateMatcher"
                 />
                 <kbq-hint>Error will be shown when the control is invalid and the form is submitted</kbq-hint>
                 <kbq-error>

--- a/packages/docs-examples/components/form-field/form-field-with-error/form-field-with-error-example.ts
+++ b/packages/docs-examples/components/form-field/form-field-with-error/form-field-with-error-example.ts
@@ -13,7 +13,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     template: `
         <kbq-form-field>
             <kbq-label>Email</kbq-label>
-            <input [formControl]="formControl" kbqInput placeholder="mail@koobiq.io" />
+            <input kbqInput placeholder="mail@koobiq.io" [formControl]="formControl" />
             <kbq-hint>Enter email</kbq-hint>
             <kbq-error>
                 @if (formControl.hasError('required')) {

--- a/packages/docs-examples/components/form-field/form-field-with-hint/form-field-with-hint-example.ts
+++ b/packages/docs-examples/components/form-field/form-field-with-hint/form-field-with-hint-example.ts
@@ -15,7 +15,7 @@ import { map } from 'rxjs';
     template: `
         <kbq-form-field>
             <kbq-label>Article title</kbq-label>
-            <input [formControl]="formControl" [maxlength]="maxLength" kbqInput placeholder="Article title" />
+            <input kbqInput placeholder="Article title" [formControl]="formControl" [maxlength]="maxLength" />
             <kbq-hint>Max {{ maxLength }} chars ({{ count() }}/{{ maxLength }})</kbq-hint>
         </kbq-form-field>
     `,

--- a/packages/docs-examples/components/form-field/form-field-with-prefix-and-suffix/form-field-with-prefix-and-suffix-example.ts
+++ b/packages/docs-examples/components/form-field/form-field-with-prefix-and-suffix/form-field-with-prefix-and-suffix-example.ts
@@ -14,7 +14,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     template: `
         <kbq-form-field>
             <i kbqPrefix kbq-icon="kbq-magnifying-glass_16"></i>
-            <input [formControl]="formControl" kbqInput placeholder="Search" />
+            <input kbqInput placeholder="Search" [formControl]="formControl" />
             <i kbqSuffix kbq-icon="kbq-info-circle_16"></i>
             <kbq-cleaner />
         </kbq-form-field>

--- a/packages/docs-examples/components/form-field/form-field-without-borders/form-field-without-borders-example.ts
+++ b/packages/docs-examples/components/form-field/form-field-without-borders/form-field-without-borders-example.ts
@@ -12,7 +12,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     providers: [kbqDisableLegacyValidationDirectiveProvider()],
     template: `
         <kbq-form-field noBorders>
-            <input [formControl]="formControl" placeholder="Form field without borders" kbqInput />
+            <input placeholder="Form field without borders" kbqInput [formControl]="formControl" />
             <kbq-error>Should enter a value</kbq-error>
         </kbq-form-field>
     `,

--- a/packages/docs-examples/components/forms/form-fieldset-invalid/form-fieldset-invalid-example.ts
+++ b/packages/docs-examples/components/forms/form-fieldset-invalid/form-fieldset-invalid-example.ts
@@ -14,15 +14,15 @@ import { KbqInputModule } from '@koobiq/components/input';
         <form [formGroup]="form">
             <kbq-fieldset>
                 <kbq-form-field kbqFieldsetItem>
-                    <input [formControl]="form.controls.surname" kbqInput placeholder="Surname" />
+                    <input kbqInput placeholder="Surname" [formControl]="form.controls.surname" />
                 </kbq-form-field>
 
                 <kbq-form-field kbqFieldsetItem>
-                    <input [formControl]="form.controls.name" kbqInput placeholder="Name" />
+                    <input kbqInput placeholder="Name" [formControl]="form.controls.name" />
                 </kbq-form-field>
 
                 <kbq-form-field kbqFieldsetItem>
-                    <input [formControl]="form.controls.patronymic" kbqInput placeholder="Patronymic" />
+                    <input kbqInput placeholder="Patronymic" [formControl]="form.controls.patronymic" />
                 </kbq-form-field>
 
                 @if (form.controls.surname.hasError('required')) {

--- a/packages/docs-examples/components/forms/form-fieldset-overview/form-fieldset-overview-example.ts
+++ b/packages/docs-examples/components/forms/form-fieldset-overview/form-fieldset-overview-example.ts
@@ -17,7 +17,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
             <legend kbqLegend>Field group title</legend>
 
             <kbq-form-field style="width: 96px; min-width: 96px">
-                <kbq-select [formControl]="control" panelWidth="auto">
+                <kbq-select panelWidth="auto" [formControl]="control">
                     @for (option of options; track option) {
                         <kbq-option [value]="option">
                             <span [innerHTML]="option"></span>

--- a/packages/docs-examples/components/icon-item/icon-item-color/icon-item-color-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-color/icon-item-color-example.ts
@@ -16,27 +16,27 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <div class="example-icon-item-layout layout-row">
             <div class="example-icon-item-container">
-                <i [color]="colors.Theme" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Theme"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Theme</div>
             </div>
 
             <div class="example-icon-item-container">
-                <i [color]="colors.Contrast" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Contrast"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Contrast</div>
             </div>
 
             <div class="example-icon-item-container">
-                <i [color]="colors.Success" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Success"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Success</div>
             </div>
 
             <div class="example-icon-item-container">
-                <i [color]="colors.Warning" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Warning"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Warning</div>
             </div>
 
             <div class="example-icon-item-container">
-                <i [color]="colors.Error" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Error"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Error</div>
             </div>
         </div>

--- a/packages/docs-examples/components/icon-item/icon-item-default/icon-item-default-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-default/icon-item-default-example.ts
@@ -15,7 +15,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
     ],
     template: `
         <div class="example-icon-item-container layout-column">
-            <i [color]="colors.Theme" kbq-icon-item="kbq-bell_16"></i>
+            <i kbq-icon-item="kbq-bell_16" [color]="colors.Theme"></i>
         </div>
     `
 })

--- a/packages/docs-examples/components/icon-item/icon-item-size/icon-item-size-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-size/icon-item-size-example.ts
@@ -16,12 +16,12 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <div class="example-icon-item-layout layout-row">
             <div class="example-icon-item-container">
-                <i [big]="true" [color]="colors.Theme" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [big]="true" [color]="colors.Theme"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Big</div>
             </div>
 
             <div class="example-icon-item-container">
-                <i [color]="colors.Theme" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Theme"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Normal</div>
             </div>
         </div>

--- a/packages/docs-examples/components/icon-item/icon-item-variant/icon-item-variant-example.ts
+++ b/packages/docs-examples/components/icon-item/icon-item-variant/icon-item-variant-example.ts
@@ -16,12 +16,12 @@ import { KbqIconModule } from '@koobiq/components/icon';
     template: `
         <div class="example-icon-item-layout layout-row">
             <div class="example-icon-item-container">
-                <i [color]="colors.Theme" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Theme"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Solid</div>
             </div>
 
             <div class="example-icon-item-container">
-                <i [color]="colors.Theme" [fade]="true" kbq-icon-item="kbq-bell_16"></i>
+                <i kbq-icon-item="kbq-bell_16" [color]="colors.Theme" [fade]="true"></i>
                 <div class="example-icon-item-container__name kbq-text-normal">Fade</div>
             </div>
         </div>

--- a/packages/docs-examples/components/input/input-number-overview/input-number-overview-example.ts
+++ b/packages/docs-examples/components/input/input-number-overview/input-number-overview-example.ts
@@ -27,12 +27,12 @@ import { KbqInputModule } from '@koobiq/components/input';
                     </label>
                     <kbq-form-field class="kbq-form__control flex-60">
                         <input
-                            [(ngModel)]="value"
-                            [max]="12000"
-                            [min]="-12000"
                             kbqNumberInput
                             kbqNormalizeWhitespace
                             placeholder="Allowed number from -7 to 7"
+                            [max]="12000"
+                            [min]="-12000"
+                            [(ngModel)]="value"
                         />
                         <kbq-stepper />
 
@@ -43,7 +43,7 @@ import { KbqInputModule } from '@koobiq/components/input';
                 <div class="kbq-form__row">
                     <label class="kbq-form__label flex-40">С разделителем групп разрядов</label>
                     <kbq-form-field class="kbq-form__control flex-60">
-                        <input [(ngModel)]="value" kbqNumberInput kbqNormalizeWhitespace />
+                        <input kbqNumberInput kbqNormalizeWhitespace [(ngModel)]="value" />
                         <kbq-stepper />
                     </kbq-form-field>
                 </div>
@@ -52,10 +52,10 @@ import { KbqInputModule } from '@koobiq/components/input';
                     <label class="kbq-form__label flex-40">Без разделителя групп разрядов</label>
                     <kbq-form-field class="kbq-form__control flex-60">
                         <input
-                            [(ngModel)]="value"
-                            [withThousandSeparator]="false"
                             kbqNumberInput
                             kbqNormalizeWhitespace
+                            [withThousandSeparator]="false"
+                            [(ngModel)]="value"
                         />
                         <kbq-stepper />
                     </kbq-form-field>
@@ -64,7 +64,7 @@ import { KbqInputModule } from '@koobiq/components/input';
                 <div class="kbq-form__row">
                     <label class="kbq-form__label flex-40">Целочисленное значение</label>
                     <kbq-form-field class="kbq-form__control flex-60">
-                        <input [(ngModel)]="integerValue" [integer]="true" kbqNumberInput kbqNormalizeWhitespace />
+                        <input kbqNumberInput kbqNormalizeWhitespace [integer]="true" [(ngModel)]="integerValue" />
                         <kbq-stepper />
                     </kbq-form-field>
                 </div>

--- a/packages/docs-examples/components/input/input-overview/input-overview-example.ts
+++ b/packages/docs-examples/components/input/input-overview/input-overview-example.ts
@@ -20,9 +20,9 @@ import { KbqInputModule } from '@koobiq/components/input';
     ],
     template: `
         <kbq-form-field>
-            <i [autoColor]="true" kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
+            <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix [autoColor]="true"></i>
 
-            <input [(ngModel)]="value" kbqInput placeholder="Placeholder" />
+            <input kbqInput placeholder="Placeholder" [(ngModel)]="value" />
 
             <kbq-cleaner />
         </kbq-form-field>
@@ -32,9 +32,9 @@ import { KbqInputModule } from '@koobiq/components/input';
         <br />
 
         <kbq-form-field kbqFormFieldWithoutBorders>
-            <i [autoColor]="true" kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
+            <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix [autoColor]="true"></i>
 
-            <input [(ngModel)]="value" kbqInput placeholder="Placeholder" />
+            <input kbqInput placeholder="Placeholder" [(ngModel)]="value" />
 
             <kbq-cleaner />
         </kbq-form-field>

--- a/packages/docs-examples/components/input/input-password-overview/input-password-overview-example.ts
+++ b/packages/docs-examples/components/input/input-password-overview/input-password-overview-example.ts
@@ -17,7 +17,7 @@ import { KbqInputModule } from '@koobiq/components/input';
     ],
     template: `
         <kbq-form-field style="width: 250px">
-            <input [(ngModel)]="value" kbqInputPassword />
+            <input kbqInputPassword [(ngModel)]="value" />
 
             <kbq-password-toggle [kbqTooltipHidden]="'Показать пароль'" [kbqTooltipNotHidden]="'Скрыть пароль'" />
 

--- a/packages/docs-examples/components/link/link-disabled/link-disabled-example.ts
+++ b/packages/docs-examples/components/link/link-disabled/link-disabled-example.ts
@@ -11,7 +11,7 @@ import { KbqLinkModule } from '@koobiq/components/link';
     imports: [KbqLinkModule],
     template: `
         <div style="padding: 16px">
-            <a [disabled]="disabled" kbq-link>Отчет от 15.05.2020</a>
+            <a kbq-link [disabled]="disabled">Отчет от 15.05.2020</a>
         </div>
     `
 })

--- a/packages/docs-examples/components/link/link-overview/link-overview-example.ts
+++ b/packages/docs-examples/components/link/link-overview/link-overview-example.ts
@@ -34,10 +34,10 @@ import { KbqLinkModule } from '@koobiq/components/link';
         <div style="padding: 16px">
             <a
                 class="kbq-link_external"
-                [disabled]="disabled"
                 href="https://koobiq.io/en/components/link"
                 target="_blank"
                 kbq-link
+                [disabled]="disabled"
             >
                 <i kbq-icon="kbq-calendar-o_16"></i>
                 <span class="kbq-link__text">Отчет сканирования</span>

--- a/packages/docs-examples/components/link/link-print/link-print-example.ts
+++ b/packages/docs-examples/components/link/link-print/link-print-example.ts
@@ -12,9 +12,9 @@ import { KbqLinkModule } from '@koobiq/components/link';
     template: `
         <div style="padding: 16px">
             <a
-                [print]="'cvedetails.com/cve/CVE-2019-1020010'"
                 href="https://www.cvedetails.com/cve/CVE-2019-1020010/"
                 kbq-link
+                [print]="'cvedetails.com/cve/CVE-2019-1020010'"
             >
                 CVE-2019-1020010
             </a>

--- a/packages/docs-examples/components/link/link-visited/link-visited-example.ts
+++ b/packages/docs-examples/components/link/link-visited/link-visited-example.ts
@@ -13,11 +13,11 @@ import { KbqLinkModule } from '@koobiq/components/link';
         <div style="padding: 16px">
             <a
                 class="kbq-link_external"
-                [useVisited]="visited"
-                (click)="visited = true"
                 href="https://koobiq.io/en/components/link"
                 target="_blank"
                 kbq-link
+                [useVisited]="visited"
+                (click)="visited = true"
             >
                 Отчет от 19.05.2020
             </a>

--- a/packages/docs-examples/components/list/list-action-button/list-action-button-example.ts
+++ b/packages/docs-examples/components/list/list-action-button/list-action-button-example.ts
@@ -15,7 +15,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
     selector: 'list-action-button-example',
     imports: [KbqListModule, FormsModule, KbqDropdownModule, KbqToolTipModule, KbqBadgeModule],
     template: `
-        <kbq-list-selection [(ngModel)]="selected" [autoSelect]="false" style="width: 400px">
+        <kbq-list-selection style="width: 400px" [autoSelect]="false" [(ngModel)]="selected">
             <kbq-list-option [value]="'An element with a very very very long name'">
                 <div>Element with a very very very very very very long name</div>
 
@@ -29,7 +29,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
                 <kbq-list-option [value]="'Item ' + item">
                     <div class="layout-row layout-align-space-between">
                         Item {{ item }}
-                        <kbq-badge [compact]="true" style="align-self: center" badgeColor="theme">badge</kbq-badge>
+                        <kbq-badge style="align-self: center" badgeColor="theme" [compact]="true">badge</kbq-badge>
                     </div>
                     <kbq-option-action
                         [kbqDropdownTriggerFor]="dropdown"

--- a/packages/docs-examples/components/list/list-multiple-checkbox/list-multiple-checkbox-example.ts
+++ b/packages/docs-examples/components/list/list-multiple-checkbox/list-multiple-checkbox-example.ts
@@ -11,7 +11,7 @@ import { KbqListModule } from '@koobiq/components/list';
     selector: 'list-multiple-checkbox-example',
     imports: [KbqListModule, FormsModule],
     template: `
-        <kbq-list-selection [(ngModel)]="selected" multiple="checkbox">
+        <kbq-list-selection multiple="checkbox" [(ngModel)]="selected">
             <kbq-list-option [disabled]="true" [value]="'Item 1'">Item 1</kbq-list-option>
             <kbq-list-option [value]="'Item 2'">Item 2</kbq-list-option>
             <kbq-list-option [value]="'Item 3'">Item 3</kbq-list-option>

--- a/packages/docs-examples/components/list/list-multiple-keyboard/list-multiple-keyboard-example.ts
+++ b/packages/docs-examples/components/list/list-multiple-keyboard/list-multiple-keyboard-example.ts
@@ -11,8 +11,8 @@ import { KbqListModule } from '@koobiq/components/list';
     selector: 'list-multiple-keyboard-example',
     imports: [KbqListModule, FormsModule],
     template: `
-        <kbq-list-selection [(ngModel)]="selected" multiple="keyboard">
-            <kbq-list-option [value]="'Item 1'" disabled>Item 1</kbq-list-option>
+        <kbq-list-selection multiple="keyboard" [(ngModel)]="selected">
+            <kbq-list-option disabled [value]="'Item 1'">Item 1</kbq-list-option>
             <kbq-list-option [value]="'Item 2'">Item 2</kbq-list-option>
             <kbq-list-option [value]="'Item 3'">Item 3</kbq-list-option>
             <kbq-list-option [value]="'Item 4'">Item 4</kbq-list-option>

--- a/packages/docs-examples/components/list/list-overview/list-overview-example.ts
+++ b/packages/docs-examples/components/list/list-overview/list-overview-example.ts
@@ -12,7 +12,7 @@ import { KbqListModule } from '@koobiq/components/list';
     imports: [KbqListModule, FormsModule],
     template: `
         <kbq-list-selection [(ngModel)]="selected">
-            <kbq-list-option [value]="'Item 1'" disabled>Item 1</kbq-list-option>
+            <kbq-list-option disabled [value]="'Item 1'">Item 1</kbq-list-option>
             <kbq-list-option [value]="'Item 2'">Item 2</kbq-list-option>
             <kbq-list-option [value]="'Item 3'">Item 3</kbq-list-option>
             <kbq-list-option [value]="'Item 4'">Item 4</kbq-list-option>

--- a/packages/docs-examples/components/loader-overlay/loader-overlay-fixed-top/loader-overlay-fixed-top-example.ts
+++ b/packages/docs-examples/components/loader-overlay/loader-overlay-fixed-top/loader-overlay-fixed-top-example.ts
@@ -20,7 +20,7 @@ import { KbqProgressSpinnerModule } from '@koobiq/components/progress-spinner';
             text text text text text text text text text text text text text text text text text text text text text
             text text text text text text text text text text text text text text text
             <kbq-loader-overlay fixed-top>
-                <kbq-progress-spinner [mode]="'indeterminate'" kbq-loader-overlay-indicator size="big" />
+                <kbq-progress-spinner kbq-loader-overlay-indicator size="big" [mode]="'indeterminate'" />
 
                 <div kbq-loader-overlay-text>Создание отчета</div>
                 <div kbq-loader-overlay-caption>18,7 МБ из 25 МБ — осталось 2 мин</div>

--- a/packages/docs-examples/components/loader-overlay/loader-overlay-large/loader-overlay-large-example.ts
+++ b/packages/docs-examples/components/loader-overlay/loader-overlay-large/loader-overlay-large-example.ts
@@ -20,7 +20,7 @@ import { KbqProgressSpinnerModule } from '@koobiq/components/progress-spinner';
             text text text text text text text text text text text text text text text text text text text text text
             text text text text text text text text text text text text text text text
             <kbq-loader-overlay [text]="'Загрузка данных'">
-                <kbq-progress-spinner [mode]="'indeterminate'" size="big" kbq-loader-overlay-indicator />
+                <kbq-progress-spinner size="big" kbq-loader-overlay-indicator [mode]="'indeterminate'" />
             </kbq-loader-overlay>
         </div>
     `

--- a/packages/docs-examples/components/loader-overlay/loader-overlay-size/loader-overlay-size-example.ts
+++ b/packages/docs-examples/components/loader-overlay/loader-overlay-size/loader-overlay-size-example.ts
@@ -28,7 +28,7 @@ import { KbqLoaderOverlayModule } from '@koobiq/components/loader-overlay';
             text text text text text text text text text text text text text text text text text text text text text
             text text text text text text text text text text text text text text text text text text text text text
             text text text text text text text text text text text text text text text
-            <kbq-loader-overlay [size]="size()" text="Loading data..." />
+            <kbq-loader-overlay text="Loading data..." [size]="size()" />
         </div>
     `
 })

--- a/packages/docs-examples/components/modal/modal-component-with-injector/modal-component-with-injector-example.ts
+++ b/packages/docs-examples/components/modal/modal-component-with-injector/modal-component-with-injector-example.ts
@@ -21,10 +21,10 @@ export class ComponentLevelService {
         <kbq-modal-body>subtitle</kbq-modal-body>
 
         <div kbq-modal-footer>
-            <button [color]="'contrast'" (click)="customService.action()" kbq-button>
+            <button kbq-button [color]="'contrast'" (click)="customService.action()">
                 Call method from injected service
             </button>
-            <button (click)="destroyModal('close')" kbq-button autofocus>Close</button>
+            <button kbq-button autofocus (click)="destroyModal('close')">Close</button>
         </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -49,7 +49,7 @@ export class CustomModalComponent {
         KbqButtonModule
     ],
     template: `
-        <button (click)="openModal()" kbq-button>Open Modal</button>
+        <button kbq-button (click)="openModal()">Open Modal</button>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [ComponentLevelService]

--- a/packages/docs-examples/components/modal/modal-component/modal-component-example.ts
+++ b/packages/docs-examples/components/modal/modal-component/modal-component-example.ts
@@ -15,8 +15,8 @@ import { KbqModalModule, KbqModalRef, KbqModalService } from '@koobiq/components
         <kbq-modal-body>{{ subtitle }}</kbq-modal-body>
 
         <div kbq-modal-footer>
-            <button [color]="'contrast'" (click)="destroyModal('save')" kbq-button>Save</button>
-            <button (click)="destroyModal('close')" kbq-button autofocus>Close</button>
+            <button kbq-button [color]="'contrast'" (click)="destroyModal('save')">Save</button>
+            <button kbq-button autofocus (click)="destroyModal('close')">Close</button>
         </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -43,7 +43,7 @@ export class CustomModalComponent {
         KbqButtonModule
     ],
     template: `
-        <button (click)="openModal()" kbq-button>Open Modal</button>
+        <button kbq-button (click)="openModal()">Open Modal</button>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/modal/modal-multiple/modal-multiple-example.ts
+++ b/packages/docs-examples/components/modal/modal-multiple/modal-multiple-example.ts
@@ -13,7 +13,7 @@ import { KbqModalModule, KbqModalService, ModalSize } from '@koobiq/components/m
         KbqButtonModule
     ],
     template: `
-        <button (click)="showConfirmModal()" kbq-button>Open two modals</button>
+        <button kbq-button (click)="showConfirmModal()">Open two modals</button>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/modal/modal-overview/modal-overview-example.ts
+++ b/packages/docs-examples/components/modal/modal-overview/modal-overview-example.ts
@@ -13,11 +13,11 @@ import { KbqModalModule, KbqModalService, ModalSize } from '@koobiq/components/m
         KbqButtonModule
     ],
     template: `
-        <button (click)="showConfirmModal()" kbq-button>Open Confirm Modal</button>
+        <button kbq-button (click)="showConfirmModal()">Open Confirm Modal</button>
 
-        <button (click)="showSuccessModal()" kbq-button>Open Success Modal</button>
+        <button kbq-button (click)="showSuccessModal()">Open Success Modal</button>
 
-        <button (click)="showDeleteModal()" kbq-button>Open Delete Modal</button>
+        <button kbq-button (click)="showDeleteModal()">Open Delete Modal</button>
     `,
     styles: [
         `

--- a/packages/docs-examples/components/modal/modal-scroll/modal-scroll-example.ts
+++ b/packages/docs-examples/components/modal/modal-scroll/modal-scroll-example.ts
@@ -27,7 +27,7 @@ export class CustomModalComponent {
         KbqButtonModule
     ],
     template: `
-        <button (click)="createLongModal()" kbq-button>Open Modal</button>
+        <button kbq-button (click)="createLongModal()">Open Modal</button>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/modal/modal-sizes/modal-sizes-example.ts
+++ b/packages/docs-examples/components/modal/modal-sizes/modal-sizes-example.ts
@@ -13,13 +13,13 @@ import { KbqModalModule, KbqModalService, ModalSize } from '@koobiq/components/m
         KbqButtonModule
     ],
     template: `
-        <button (click)="showModal(modalSize.Small)" kbq-button>Small</button>
+        <button kbq-button (click)="showModal(modalSize.Small)">Small</button>
 
-        <button (click)="showModal(modalSize.Medium)" kbq-button>Medium</button>
+        <button kbq-button (click)="showModal(modalSize.Medium)">Medium</button>
 
-        <button (click)="showModal(modalSize.Large)" kbq-button>Large</button>
+        <button kbq-button (click)="showModal(modalSize.Large)">Large</button>
 
-        <button (click)="showCustomModal()" kbq-button>Custom width</button>
+        <button kbq-button (click)="showCustomModal()">Custom width</button>
     `,
     styles: [
         `

--- a/packages/docs-examples/components/modal/modal-template/modal-template-example.ts
+++ b/packages/docs-examples/components/modal/modal-template/modal-template-example.ts
@@ -13,7 +13,7 @@ import { KbqModalModule, KbqModalRef, KbqModalService } from '@koobiq/components
         KbqButtonModule
     ],
     template: `
-        <button (click)="createModal(title, content, footer)" kbq-button>Open Modal</button>
+        <button kbq-button (click)="createModal(title, content, footer)">Open Modal</button>
 
         <ng-template #title>DoS attack</ng-template>
 
@@ -25,19 +25,19 @@ import { KbqModalModule, KbqModalRef, KbqModalService } from '@koobiq/components
 
         <ng-template #footer>
             <div class="layout-row flex-grow layout-align-space-between">
-                <button (click)="destroyModal()" kbq-button>Add. action</button>
+                <button kbq-button (click)="destroyModal()">Add. action</button>
 
                 <div>
                     <button
                         class="layout-margin-right-m"
-                        [color]="'contrast'"
-                        (click)="destroyModal()"
                         kbq-button
                         kbq-modal-main-action
+                        [color]="'contrast'"
+                        (click)="destroyModal()"
                     >
                         Save
                     </button>
-                    <button (click)="destroyModal()" kbq-button>Cancel</button>
+                    <button kbq-button (click)="destroyModal()">Cancel</button>
                 </div>
             </div>
         </ng-template>

--- a/packages/docs-examples/components/overflow-items/overflow-items-overview/overflow-items-overview-example.ts
+++ b/packages/docs-examples/components/overflow-items/overflow-items-overview/overflow-items-overview-example.ts
@@ -25,7 +25,7 @@ import { KbqToggleModule } from '@koobiq/components/toggle';
             Reverse overflow order
         </kbq-toggle>
 
-        <div #kbqOverflowItems="kbqOverflowItems" [reverseOverflowOrder]="reverseOverflowOrder()" kbqOverflowItems>
+        <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems [reverseOverflowOrder]="reverseOverflowOrder()">
             @if (reverseOverflowOrder()) {
                 <div class="layout-margin-right-xs" kbqOverflowItemsResult>
                     and {{ kbqOverflowItems.hiddenItemIDs().size }} more

--- a/packages/docs-examples/components/popover/popover-arrow-and-offset/popover-arrow-and-offset-example.ts
+++ b/packages/docs-examples/components/popover/popover-arrow-and-offset/popover-arrow-and-offset-example.ts
@@ -37,20 +37,20 @@ import { KbqToggleChange, KbqToggleModule } from '@koobiq/components/toggle';
 
                 <ng-template #customFooter>
                     <div class="layout-row layout-wrap layout-gap-l">
-                        <button (click)="kbqPopover.hide(0)" color="contrast" kbq-button>Save</button>
-                        <button (click)="kbqPopover.hide(0)" kbq-button>Cancel</button>
+                        <button color="contrast" kbq-button (click)="kbqPopover.hide(0)">Save</button>
+                        <button kbq-button (click)="kbqPopover.hide(0)">Cancel</button>
                     </div>
                 </ng-template>
 
                 <button
                     #kbqPopover="kbqPopover"
+                    kbq-button
+                    kbqPopover
                     [kbqPopoverContent]="customContent"
                     [kbqPopoverFooter]="customFooter"
                     [kbqPopoverArrow]="arrow"
                     [kbqPopoverOffset]="offset"
                     [kbqPopoverSize]="popoverSize"
-                    kbq-button
-                    kbqPopover
                 >
                     Open popover
                 </button>

--- a/packages/docs-examples/components/popover/popover-arrowless/popover-arrowless-example.ts
+++ b/packages/docs-examples/components/popover/popover-arrowless/popover-arrowless-example.ts
@@ -33,19 +33,19 @@ import { KbqPopoverModule } from '@koobiq/components/popover';
 
         <ng-template #customFooter>
             <div class="layout-row layout-wrap layout-gap-l">
-                <button (click)="kbqPopover.hide(0)" color="contrast" kbq-button>Save</button>
-                <button (click)="kbqPopover.hide(0)" kbq-button>Cancel</button>
+                <button color="contrast" kbq-button (click)="kbqPopover.hide(0)">Save</button>
+                <button kbq-button (click)="kbqPopover.hide(0)">Cancel</button>
             </div>
         </ng-template>
 
         <button
             #kbqPopover="kbqPopover"
+            kbq-button
+            kbqPopover
             [kbqPopoverContent]="customContent"
             [kbqPopoverFooter]="customFooter"
             [kbqPopoverSize]="popoverSize"
             [kbqPopoverArrow]="false"
-            kbq-button
-            kbqPopover
         >
             Open popover
         </button>

--- a/packages/docs-examples/components/popover/popover-close/popover-close-example.html
+++ b/packages/docs-examples/components/popover/popover-close/popover-close-example.html
@@ -56,9 +56,9 @@
             <div class="example-popover-close__list-item">
                 <div class="example-popover-close__list-item-left">
                     <img
+                        class="example-popover-close__list-item-image"
                         alt="{{ member.name }}"
                         src="assets/images/popover/list-member-{{ i + 1 }}.png"
-                        class="example-popover-close__list-item-image"
                     />
                     <div class="example-popover-close__list-item-name">{{ member.name }}</div>
                 </div>

--- a/packages/docs-examples/components/popover/popover-common/popover-common-example.ts
+++ b/packages/docs-examples/components/popover/popover-common/popover-common-example.ts
@@ -27,18 +27,18 @@ import { KbqPopoverModule } from '@koobiq/components/popover';
 
         <ng-template #customFooter>
             <div class="layout-row layout-wrap" style="gap: 16px">
-                <button [color]="'contrast'" (click)="kbqPopover.hide(0)" kbq-button>Сохранить</button>
-                <button (click)="kbqPopover.hide(0)" kbq-button>Отмена</button>
+                <button kbq-button [color]="'contrast'" (click)="kbqPopover.hide(0)">Сохранить</button>
+                <button kbq-button (click)="kbqPopover.hide(0)">Отмена</button>
             </div>
         </ng-template>
 
         <button
             #kbqPopover="kbqPopover"
+            kbq-button
+            kbqPopover
             [kbqPopoverClass]="'popover-common-example'"
             [kbqPopoverContent]="customContent"
             [kbqPopoverFooter]="customFooter"
-            kbq-button
-            kbqPopover
         >
             Открыть поповер
         </button>

--- a/packages/docs-examples/components/popover/popover-content/popover-content-example.html
+++ b/packages/docs-examples/components/popover/popover-content/popover-content-example.html
@@ -26,9 +26,9 @@
             <div class="example-popover-content-share__list-item">
                 <div class="example-popover-content-share__list-item-left">
                     <img
+                        class="example-popover-content-share__list-item-image"
                         alt="{{ member.name }}"
                         src="assets/images/popover/list-member-{{ i + 1 }}.png"
-                        class="example-popover-content-share__list-item-image"
                     />
                     <div class="example-popover-content-share__list-item-name">{{ member.name }}</div>
                 </div>

--- a/packages/docs-examples/components/popover/popover-hover/popover-hover-example.ts
+++ b/packages/docs-examples/components/popover/popover-hover/popover-hover-example.ts
@@ -27,19 +27,19 @@ import { KbqPopoverModule } from '@koobiq/components/popover';
 
         <ng-template #customFooter>
             <div class="layout-row layout-wrap" style="gap: 16px">
-                <button [color]="'contrast'" (click)="kbqPopover.hide(0)" kbq-button>Сохранить</button>
-                <button (click)="kbqPopover.hide(0)" kbq-button>Отмена</button>
+                <button kbq-button [color]="'contrast'" (click)="kbqPopover.hide(0)">Сохранить</button>
+                <button kbq-button (click)="kbqPopover.hide(0)">Отмена</button>
             </div>
         </ng-template>
 
         <button
             #kbqPopover="kbqPopover"
+            kbq-button
+            kbqPopover
             [kbqPopoverClass]="'popover-common-example'"
             [kbqPopoverContent]="customContent"
             [kbqPopoverFooter]="customFooter"
             [kbqTrigger]="'hover'"
-            kbq-button
-            kbqPopover
         >
             Открыть поповер
         </button>

--- a/packages/docs-examples/components/popover/popover-scroll/popover-scroll-example.ts
+++ b/packages/docs-examples/components/popover/popover-scroll/popover-scroll-example.ts
@@ -32,32 +32,32 @@ import { KbqPopoverModule, KbqPopoverTrigger } from '@koobiq/components/popover'
 
         <ng-template #customFooter>
             <div class="layout-row layout-wrap" style="gap: 16px">
-                <button [color]="'contrast'" (click)="activePopover.hide(0)" kbq-button>Сохранить</button>
-                <button (click)="activePopover.hide(0)" kbq-button>Отмена</button>
+                <button kbq-button [color]="'contrast'" (click)="activePopover.hide(0)">Сохранить</button>
+                <button kbq-button (click)="activePopover.hide(0)">Отмена</button>
             </div>
         </ng-template>
 
         <div class="layout-row layout-wrap" style="gap: 16px">
             <button
                 #kbqNoClosePopover="kbqPopover"
+                kbq-button
+                kbqPopover
                 [kbqPopoverClass]="'popover-scroll-example'"
                 [kbqPopoverContent]="customContent"
                 [kbqPopoverFooter]="customFooter"
                 (click)="activePopover = kbqNoClosePopover"
-                kbq-button
-                kbqPopover
             >
                 Поповер не закрывается при прокрутке
             </button>
             <button
                 #kbqClosePopover="kbqPopover"
+                kbq-button
+                kbqPopover
                 [closeOnScroll]="true"
                 [kbqPopoverClass]="'popover-scroll-example'"
                 [kbqPopoverContent]="customContent"
                 [kbqPopoverFooter]="customFooter"
                 (click)="activePopover = kbqClosePopover"
-                kbq-button
-                kbqPopover
             >
                 Закрывается при прокрутке
             </button>

--- a/packages/docs-examples/components/progress-bar/progress-bar-overview/progress-bar-overview-example.ts
+++ b/packages/docs-examples/components/progress-bar/progress-bar-overview/progress-bar-overview-example.ts
@@ -25,7 +25,7 @@ import { KbqProgressBarModule } from '@koobiq/components/progress-bar';
     template: `
         <kbq-progress-bar class="example-progress-bar" [value]="percent()" />
         <kbq-form-field>
-            <input [(ngModel)]="percent" [min]="0" [max]="100" [step]="5" kbqInput kbqNumberInput />
+            <input kbqInput kbqNumberInput [min]="0" [max]="100" [step]="5" [(ngModel)]="percent" />
             <kbq-stepper />
         </kbq-form-field>
     `

--- a/packages/docs-examples/components/radio/radio-size/radio-size-example.ts
+++ b/packages/docs-examples/components/radio/radio-size/radio-size-example.ts
@@ -29,7 +29,7 @@ import { KbqRadioModule } from '@koobiq/components/radio';
                 </div>
                 <div class="example-radio-group">
                     <div class="layout-margin-bottom-m kbq-form__label">Big</div>
-                    <kbq-radio-group [big]="true" name="my_options_2">
+                    <kbq-radio-group name="my_options_2" [big]="true">
                         <kbq-radio-button [checked]="true" [value]="'option_1'">William Anderson</kbq-radio-button>
 
                         <kbq-radio-button [value]="'option_2'">James Peterson</kbq-radio-button>

--- a/packages/docs-examples/components/scrollbar/scrollbar-scroll-to-top/scrollbar-scroll-to-top-example.ts
+++ b/packages/docs-examples/components/scrollbar/scrollbar-scroll-to-top/scrollbar-scroll-to-top-example.ts
@@ -13,16 +13,16 @@ import { KbqScrollbarModule } from '@koobiq/components/scrollbar';
         KbqButtonModule
     ],
     template: `
-        <kbq-scrollbar #scrollbarRef="kbqScrollbar" (onScroll)="onScroll($event)" style="width: 200px; height: 200px;">
+        <kbq-scrollbar #scrollbarRef="kbqScrollbar" style="width: 200px; height: 200px;" (onScroll)="onScroll($event)">
             @for (item of items; track item) {
                 <div>{{ item }}</div>
                 <hr />
             }
         </kbq-scrollbar>
         <button
+            kbq-button
             [disabled]="!(scrollbarRef?.contentElement?.nativeElement?.scrollTop || 0 > 0)"
             (click)="scrollbarRef.scrollTo({ top: 0, left: 0, behavior: 'smooth' })"
-            kbq-button
         >
             Scroll To Top
         </button>

--- a/packages/docs-examples/components/scrollbar/scrollbar-with-options/scrollbar-with-options-example.ts
+++ b/packages/docs-examples/components/scrollbar/scrollbar-with-options/scrollbar-with-options-example.ts
@@ -9,7 +9,7 @@ import { KbqScrollbarModule, KbqScrollbarOptions } from '@koobiq/components/scro
     selector: 'scrollbar-with-options-example',
     imports: [KbqScrollbarModule],
     template: `
-        <kbq-scrollbar [options]="options" style="width: 200px; height: 200px;">
+        <kbq-scrollbar style="width: 200px; height: 200px;" [options]="options">
             @for (item of items; track item) {
                 <div>{{ item }}</div>
                 <hr />

--- a/packages/docs-examples/components/select/select-cleaner/select-cleaner-example.ts
+++ b/packages/docs-examples/components/select/select-cleaner/select-cleaner-example.ts
@@ -12,7 +12,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-select [value]="selected" placeholder="Placeholder">
+            <kbq-select placeholder="Placeholder" [value]="selected">
                 <kbq-cleaner #kbqSelectCleaner />
                 @for (option of options; track option) {
                     <kbq-option [value]="option">{{ option }}</kbq-option>

--- a/packages/docs-examples/components/select/select-custom-matcher/select-custom-matcher-example.ts
+++ b/packages/docs-examples/components/select/select-custom-matcher/select-custom-matcher-example.ts
@@ -13,9 +13,9 @@ import { KbqSelectModule } from '@koobiq/components/select';
     template: `
         <kbq-select
             #select="kbqSelect"
-            [(value)]="selected"
             [tabIndex]="-1"
             [class]="{ 'kbq-select': false, 'my-custom-select': true }"
+            [(value)]="selected"
         >
             <button kbq-button kbq-select-matcher>
                 {{ select.triggerValue }}

--- a/packages/docs-examples/components/select/select-disabled/select-disabled-example.ts
+++ b/packages/docs-examples/components/select/select-disabled/select-disabled-example.ts
@@ -13,7 +13,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
         <div class="example-row">
             <div class="kbq-form__label">For select</div>
             <kbq-form-field>
-                <kbq-select [value]="selected" placeholder="Placeholder" disabled>
+                <kbq-select placeholder="Placeholder" disabled [value]="selected">
                     @for (option of options; track option) {
                         <kbq-option [value]="option">{{ option }}</kbq-option>
                     }
@@ -24,7 +24,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
         <div class="example-row">
             <div class="kbq-form__label">For options</div>
             <kbq-form-field>
-                <kbq-select [value]="selected" placeholder="Placeholder">
+                <kbq-select placeholder="Placeholder" [value]="selected">
                     @for (option of options; track option; let odd = $odd) {
                         <kbq-option [disabled]="odd" [value]="option">{{ option }}</kbq-option>
                     }
@@ -35,7 +35,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
         <div class="example-row">
             <div class="kbq-form__label">For optgroup</div>
             <kbq-form-field>
-                <kbq-select [value]="selected" placeholder="Placeholder">
+                <kbq-select placeholder="Placeholder" [value]="selected">
                     @for (group of groups; track group; let odd = $odd) {
                         <kbq-optgroup [label]="group" [disabled]="odd">
                             @for (option of options; track option) {

--- a/packages/docs-examples/components/select/select-height/select-height-example.ts
+++ b/packages/docs-examples/components/select/select-height/select-height-example.ts
@@ -12,7 +12,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-select [value]="selected" panelClass="example-select-panel-height">
+            <kbq-select panelClass="example-select-panel-height" [value]="selected">
                 @for (option of options; track option) {
                     <kbq-option [value]="option">{{ option }}</kbq-option>
                 }

--- a/packages/docs-examples/components/select/select-multiple/select-multiple-example.ts
+++ b/packages/docs-examples/components/select/select-multiple/select-multiple-example.ts
@@ -12,7 +12,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-select [value]="selected" multiple placeholder="Placeholder">
+            <kbq-select multiple placeholder="Placeholder" [value]="selected">
                 @for (option of options; track option) {
                     <kbq-option [value]="option">{{ option }}</kbq-option>
                 }

--- a/packages/docs-examples/components/select/select-prioritized-selected/select-prioritized-selected-example.ts
+++ b/packages/docs-examples/components/select/select-prioritized-selected/select-prioritized-selected-example.ts
@@ -12,7 +12,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
     changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
-            <kbq-select [(value)]="selected" (openedChange)="openedChange($event)" placeholder="Placeholder" multiple>
+            <kbq-select placeholder="Placeholder" multiple [(value)]="selected" (openedChange)="openedChange($event)">
                 @for (option of options; track option) {
                     <kbq-option [value]="option">{{ option }}</kbq-option>
                 }

--- a/packages/docs-examples/components/select/select-search/select-search-example.ts
+++ b/packages/docs-examples/components/select/select-search/select-search-example.ts
@@ -29,7 +29,7 @@ import { map, startWith } from 'rxjs/operators';
             <kbq-select placeholder="Placeholder">
                 <kbq-form-field kbqFormFieldWithoutBorders kbqSelectSearch>
                     <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
-                    <input [formControl]="searchControl" kbqInput type="text" />
+                    <input kbqInput type="text" [formControl]="searchControl" />
                     <kbq-cleaner />
                 </kbq-form-field>
 

--- a/packages/docs-examples/components/select/select-validation/select-validation-example.ts
+++ b/packages/docs-examples/components/select/select-validation/select-validation-example.ts
@@ -28,7 +28,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
         <div class="kbq-form-vertical layout-column">
             <div class="kbq-form__label">Invalid</div>
             <kbq-form-field>
-                <kbq-select [formControl]="invalidControl" placeholder="Placeholder">
+                <kbq-select placeholder="Placeholder" [formControl]="invalidControl">
                     <kbq-option [value]="null">None</kbq-option>
                     @for (option of options; track option) {
                         <kbq-option [value]="option">{{ option }}</kbq-option>

--- a/packages/docs-examples/components/select/select-with-multiline-matcher/select-with-multiline-matcher-example.ts
+++ b/packages/docs-examples/components/select/select-with-multiline-matcher/select-with-multiline-matcher-example.ts
@@ -15,7 +15,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
     template: `
         <div>
             <kbq-form-field>
-                <kbq-select [multiline]="true" [value]="selected" [panelWidth]="400" placeholder="Placeholder">
+                <kbq-select placeholder="Placeholder" [multiline]="true" [value]="selected" [panelWidth]="400">
                     @for (option of options; track option) {
                         <kbq-option [value]="option">{{ option }}</kbq-option>
                     }

--- a/packages/docs-examples/components/select/select-with-panel-width-attribute/select-with-panel-width-attribute-example.ts
+++ b/packages/docs-examples/components/select/select-with-panel-width-attribute/select-with-panel-width-attribute-example.ts
@@ -16,7 +16,7 @@ import { KbqSelectModule } from '@koobiq/components/select';
         <div>
             <label class="kbq-form__label">Fixed panelWidth</label>
             <kbq-form-field>
-                <kbq-select [panelWidth]="400" placeholder="Placeholder">
+                <kbq-select placeholder="Placeholder" [panelWidth]="400">
                     @for (option of options; track option) {
                         <kbq-option [value]="option">{{ option }}</kbq-option>
                     }

--- a/packages/docs-examples/components/sidebar/sidebar-overview/sidebar-overview-example.ts
+++ b/packages/docs-examples/components/sidebar/sidebar-overview/sidebar-overview-example.ts
@@ -22,10 +22,10 @@ import { KbqSidebarModule, SidebarPositions } from '@koobiq/components/sidebar';
 
         <main>
             <div>Main content</div>
-            <div><button (click)="toggleLeft()" kbq-button>Toggle left model</button></div>
-            <div><button (click)="leftSidebar.toggle()" kbq-button>Toggle left</button></div>
-            <div><button (click)="toggleRight()" kbq-button>Toggle right model</button></div>
-            <div><button (click)="rightSidebar.toggle()" kbq-button>Toggle right</button></div>
+            <div><button kbq-button (click)="toggleLeft()">Toggle left model</button></div>
+            <div><button kbq-button (click)="leftSidebar.toggle()">Toggle left</button></div>
+            <div><button kbq-button (click)="toggleRight()">Toggle right model</button></div>
+            <div><button kbq-button (click)="rightSidebar.toggle()">Toggle right</button></div>
         </main>
 
         <kbq-sidebar

--- a/packages/docs-examples/components/sidebar/sidebar-with-splitter/sidebar-with-splitter-example.ts
+++ b/packages/docs-examples/components/sidebar/sidebar-with-splitter/sidebar-with-splitter-example.ts
@@ -14,10 +14,10 @@ import { Direction, KbqSplitterModule } from '@koobiq/components/splitter';
         <kbq-splitter [direction]="direction.Horizontal" [disabled]="!opened">
             <kbq-sidebar
                 #sidebar="kbqSidebar"
+                kbq-splitter-area
                 [opened]="opened"
                 [position]="position.Left"
                 (stateChanged)="onStateChanged($event)"
-                kbq-splitter-area
             >
                 <div kbq-sidebar-opened minWidth="170px" width="170px" maxWidth="50%">Opened content</div>
                 <div kbq-sidebar-closed width="44px">Closed content</div>
@@ -25,8 +25,8 @@ import { Direction, KbqSplitterModule } from '@koobiq/components/splitter';
 
             <main kbq-splitter-area>
                 <div>Main content</div>
-                <div><button (click)="toggle()" kbq-button>Toggle model</button></div>
-                <div><button (click)="sidebar.toggle()" kbq-button>Toggle</button></div>
+                <div><button kbq-button (click)="toggle()">Toggle model</button></div>
+                <div><button kbq-button (click)="sidebar.toggle()">Toggle</button></div>
             </main>
         </kbq-splitter>
     `,

--- a/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.ts
+++ b/packages/docs-examples/components/splitter/splitter-dynamic-data/splitter-dynamic-data-example.ts
@@ -26,7 +26,7 @@ import { KbqSplitterModule } from '@koobiq/components/splitter';
         }
     `,
     template: `
-        <button (click)="isFirstVisible = !isFirstVisible" kbq-button>Change first area visibility</button>
+        <button kbq-button (click)="isFirstVisible = !isFirstVisible">Change first area visibility</button>
 
         <kbq-splitter>
             @if (isFirstVisible) {

--- a/packages/docs-examples/components/table/table-with-borders/table-with-borders-example.ts
+++ b/packages/docs-examples/components/table/table-with-borders/table-with-borders-example.ts
@@ -12,7 +12,7 @@ import { KbqTableModule } from '@koobiq/components/table';
         KbqTableModule
     ],
     template: `
-        <table [border]="true" style="margin-bottom: 32px; width: 100%" kbq-table>
+        <table style="margin-bottom: 32px; width: 100%" kbq-table [border]="true">
             <thead>
                 <tr>
                     <th>Файл</th>

--- a/packages/docs-examples/components/tabs/tabs-actionbar/tabs-actionbar-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-actionbar/tabs-actionbar-example.ts
@@ -19,7 +19,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
             <div class="example-tabs-actionbar_nav">
                 <nav kbqTabNavBar underlined>
                     @for (dashboard of dashboards; track dashboard) {
-                        <a [active]="activeDashboard === dashboard" (click)="activeDashboard = dashboard" kbqTabLink>
+                        <a kbqTabLink [active]="activeDashboard === dashboard" (click)="activeDashboard = dashboard">
                             {{ dashboard }}
                         </a>
                     }
@@ -33,7 +33,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
                 <button class="kbq-button_transparent" color="contrast" kbq-button>
                     <i kbq-icon="kbq-filter_16"></i>
                 </button>
-                <button (click)="createDashboard()" color="contrast" kbq-button>
+                <button color="contrast" kbq-button (click)="createDashboard()">
                     <i kbq-icon="kbq-plus_16"></i>
                     Create dashboard
                 </button>

--- a/packages/docs-examples/components/tabs/tabs-active-tab-id/tabs-active-tab-id-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-active-tab-id/tabs-active-tab-id-example.ts
@@ -19,7 +19,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
             @for (tab of tabs; track tab) {
                 <kbq-tab [tabId]="tab.tabId">
                     <ng-template kbq-tab-label>
-                        <i [ngClass]="tab.icon" kbq-icon></i>
+                        <i kbq-icon [ngClass]="tab.icon"></i>
                         {{ tab.tabId }}
                     </ng-template>
                     Content for selected tab with id: {{ selectedTabId }}

--- a/packages/docs-examples/components/tabs/tabs-active-tab-index/tabs-active-tab-index-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-active-tab-index/tabs-active-tab-index-example.ts
@@ -19,7 +19,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
             @for (tab of tabs; track tab) {
                 <kbq-tab [tabId]="tab.tabId">
                     <ng-template kbq-tab-label>
-                        <i [ngClass]="tab.icon" kbq-icon></i>
+                        <i kbq-icon [ngClass]="tab.icon"></i>
                         {{ tab.tabId }}
                     </ng-template>
                     Content for selected tab with index: {{ selectedTabIndex }}

--- a/packages/docs-examples/components/tabs/tabs-empty-label/tabs-empty-label-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-empty-label/tabs-empty-label-example.ts
@@ -32,7 +32,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
                         weaknesses in an encryption system (if any exist) that would make the task easier.
                     </p>
                 </kbq-tab>
-                <kbq-tab [tooltipPlacement]="PopUpPlacements.Top" label="DDoS" tooltipTitle="No incidents" empty>
+                <kbq-tab label="DDoS" tooltipTitle="No incidents" empty [tooltipPlacement]="PopUpPlacements.Top">
                     <div class="example-tabs-empty-label_tab-content">No DDoS attacks have been registered</div>
                 </kbq-tab>
                 <kbq-tab label="DoS">

--- a/packages/docs-examples/components/tabs/tabs-nav-bar-overview/tabs-nav-bar-overview-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-nav-bar-overview/tabs-nav-bar-overview-example.ts
@@ -9,9 +9,9 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
     selector: 'tabs-nav-bar-overview-example',
     imports: [KbqTabsModule],
     template: `
-        <nav [tabNavPanel]="tabNavPanel" kbqTabNavBar>
+        <nav kbqTabNavBar [tabNavPanel]="tabNavPanel">
             @for (link of links; track link) {
-                <a [active]="activeLink === link" (click)="activeLink = link" kbqTabLink>
+                <a kbqTabLink [active]="activeLink === link" (click)="activeLink = link">
                     {{ link }}
                 </a>
             }

--- a/packages/docs-examples/components/tabs/tabs-vertical-icons/tabs-vertical-icons-example.ts
+++ b/packages/docs-examples/components/tabs/tabs-vertical-icons/tabs-vertical-icons-example.ts
@@ -17,7 +17,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
     template: `
         <div class="example-tabs-vertical-icons">
             <kbq-tab-group vertical>
-                <kbq-tab [tooltipPlacement]="PopUpPlacements.Left" tooltipTitle="BruteForce" empty>
+                <kbq-tab tooltipTitle="BruteForce" empty [tooltipPlacement]="PopUpPlacements.Left">
                     <ng-template kbq-tab-label>
                         <i kbq-icon="kbq-bug_16"></i>
                     </ng-template>
@@ -42,7 +42,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
                         Revenge and blackmail, as well as hacktivism, can motivate these attacks.
                     </p>
                 </kbq-tab>
-                <kbq-tab [tooltipPlacement]="PopUpPlacements.Left" tooltipTitle="Complex Attack" empty>
+                <kbq-tab tooltipTitle="Complex Attack" empty [tooltipPlacement]="PopUpPlacements.Left">
                     <ng-template kbq-tab-label>
                         <i kbq-icon="kbq-bug_16"></i>
                     </ng-template>
@@ -61,7 +61,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
                         weaknesses in an encryption system (if any exist) that would make the task easier.
                     </p>
                 </kbq-tab>
-                <kbq-tab [tooltipPlacement]="PopUpPlacements.Left" tooltipTitle="DDoS" empty>
+                <kbq-tab tooltipTitle="DDoS" empty [tooltipPlacement]="PopUpPlacements.Left">
                     <ng-template kbq-tab-label>
                         <i kbq-icon="kbq-bug_16"></i>
                     </ng-template>
@@ -86,7 +86,7 @@ import { KbqTabsModule } from '@koobiq/components/tabs';
                         Revenge and blackmail, as well as hacktivism, can motivate these attacks.
                     </p>
                 </kbq-tab>
-                <kbq-tab [tooltipPlacement]="PopUpPlacements.Left" tooltipTitle="DoS" empty>
+                <kbq-tab tooltipTitle="DoS" empty [tooltipPlacement]="PopUpPlacements.Left">
                     <ng-template kbq-tab-label>
                         <i kbq-icon="kbq-bug_16"></i>
                     </ng-template>

--- a/packages/docs-examples/components/tag/tag-autocomplete-option-operations/tag-autocomplete-option-operations-example.ts
+++ b/packages/docs-examples/components/tag/tag-autocomplete-option-operations/tag-autocomplete-option-operations-example.ts
@@ -37,6 +37,7 @@ const autocompleteValueCoercion = (value): string => (value?.new ? value.value :
                 }
                 <input
                     #tagInput
+                    placeholder="Placeholder"
                     [distinct]="true"
                     [formControl]="control"
                     [kbqAutocomplete]="autocomplete"
@@ -45,7 +46,6 @@ const autocompleteValueCoercion = (value): string => (value?.new ? value.value :
                     [kbqTagInputSeparatorKeyCodes]="[]"
                     (blur)="addOnBlurFunc($event)"
                     (kbqTagInputTokenEnd)="onCreate($event)"
-                    placeholder="Placeholder"
                 />
 
                 <kbq-cleaner #kbqTagListCleaner (click)="selectedTags.length = 0" />

--- a/packages/docs-examples/components/tag/tag-autocomplete/tag-autocomplete-example.ts
+++ b/packages/docs-examples/components/tag/tag-autocomplete/tag-autocomplete-example.ts
@@ -39,6 +39,7 @@ const autocompleteValueCoercion = (value): string => (value?.new ? value.value :
                 }
                 <input
                     #tagInput
+                    placeholder="Placeholder"
                     [distinct]="true"
                     [formControl]="control"
                     [kbqAutocomplete]="autocomplete"
@@ -47,7 +48,6 @@ const autocompleteValueCoercion = (value): string => (value?.new ? value.value :
                     [kbqTagInputSeparatorKeyCodes]="[]"
                     (blur)="addOnBlurFunc($event)"
                     (kbqTagInputTokenEnd)="onCreate($event)"
-                    placeholder="Placeholder"
                 />
 
                 <kbq-cleaner #kbqTagListCleaner (click)="selectedTags.length = 0" />

--- a/packages/docs-examples/components/tag/tag-input-with-form-control-validators/tag-input-with-form-control-validators-example.ts
+++ b/packages/docs-examples/components/tag/tag-input-with-form-control-validators/tag-input-with-form-control-validators-example.ts
@@ -46,10 +46,10 @@ const customMaxLengthValidator = (max: number): ValidatorFn => {
                 }
 
                 <input
-                    [kbqTagInputFor]="inputTagList"
-                    (kbqTagInputTokenEnd)="createTag($event)"
                     kbqInput
                     placeholder="New keyword..."
+                    [kbqTagInputFor]="inputTagList"
+                    (kbqTagInputTokenEnd)="createTag($event)"
                 />
             </kbq-tag-list>
 

--- a/packages/docs-examples/components/tag/tag-input/tag-input-example.ts
+++ b/packages/docs-examples/components/tag/tag-input/tag-input-example.ts
@@ -29,11 +29,11 @@ import { KbqTagInputEvent, KbqTagsModule } from '@koobiq/components/tags';
                 }
 
                 <input
+                    placeholder="New tag..."
                     [formControl]="control"
                     [kbqTagInputFor]="tagList"
                     [kbqTagInputSeparatorKeyCodes]="separatorKeysCodes"
                     (kbqTagInputTokenEnd)="onCreate($event)"
-                    placeholder="New tag..."
                 />
 
                 <kbq-cleaner #kbqTagListCleaner (click)="onClear()" />

--- a/packages/docs-examples/components/textarea/text-area-overview/text-area-overview-example.ts
+++ b/packages/docs-examples/components/textarea/text-area-overview/text-area-overview-example.ts
@@ -13,16 +13,16 @@ import { KbqTextareaModule } from '@koobiq/components/textarea';
     imports: [KbqFormFieldModule, KbqTextareaModule, FormsModule],
     template: `
         <kbq-form-field class="layout-margin-bottom-xl">
-            <textarea [placeholder]="placeholder" kbqTextarea></textarea>
+            <textarea kbqTextarea [placeholder]="placeholder"></textarea>
         </kbq-form-field>
         <kbq-form-field class="layout-margin-bottom-xl">
-            <textarea [disabled]="disabled" [placeholder]="placeholder" kbqTextarea></textarea>
+            <textarea kbqTextarea [disabled]="disabled" [placeholder]="placeholder"></textarea>
         </kbq-form-field>
         <kbq-form-field class="layout-margin-bottom-xl">
-            <textarea [(ngModel)]="value" [placeholder]="placeholder" [required]="required" kbqTextarea></textarea>
+            <textarea kbqTextarea [placeholder]="placeholder" [required]="required" [(ngModel)]="value"></textarea>
         </kbq-form-field>
         <kbq-form-field kbqFormFieldWithoutBorders>
-            <textarea [(ngModel)]="value" kbqTextarea placeholder="Placeholder"></textarea>
+            <textarea kbqTextarea placeholder="Placeholder" [(ngModel)]="value"></textarea>
         </kbq-form-field>
     `
 })

--- a/packages/docs-examples/components/timepicker/timepicker-validation-symbols/timepicker-validation-symbols-example.ts
+++ b/packages/docs-examples/components/timepicker/timepicker-validation-symbols/timepicker-validation-symbols-example.ts
@@ -20,7 +20,7 @@ import { DateTime } from 'luxon';
         <div class="docs-row">
             <kbq-form-field #tooltip="kbqWarningTooltip" [kbqWarningTooltip]="'Только цифры'">
                 <i kbq-icon="kbq-clock_16" kbqPrefix></i>
-                <input [(ngModel)]="time" [format]="timeFormats.HHmm" [kbqValidationTooltip]="tooltip" kbqTimepicker />
+                <input kbqTimepicker [format]="timeFormats.HHmm" [kbqValidationTooltip]="tooltip" [(ngModel)]="time" />
             </kbq-form-field>
         </div>
     `

--- a/packages/docs-examples/components/timezone/timezone-search-overview/timezone-search-overview-example.ts
+++ b/packages/docs-examples/components/timezone/timezone-search-overview/timezone-search-overview-example.ts
@@ -40,11 +40,11 @@ import { timezones } from '../mock';
                 <kbq-form-field kbqFormFieldWithoutBorders kbqSelectSearch>
                     <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
                     <input
-                        [formControl]="searchControl"
-                        [placeholder]="'Город или часовой пояс'"
                         autocomplete="off"
                         kbqInput
                         type="text"
+                        [formControl]="searchControl"
+                        [placeholder]="'Город или часовой пояс'"
                     />
                     <kbq-cleaner />
                 </kbq-form-field>

--- a/packages/docs-examples/components/title/title-overview/title-overview-example.ts
+++ b/packages/docs-examples/components/title/title-overview/title-overview-example.ts
@@ -27,16 +27,16 @@ import { KbqTitleModule } from '@koobiq/components/title';
             <br />
 
             <div kbq-title style="max-width: 50%">
-                <div class="example-title-overview-parent" #kbqTitleContainer>
-                    <div class="example-title-overview-child kbq-text-normal" #kbqTitleText>
+                <div #kbqTitleContainer class="example-title-overview-parent">
+                    <div #kbqTitleText class="example-title-overview-child kbq-text-normal">
                         {{ field }}
                     </div>
                 </div>
             </div>
             <br />
-            <button (click)="onAddText()" kbq-button>Add text</button>
+            <button kbq-button (click)="onAddText()">Add text</button>
             <br />
-            <button (click)="field = defaultValue" kbq-button>Set Default text</button>
+            <button kbq-button (click)="field = defaultValue">Set Default text</button>
         </div>
     `,
     styleUrls: ['./title-overview-example.css']

--- a/packages/docs-examples/components/toast/toast-overview/toast-overview-example.ts
+++ b/packages/docs-examples/components/toast/toast-overview/toast-overview-example.ts
@@ -15,11 +15,11 @@ import { KbqToastService, KbqToastStyle } from '@koobiq/components/toast';
     selector: 'toast-overview-example',
     template: `
         <ng-template #toastAction let-toast>
-            <a (click)="toast.close()" (keydown.enter)="toast.close()" kbq-link pseudo>Обновить</a>
+            <a kbq-link pseudo (click)="toast.close()" (keydown.enter)="toast.close()">Обновить</a>
         </ng-template>
 
         <div class="demo-block">
-            <button class="example-button" (click)="showToast(toastAction)" kbq-button>Показать тост</button>
+            <button class="example-button" kbq-button (click)="showToast(toastAction)">Показать тост</button>
         </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/packages/docs-examples/components/toast/toast-progress-bar-overview/toast-progress-bar-overview-example.ts
+++ b/packages/docs-examples/components/toast/toast-progress-bar-overview/toast-progress-bar-overview-example.ts
@@ -21,10 +21,10 @@ import { KbqToastService } from '@koobiq/components/toast';
         </ng-template>
 
         <ng-template #toastStickyActionsTemplate let-toast>
-            <a (click)="toast.close()" (keydown.enter)="toast.close()" kbq-link pseudo>Отмена</a>
+            <a kbq-link pseudo (click)="toast.close()" (keydown.enter)="toast.close()">Отмена</a>
         </ng-template>
 
-        <button (click)="showStickyToast(toastStickyContentTemplate, toastStickyActionsTemplate)" kbq-button>
+        <button kbq-button (click)="showStickyToast(toastStickyContentTemplate, toastStickyActionsTemplate)">
             Тост с прогресс-баром, кнопкой Отмена и без крестика
         </button>
     `,

--- a/packages/docs-examples/components/toast/toast-report-overview/toast-report-overview-example.ts
+++ b/packages/docs-examples/components/toast/toast-report-overview/toast-report-overview-example.ts
@@ -21,10 +21,10 @@ import { KbqToastService, KbqToastStyle } from '@koobiq/components/toast';
         </ng-template>
 
         <ng-template #toastActionsTemplate let-toast>
-            <a (click)="toast.close()" (keydown.enter)="toast.close()" kbq-link pseudo>Восстановить</a>
+            <a kbq-link pseudo (click)="toast.close()" (keydown.enter)="toast.close()">Восстановить</a>
         </ng-template>
 
-        <button (click)="showToast(toastContentTemplate, toastActionsTemplate)" kbq-button>Отчет</button>
+        <button kbq-button (click)="showToast(toastContentTemplate, toastActionsTemplate)">Отчет</button>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/packages/docs-examples/components/toggle/toggle-label-left/toggle-label-left-example.ts
+++ b/packages/docs-examples/components/toggle/toggle-label-left/toggle-label-left-example.ts
@@ -10,7 +10,7 @@ import { KbqToggleModule } from '@koobiq/components/toggle';
     imports: [KbqToggleModule],
     template: `
         <div class="example-toggle-label-left__container layout-align-center-start layout-column layout-gap-s">
-            <kbq-toggle [checked]="true" labelPosition="left">Tap to wake</kbq-toggle>
+            <kbq-toggle labelPosition="left" [checked]="true">Tap to wake</kbq-toggle>
             <kbq-toggle labelPosition="left">Shake to undo</kbq-toggle>
             <kbq-toggle labelPosition="left">Vibration</kbq-toggle>
         </div>

--- a/packages/docs-examples/components/tooltip/tooltip-arrow-and-offset/tooltip-arrow-and-offset-example.ts
+++ b/packages/docs-examples/components/tooltip/tooltip-arrow-and-offset/tooltip-arrow-and-offset-example.ts
@@ -25,10 +25,10 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
         <div class="layout-row layout-align-space-around-center">
             <div class="layout-row layout-align-center-center">
                 <button
-                    [kbqTooltipArrow]="arrow"
-                    [kbqTooltipOffset]="offset"
                     kbq-button
                     kbqTooltip="Очень длинное название на тултипе"
+                    [kbqTooltipArrow]="arrow"
+                    [kbqTooltipOffset]="offset"
                 >
                     Кнопка с тултипом
                 </button>

--- a/packages/docs-examples/components/tooltip/tooltip-extended/tooltip-extended-example.ts
+++ b/packages/docs-examples/components/tooltip/tooltip-extended/tooltip-extended-example.ts
@@ -20,10 +20,10 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
     ],
     template: `
         <button
+            kbq-button
             [kbqExtendedTooltip]="tooltipContent"
             [kbqTooltipClass]="'custom-tooltip'"
             [kbqTooltipHeader]="tooltipHeader"
-            kbq-button
         >
             Кнопка со сложным тултипом
         </button>

--- a/packages/docs-examples/components/tooltip/tooltip-hide-with-timeout/tooltip-hide-with-timeout-example.ts
+++ b/packages/docs-examples/components/tooltip/tooltip-hide-with-timeout/tooltip-hide-with-timeout-example.ts
@@ -15,7 +15,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
     ],
     template: `
         <div class="layout-column" style="gap: 16px; align-items: flex-start">
-            <button [hideWithTimeout]="true" kbq-button kbqTooltip="Тултип">Кнопка с тултипом</button>
+            <button kbq-button kbqTooltip="Тултип" [hideWithTimeout]="true">Кнопка с тултипом</button>
         </div>
     `
 })

--- a/packages/docs-examples/components/tooltip/tooltip-multiple-lines/tooltip-multiple-lines-example.ts
+++ b/packages/docs-examples/components/tooltip/tooltip-multiple-lines/tooltip-multiple-lines-example.ts
@@ -15,7 +15,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
         KbqToolTipModule
     ],
     template: `
-        <button [kbqPlacement]="placement" kbq-button kbqTooltip="Подсказка может занимать две и более строк">
+        <button kbq-button kbqTooltip="Подсказка может занимать две и более строк" [kbqPlacement]="placement">
             Кнопка с тултипом
         </button>
     `

--- a/packages/docs-examples/components/tooltip/tooltip-overview/tooltip-overview-example.ts
+++ b/packages/docs-examples/components/tooltip/tooltip-overview/tooltip-overview-example.ts
@@ -16,8 +16,8 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
     ],
     template: `
         <div class="layout-column" style="gap: 16px; align-items: flex-start">
-            <button [kbqPlacement]="placement" kbq-button kbqTooltip="Тултип">Кнопка с тултипом</button>
-            <button [kbqPlacement]="placement" kbq-button kbqWarningTooltip="Тултип">Кнопка с предупреждением</button>
+            <button kbq-button kbqTooltip="Тултип" [kbqPlacement]="placement">Кнопка с тултипом</button>
+            <button kbq-button kbqWarningTooltip="Тултип" [kbqPlacement]="placement">Кнопка с предупреждением</button>
         </div>
     `
 })

--- a/packages/docs-examples/components/tooltip/tooltip-relative-to-pointer/tooltip-relative-to-pointer-example.ts
+++ b/packages/docs-examples/components/tooltip/tooltip-relative-to-pointer/tooltip-relative-to-pointer-example.ts
@@ -14,7 +14,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
         KbqToolTipModule
     ],
     template: `
-        <button [kbqRelativeToPointer]="true" kbq-button kbqTooltip="relativeToPointer">
+        <button kbq-button kbqTooltip="relativeToPointer" [kbqRelativeToPointer]="true">
             Button with a tooltip positioned relative to the cursor
         </button>
     `

--- a/packages/docs-examples/components/tooltip/tooltip-style/tooltip-style-example.ts
+++ b/packages/docs-examples/components/tooltip/tooltip-style/tooltip-style-example.ts
@@ -17,46 +17,46 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
     template: `
         <div class="layout-row layout-wrap" style="gap: 16px">
             <button
+                kbq-button
+                kbqTooltip="Тултип"
                 [kbqPlacement]="placement"
                 [kbqTooltipColor]="KbqComponentColors.Contrast"
-                kbq-button
-                kbqTooltip="Тултип"
             >
                 {{ buttonText }}
             </button>
 
             <button
+                kbq-button
+                kbqTooltip="Тултип"
                 [kbqPlacement]="placement"
                 [kbqTooltipColor]="KbqComponentColors.ContrastFade"
-                kbq-button
-                kbqTooltip="Тултип"
             >
                 {{ buttonText }}
             </button>
 
             <button
+                kbq-button
+                kbqTooltip="Тултип"
                 [kbqPlacement]="placement"
                 [kbqTooltipColor]="KbqComponentColors.Error"
-                kbq-button
-                kbqTooltip="Тултип"
             >
                 {{ buttonText }}
             </button>
 
             <button
+                kbq-button
+                kbqTooltip="Тултип"
                 [kbqPlacement]="placement"
                 [kbqTooltipColor]="KbqComponentColors.Warning"
-                kbq-button
-                kbqTooltip="Тултип"
             >
                 {{ buttonText }}
             </button>
 
             <button
-                [kbqPlacement]="placement"
-                [kbqTooltipColor]="KbqComponentColors.Theme"
                 kbq-button
                 kbqTooltip="Тултип"
+                [kbqPlacement]="placement"
+                [kbqTooltipColor]="KbqComponentColors.Theme"
             >
                 {{ buttonText }}
             </button>

--- a/packages/docs-examples/components/top-bar/top-bar-actions/top-bar-actions-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-actions/top-bar-actions-example.ts
@@ -50,6 +50,7 @@ type ExampleAction = {
                 <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     @for (action of actions; track action.id) {
                         <button
+                            kbq-button
                             [kbqOverflowItem]="action.id"
                             [alwaysVisible]="action?.alwaysVisible"
                             [kbqStyle]="action.style"
@@ -58,10 +59,9 @@ type ExampleAction = {
                             [kbqTooltipArrow]="false"
                             [kbqTooltipDisabled]="canTooltipBeAppied(action)"
                             [kbqTooltip]="action.text || action.id"
-                            kbq-button
                         >
                             @if (action.icon) {
-                                <i [class]="action.icon" kbq-icon=""></i>
+                                <i kbq-icon="" [class]="action.icon"></i>
                             }
                             @if (canTooltipBeAppied(action)) {
                                 {{ action.text }}
@@ -71,10 +71,10 @@ type ExampleAction = {
 
                     <div kbqOverflowItemsResult>
                         <button
+                            kbq-button
                             [kbqStyle]="KbqButtonStyles.Transparent"
                             [color]="KbqComponentColors.Contrast"
                             [kbqDropdownTriggerFor]="appDropdown"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                         </button>

--- a/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-breadcrumbs-adaptive/top-bar-breadcrumbs-adaptive-example.ts
@@ -73,18 +73,18 @@ const ExampleLocalizedData = new InjectionToken<Record<string | 'default', Examp
                     <kbq-breadcrumb-item text="Section" routerLink="./main/sections" />
                     <kbq-breadcrumb-item routerLink="./main/sections/details" text="Details">
                         <a
-                            class="kbq-truncate-line"
                             *kbqBreadcrumbView
+                            class="kbq-truncate-line"
                             routerLink="./main/sections/page/details"
                             tabindex="-1"
                         >
                             <button disabled aria-current="page" kbq-button kbqBreadcrumb>
                                 <span>Details</span>
                                 <i
-                                    [kbqPlacement]="PopUpPlacements.Bottom"
-                                    [kbqTooltipArrow]="false"
                                     kbq-icon="kbq-info-circle_16"
                                     kbqTooltip="Info"
+                                    [kbqPlacement]="PopUpPlacements.Bottom"
+                                    [kbqTooltipArrow]="false"
                                 ></i>
                             </button>
                         </a>
@@ -95,26 +95,26 @@ const ExampleLocalizedData = new InjectionToken<Record<string | 'default', Examp
             <div kbqTopBarContainer placement="end">
                 <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     <button
+                        kbqOverflowItem="filter"
+                        kbqTooltip="Filter"
+                        kbq-button
                         [kbqStyle]="KbqButtonStyles.Transparent"
                         [color]="KbqComponentColors.Contrast"
                         [kbqPlacement]="PopUpPlacements.Bottom"
                         [kbqTooltipArrow]="false"
-                        kbqOverflowItem="filter"
-                        kbqTooltip="Filter"
-                        kbq-button
                     >
                         <i kbq-icon="kbq-filter_16"></i>
                     </button>
 
                     <button
+                        kbqOverflowItem="share"
+                        kbqTooltip="Share"
+                        kbq-button
                         [kbqStyle]="KbqButtonStyles.Filled"
                         [color]="KbqComponentColors.ContrastFade"
                         [kbqTooltipDisabled]="isDesktop()"
                         [kbqPlacement]="PopUpPlacements.Bottom"
                         [kbqTooltipArrow]="false"
-                        kbqOverflowItem="share"
-                        kbqTooltip="Share"
-                        kbq-button
                     >
                         @if (isDesktop()) {
                             Share
@@ -125,10 +125,10 @@ const ExampleLocalizedData = new InjectionToken<Record<string | 'default', Examp
 
                     <div kbqOverflowItemsResult>
                         <button
+                            kbq-button
                             [kbqStyle]="KbqButtonStyles.Transparent"
                             [color]="KbqComponentColors.Contrast"
                             [kbqDropdownTriggerFor]="appDropdown"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                         </button>

--- a/packages/docs-examples/components/top-bar/top-bar-breadcrumbs/top-bar-breadcrumbs-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-breadcrumbs/top-bar-breadcrumbs-example.ts
@@ -45,26 +45,26 @@ import { map } from 'rxjs/operators';
             <div kbqTopBarContainer placement="end">
                 <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     <button
+                        kbqOverflowItem="0"
+                        kbqTooltip="Filter"
+                        kbq-button
                         [kbqStyle]="KbqButtonStyles.Transparent"
                         [color]="KbqComponentColors.Contrast"
                         [kbqPlacement]="PopUpPlacements.Bottom"
                         [kbqTooltipArrow]="false"
-                        kbqOverflowItem="0"
-                        kbqTooltip="Filter"
-                        kbq-button
                     >
                         <i kbq-icon="kbq-filter_16"></i>
                     </button>
 
                     <button
+                        kbqOverflowItem="1"
+                        kbqTooltip="Share"
+                        kbq-button
                         [kbqStyle]="KbqButtonStyles.Filled"
                         [color]="KbqComponentColors.ContrastFade"
                         [kbqTooltipDisabled]="isDesktop()"
                         [kbqPlacement]="PopUpPlacements.Bottom"
                         [kbqTooltipArrow]="false"
-                        kbqOverflowItem="1"
-                        kbqTooltip="Share"
-                        kbq-button
                     >
                         @if (isDesktop()) {
                             Share
@@ -75,10 +75,10 @@ import { map } from 'rxjs/operators';
 
                     <div kbqOverflowItemsResult>
                         <button
+                            kbq-button
                             [kbqStyle]="KbqButtonStyles.Transparent"
                             [color]="KbqComponentColors.Contrast"
                             [kbqDropdownTriggerFor]="appDropdown"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                         </button>

--- a/packages/docs-examples/components/top-bar/top-bar-overflow/top-bar-overflow-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-overflow/top-bar-overflow-example.ts
@@ -64,6 +64,7 @@ type ExampleAction = {
                 <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     @for (action of actions; track action.id) {
                         <button
+                            kbq-button
                             [kbqOverflowItem]="action.id"
                             [kbqStyle]="action.style"
                             [color]="action.color"
@@ -72,10 +73,9 @@ type ExampleAction = {
                             [kbqTooltipDisabled]="canTooltipBeAppied(action)"
                             [kbqTooltip]="action.text || action.id"
                             [alwaysVisible]="action?.alwaysVisible"
-                            kbq-button
                         >
                             @if (action.icon) {
-                                <i [class]="action.icon" kbq-icon=""></i>
+                                <i kbq-icon="" [class]="action.icon"></i>
                             }
                             @if (canTooltipBeAppied(action)) {
                                 {{ action.text }}
@@ -85,10 +85,10 @@ type ExampleAction = {
 
                     <div kbqOverflowItemsResult>
                         <button
+                            kbq-button
                             [kbqStyle]="KbqButtonStyles.Transparent"
                             [color]="KbqComponentColors.Contrast"
                             [kbqDropdownTriggerFor]="appDropdown"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                         </button>

--- a/packages/docs-examples/components/top-bar/top-bar-overview/top-bar-overview-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-overview/top-bar-overview-example.ts
@@ -52,6 +52,7 @@ type ExampleAction = {
                 <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     @for (action of actions; track action.id) {
                         <button
+                            kbq-button
                             [kbqOverflowItem]="action.id"
                             [kbqStyle]="action.style"
                             [color]="action.color"
@@ -59,10 +60,9 @@ type ExampleAction = {
                             [kbqTooltipArrow]="false"
                             [kbqTooltipDisabled]="isDesktop()"
                             [kbqTooltip]="action.text || action.id"
-                            kbq-button
                         >
                             @if (action.icon) {
-                                <i [class]="action.icon" kbq-icon=""></i>
+                                <i kbq-icon="" [class]="action.icon"></i>
                             }
                             @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
                                 {{ action.text }}
@@ -72,10 +72,10 @@ type ExampleAction = {
 
                     <div kbqOverflowItemsResult>
                         <button
+                            kbq-button
                             [kbqStyle]="KbqButtonStyles.Transparent"
                             [color]="KbqComponentColors.Contrast"
                             [kbqDropdownTriggerFor]="appDropdown"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                         </button>

--- a/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-title-counter-adaptive/top-bar-title-counter-adaptive-example.ts
@@ -83,6 +83,7 @@ type ExampleAction = {
                 <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     @for (action of actions; track action.id) {
                         <button
+                            kbq-button
                             [kbqOverflowItem]="action.id"
                             [kbqStyle]="action.style"
                             [color]="action.color"
@@ -90,10 +91,9 @@ type ExampleAction = {
                             [kbqTooltipArrow]="false"
                             [kbqTooltipDisabled]="isDesktop()"
                             [kbqTooltip]="action.text || action.id"
-                            kbq-button
                         >
                             @if (action.icon) {
-                                <i [class]="action.icon" kbq-icon=""></i>
+                                <i kbq-icon="" [class]="action.icon"></i>
                             }
                             @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
                                 {{ action.text }}
@@ -103,10 +103,10 @@ type ExampleAction = {
 
                     <div kbqOverflowItemsResult>
                         <button
+                            kbq-button
                             [kbqStyle]="KbqButtonStyles.Transparent"
                             [color]="KbqComponentColors.Contrast"
                             [kbqDropdownTriggerFor]="appDropdown"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                         </button>

--- a/packages/docs-examples/components/top-bar/top-bar-title-counter/top-bar-title-counter-example.ts
+++ b/packages/docs-examples/components/top-bar/top-bar-title-counter/top-bar-title-counter-example.ts
@@ -58,6 +58,7 @@ type ExampleAction = {
                 <div #kbqOverflowItems="kbqOverflowItems" kbqOverflowItems>
                     @for (action of actions; track action.id) {
                         <button
+                            kbq-button
                             [kbqOverflowItem]="action.id"
                             [kbqStyle]="action.style"
                             [color]="action.color"
@@ -66,10 +67,9 @@ type ExampleAction = {
                             [kbqTooltipDisabled]="isDesktop()"
                             [kbqTooltip]="action.text || action.id.toString()"
                             [alwaysVisible]="action?.alwaysVisible"
-                            kbq-button
                         >
                             @if (action.icon) {
-                                <i [class]="action.icon" kbq-icon=""></i>
+                                <i kbq-icon="" [class]="action.icon"></i>
                             }
                             @if ((action.text && isDesktop()) || (!action.icon && action.text)) {
                                 {{ action.text }}
@@ -79,10 +79,10 @@ type ExampleAction = {
 
                     <div kbqOverflowItemsResult>
                         <button
+                            kbq-button
                             [kbqStyle]="KbqButtonStyles.Transparent"
                             [color]="KbqComponentColors.Contrast"
                             [kbqDropdownTriggerFor]="appDropdown"
-                            kbq-button
                         >
                             <i kbq-icon="kbq-ellipsis-horizontal_16"></i>
                         </button>

--- a/packages/docs-examples/components/tree-select/tree-select-child-selection-overview/tree-select-child-selection-overview-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-child-selection-overview/tree-select-child-selection-overview-example.ts
@@ -116,19 +116,19 @@ export const DATA_OBJECT = {
         <kbq-form-field>
             <kbq-tree-select [formControl]="control" [multiple]="true" (selectionChange)="onSelectionChange($event)">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
-                    <kbq-tree-option *kbqTreeNodeDef="let node" [checkboxThirdState]="true" kbqTreeNodePadding>
+                    <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [checkboxThirdState]="true">
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
-                        [checkboxThirdState]="true"
                         kbqTreeNodePadding
+                        [checkboxThirdState]="true"
                     >
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>

--- a/packages/docs-examples/components/tree-select/tree-select-custom-matcher/tree-select-custom-matcher-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-custom-matcher/tree-select-custom-matcher-example.ts
@@ -108,9 +108,9 @@ export const DATA_OBJECT = {
     template: `
         <kbq-tree-select
             #select="kbqTreeSelect"
-            [(ngModel)]="selected"
             [class]="{ 'kbq-tree-select': false, 'my-custom-select': true }"
             [tabIndex]="-1"
+            [(ngModel)]="selected"
         >
             <button kbq-button kbq-select-matcher>
                 {{ select.triggerValue }}
@@ -125,9 +125,9 @@ export const DATA_OBJECT = {
 
                 <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                     <i
-                        [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         kbq-icon="kbq-chevron-down-s_16"
                         kbqTreeNodeToggle
+                        [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                     ></i>
                     {{ treeControl.getViewValue(node) }}
                 </kbq-tree-option>

--- a/packages/docs-examples/components/tree-select/tree-select-custom-trigger/tree-select-custom-trigger-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-custom-trigger/tree-select-custom-trigger-example.ts
@@ -116,9 +116,9 @@ export const DATA_OBJECT = {
 
                 <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                     <i
-                        [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         kbq-icon="kbq-chevron-down-s_16"
                         kbqTreeNodeToggle
+                        [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                     ></i>
                     {{ treeControl.getViewValue(node) }}
                 </kbq-tree-option>

--- a/packages/docs-examples/components/tree-select/tree-select-footer-overview/tree-select-footer-overview-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-footer-overview/tree-select-footer-overview-example.ts
@@ -116,9 +116,9 @@ export const DATA_OBJECT = {
 
                     <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>

--- a/packages/docs-examples/components/tree-select/tree-select-lazyload/tree-select-lazyload-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-lazyload/tree-select-lazyload-example.ts
@@ -187,9 +187,9 @@ export class LazyLoadDataSource<T, F> extends KbqTreeFlatDataSource<T, F> {
 
                     <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         @if (node.loading) {
                             <kbq-progress-spinner mode="indeterminate" />

--- a/packages/docs-examples/components/tree-select/tree-select-multiple-overview/tree-select-multiple-overview-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-multiple-overview/tree-select-multiple-overview-example.ts
@@ -113,7 +113,7 @@ export const DATA_OBJECT = {
     ],
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selected" [multiple]="true">
+            <kbq-tree-select [multiple]="true" [(ngModel)]="selected">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -121,9 +121,9 @@ export const DATA_OBJECT = {
 
                     <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>

--- a/packages/docs-examples/components/tree-select/tree-select-overview/tree-select-overview-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-overview/tree-select-overview-example.ts
@@ -115,9 +115,9 @@ export const DATA_OBJECT = {
 
                     <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>

--- a/packages/docs-examples/components/tree-select/tree-select-search-overview/tree-select-search-overview-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-search-overview/tree-select-search-overview-example.ts
@@ -118,10 +118,10 @@ export const DATA_OBJECT = {
     ],
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selected" [multiple]="true">
+            <kbq-tree-select [multiple]="true" [(ngModel)]="selected">
                 <kbq-form-field kbqFormFieldWithoutBorders kbqSelectSearch>
                     <i kbq-icon="kbq-magnifying-glass_16" kbqPrefix></i>
-                    <input [formControl]="searchControl" kbqInput type="text" />
+                    <input kbqInput type="text" [formControl]="searchControl" />
                     <kbq-cleaner />
                 </kbq-form-field>
 
@@ -136,9 +136,9 @@ export const DATA_OBJECT = {
 
                     <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         <span
                             [innerHTML]="treeControl.getViewValue(node) | mcHighlight: treeControl.filterValue.value"

--- a/packages/docs-examples/components/tree-select/tree-select-with-multiline-matcher-overview/tree-select-with-multiline-matcher-example.ts
+++ b/packages/docs-examples/components/tree-select/tree-select-with-multiline-matcher-overview/tree-select-with-multiline-matcher-example.ts
@@ -107,7 +107,7 @@ export const DATA_OBJECT = {
     imports: [KbqFormFieldModule, FormsModule, KbqTreeModule, KbqTreeSelectModule, KbqIconModule],
     template: `
         <kbq-form-field>
-            <kbq-tree-select [(ngModel)]="selected" [multiline]="true">
+            <kbq-tree-select [multiline]="true" [(ngModel)]="selected">
                 <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
                     <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                         {{ treeControl.getViewValue(node) }}
@@ -115,9 +115,9 @@ export const DATA_OBJECT = {
 
                     <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding>
                         <i
-                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                             kbq-icon="kbq-chevron-down-s_16"
                             kbqTreeNodeToggle
+                            [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
                         ></i>
                         {{ treeControl.getViewValue(node) }}
                     </kbq-tree-option>

--- a/packages/docs-examples/components/tree/tree-access-rights/tree-access-rights-example.ts
+++ b/packages/docs-examples/components/tree/tree-access-rights/tree-access-rights-example.ts
@@ -198,12 +198,12 @@ abstract class TreeParams {
     ],
     template: `
         <kbq-tree-selection
+            multiple="checkbox"
             [autoSelect]="false"
             [dataSource]="dataSource"
             [ngModel]="modelValue"
             [treeControl]="treeControl"
             (ngModelChange)="onModelChange($event)"
-            multiple="checkbox"
         >
             <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                 <span>{{ treeControl.getViewValue(node) }}</span>

--- a/packages/docs-examples/components/tree/tree-action-button/tree-action-button-example.ts
+++ b/packages/docs-examples/components/tree/tree-action-button/tree-action-button-example.ts
@@ -117,19 +117,19 @@ export const DATA_OBJECT = {
     ],
     template: `
         <kbq-tree-selection
-            [(ngModel)]="modelValue"
+            style="width: 400px"
             [autoSelect]="false"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
+            [(ngModel)]="modelValue"
             (onSelectAll)="onSelectAll($event)"
-            style="width: 400px"
         >
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'tests'" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'tests'">
                 <i kbq-icon="kbq-info-circle_16"></i>
 
                 <div class="layout-row layout-align-space-between">
                     <span [innerHTML]="treeControl.getViewValue(node)"></span>
-                    <kbq-badge [compact]="true" badgeColor="theme">badge</kbq-badge>
+                    <kbq-badge badgeColor="theme" [compact]="true">badge</kbq-badge>
                 </div>
 
                 <kbq-option-action
@@ -146,7 +146,7 @@ export const DATA_OBJECT = {
 
                 <div class="layout-row layout-align-space-between">
                     <span [innerHTML]="treeControl.getViewValue(node)"></span>
-                    <kbq-badge [compact]="true" badgeColor="theme">badge</kbq-badge>
+                    <kbq-badge badgeColor="theme" [compact]="true">badge</kbq-badge>
                 </div>
 
                 <kbq-option-action

--- a/packages/docs-examples/components/tree/tree-checked-filtering/tree-checked-filtering-example.ts
+++ b/packages/docs-examples/components/tree/tree-checked-filtering/tree-checked-filtering-example.ts
@@ -176,7 +176,7 @@ abstract class TreeParams {
     ],
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="filterValue" (ngModelChange)="onFilterChange($event)" kbqInput type="text" />
+            <input kbqInput type="text" [(ngModel)]="filterValue" (ngModelChange)="onFilterChange($event)" />
         </kbq-form-field>
         <div class="layout-margin-top-4xl">
             <kbq-button-toggle-group #group1="kbqButtonToggleGroup" (change)="onToggleClick($event)">
@@ -195,14 +195,14 @@ abstract class TreeParams {
             </kbq-button-toggle-group>
         </div>
         <kbq-tree-selection
-            [(ngModel)]="modelValue"
+            multiple="checkbox"
             [autoSelect]="false"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
+            [(ngModel)]="modelValue"
             (ngModelChange)="onModelValueChange($event)"
-            multiple="checkbox"
         >
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'tests'" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'tests'">
                 <span [innerHTML]="treeControl.getViewValue(node) | mcHighlight: treeControl.filterValue.value"></span>
             </kbq-tree-option>
 

--- a/packages/docs-examples/components/tree/tree-custom-filtering/tree-custom-filtering-example.ts
+++ b/packages/docs-examples/components/tree/tree-custom-filtering/tree-custom-filtering-example.ts
@@ -160,15 +160,15 @@ export class CustomTreeControlFilter<T> implements FlatTreeControlFilter<T> {
     imports: [KbqFormFieldModule, KbqInputModule, FormsModule, KbqTreeModule, KbqHighlightModule],
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="filterValue" (ngModelChange)="onFilterChange($event)" kbqInput type="text" />
+            <input kbqInput type="text" [(ngModel)]="filterValue" (ngModelChange)="onFilterChange($event)" />
         </kbq-form-field>
         <kbq-tree-selection
             class="layout-margin-top-4xl"
-            [(ngModel)]="modelValue"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
+            [(ngModel)]="modelValue"
         >
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'tests'" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'tests'">
                 <span [innerHTML]="treeControl.getViewValue(node) | mcHighlight: treeControl.filterValue.value"></span>
             </kbq-tree-option>
 

--- a/packages/docs-examples/components/tree/tree-descendants-subcategories/tree-descendants-subcategories-example.ts
+++ b/packages/docs-examples/components/tree/tree-descendants-subcategories/tree-descendants-subcategories-example.ts
@@ -166,18 +166,18 @@ abstract class TreeParams {
     ],
     template: `
         <kbq-tree-selection
-            [(ngModel)]="modelValue"
+            multiple="checkbox"
             [autoSelect]="false"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
+            [(ngModel)]="modelValue"
             (selectionChange)="onSelectionChange($event)"
-            multiple="checkbox"
         >
-            <kbq-tree-option *kbqTreeNodeDef="let node" [checkboxThirdState]="true" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [checkboxThirdState]="true">
                 <span [innerHTML]="treeControl.getViewValue(node) | mcHighlight: treeControl.filterValue.value"></span>
             </kbq-tree-option>
 
-            <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" [checkboxThirdState]="true" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node; when: hasChild" kbqTreeNodePadding [checkboxThirdState]="true">
                 <kbq-tree-node-toggle [node]="node" />
 
                 <span [innerHTML]="treeControl.getViewValue(node) | mcHighlight: treeControl.filterValue.value"></span>

--- a/packages/docs-examples/components/tree/tree-filtering/tree-filtering-example.ts
+++ b/packages/docs-examples/components/tree/tree-filtering/tree-filtering-example.ts
@@ -107,15 +107,15 @@ export const DATA_OBJECT = {
     imports: [KbqFormFieldModule, KbqInputModule, FormsModule, KbqTreeModule, KbqHighlightModule],
     template: `
         <kbq-form-field>
-            <input [(ngModel)]="filterValue" (ngModelChange)="onFilterChange($event)" kbqInput type="text" />
+            <input kbqInput type="text" [(ngModel)]="filterValue" (ngModelChange)="onFilterChange($event)" />
         </kbq-form-field>
         <kbq-tree-selection
             class="layout-margin-top-4xl"
-            [(ngModel)]="modelValue"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
+            [(ngModel)]="modelValue"
         >
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'tests'" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'tests'">
                 <span [innerHTML]="treeControl.getViewValue(node) | mcHighlight: treeControl.filterValue.value"></span>
             </kbq-tree-option>
 

--- a/packages/docs-examples/components/tree/tree-lazyload/tree-lazyload-example.ts
+++ b/packages/docs-examples/components/tree/tree-lazyload/tree-lazyload-example.ts
@@ -169,7 +169,7 @@ class LazyLoadDataSource<T, F> extends KbqTreeFlatDataSource<T, F> {
     standalone: true,
     selector: 'tree-lazyload-example',
     template: `
-        <kbq-tree-selection [(ngModel)]="modelValue" [dataSource]="dataSource" [treeControl]="treeControl">
+        <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl" [(ngModel)]="modelValue">
             <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding>
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>
             </kbq-tree-option>

--- a/packages/docs-examples/components/tree/tree-multiple-checkbox/tree-multiple-checkbox-example.ts
+++ b/packages/docs-examples/components/tree/tree-multiple-checkbox/tree-multiple-checkbox-example.ts
@@ -109,12 +109,12 @@ export const DATA_OBJECT = {
     ],
     template: `
         <kbq-tree-selection
-            [(ngModel)]="modelValue"
+            multiple="checkbox"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
-            multiple="checkbox"
+            [(ngModel)]="modelValue"
         >
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'tests'" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'tests'">
                 <i kbq-icon="kbq-info-circle_16"></i>
 
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>

--- a/packages/docs-examples/components/tree/tree-multiple-checklist/tree-multiple-checklist-example.ts
+++ b/packages/docs-examples/components/tree/tree-multiple-checklist/tree-multiple-checklist-example.ts
@@ -109,37 +109,37 @@ export const DATA_OBJECT = {
         KbqCheckboxModule
     ],
     template: `
-        <kbq-tree-selection [(ngModel)]="modelValue" [dataSource]="dataSource" [treeControl]="treeControl">
+        <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl" [(ngModel)]="modelValue">
             <kbq-tree-option
                 *kbqTreeNodeDef="let node"
+                kbqTreeNodePadding
                 [class.kbq-selected]="selectedState(node)"
                 [disabled]="node.name === 'tests'"
                 (click)="onOptionClick($event, node)"
                 (keydown.enter)="fileSelectionToggle(node)"
                 (keydown.space)="fileSelectionToggle(node)"
-                kbqTreeNodePadding
             >
                 <kbq-checkbox
+                    style="margin-right: 8px"
                     [checked]="checklistSelection.isSelected(node)"
                     [disabled]="node.name === 'tests'"
-                    style="margin-right: 8px"
                 />
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>
             </kbq-tree-option>
 
             <kbq-tree-option
                 *kbqTreeNodeDef="let node; when: hasChild"
+                kbqTreeNodePadding
                 [class.kbq-selected]="selectedState(node)"
                 (click)="onOptionClick($event, node)"
                 (keydown.enter)="fileSelectionToggle(node)"
                 (keydown.space)="fileSelectionToggle(node)"
-                kbqTreeNodePadding
             >
                 <kbq-tree-node-toggle [node]="node" />
                 <kbq-checkbox
+                    style="margin-right: 8px"
                     [checked]="descendantsAllSelected(node)"
                     [indeterminate]="descendantsPartiallySelected(node)"
-                    style="margin-right: 8px"
                 />
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>
             </kbq-tree-option>

--- a/packages/docs-examples/components/tree/tree-multiple-keyboard/tree-multiple-keyboard-example.ts
+++ b/packages/docs-examples/components/tree/tree-multiple-keyboard/tree-multiple-keyboard-example.ts
@@ -107,12 +107,12 @@ export const DATA_OBJECT = {
     ],
     template: `
         <kbq-tree-selection
-            [(ngModel)]="modelValue"
+            multiple="keyboard"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
-            multiple="keyboard"
+            [(ngModel)]="modelValue"
         >
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'tests'" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'tests'">
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>
             </kbq-tree-option>
 

--- a/packages/docs-examples/components/tree/tree-overview/tree-overview-example.ts
+++ b/packages/docs-examples/components/tree/tree-overview/tree-overview-example.ts
@@ -106,8 +106,8 @@ export const DATA_OBJECT = {
         FormsModule
     ],
     template: `
-        <kbq-tree-selection [(ngModel)]="modelValue" [dataSource]="dataSource" [treeControl]="treeControl">
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'tests'" kbqTreeNodePadding>
+        <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl" [(ngModel)]="modelValue">
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'tests'">
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>
             </kbq-tree-option>
 

--- a/packages/docs-examples/components/tree/tree-select-and-mark/tree-select-and-mark-example.ts
+++ b/packages/docs-examples/components/tree/tree-select-and-mark/tree-select-and-mark-example.ts
@@ -123,12 +123,12 @@ export const DATA_OBJECT = [
     template: `
         <div class="layout-row">
             <div class="flex-30">
-                <kbq-tree-selection [(ngModel)]="modelValue" [dataSource]="dataSource" [treeControl]="treeControl">
+                <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl" [(ngModel)]="modelValue">
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node"
+                        kbqTreeNodePadding
                         [class.kbq-checked]="node.checked"
                         (keydown.space)="toggleCheckboxState($event, node)"
-                        kbqTreeNodePadding
                     >
                         <kbq-pseudo-checkbox [state]="node.checked" (click)="toggleCheckboxState($event, node)" />
                         <span [innerHTML]="treeControl.getViewValue(node)"></span>
@@ -136,9 +136,9 @@ export const DATA_OBJECT = [
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
+                        kbqTreeNodePadding
                         [class.kbq-checked]="node.checked"
                         (keydown.space)="toggleCheckboxState($event, node)"
-                        kbqTreeNodePadding
                     >
                         <kbq-tree-node-toggle [node]="node" />
 

--- a/packages/docs-examples/components/tree/tree-selection-separate-from-focus/tree-selection-separate-from-focus-example.ts
+++ b/packages/docs-examples/components/tree/tree-selection-separate-from-focus/tree-selection-separate-from-focus-example.ts
@@ -122,16 +122,16 @@ export const DATA_OBJECT = [
         <div class="layout-row">
             <div class="flex-30">
                 <kbq-tree-selection
-                    [(ngModel)]="modelValue"
                     [autoSelect]="false"
                     [dataSource]="dataSource"
                     [treeControl]="treeControl"
+                    [(ngModel)]="modelValue"
                 >
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node"
+                        kbqTreeNodePadding
                         [class.kbq-checked]="node.checked"
                         (keydown.space)="toggleCheckboxState($event, node)"
-                        kbqTreeNodePadding
                     >
                         <kbq-pseudo-checkbox [state]="node.checked" (click)="toggleCheckboxState($event, node)" />
                         <span [innerHTML]="treeControl.getViewValue(node)"></span>
@@ -139,9 +139,9 @@ export const DATA_OBJECT = [
 
                     <kbq-tree-option
                         *kbqTreeNodeDef="let node; when: hasChild"
+                        kbqTreeNodePadding
                         [class.kbq-checked]="node.checked"
                         (keydown.space)="toggleCheckboxState($event, node)"
-                        kbqTreeNodePadding
                     >
                         <kbq-tree-node-toggle [node]="node" />
 

--- a/packages/docs-examples/components/tree/tree-toggle-on-click/tree-toggle-on-click-example.ts
+++ b/packages/docs-examples/components/tree/tree-toggle-on-click/tree-toggle-on-click-example.ts
@@ -103,24 +103,24 @@ export const DATA_OBJECT = [
     ],
     template: `
         <kbq-tree-selection
-            [(ngModel)]="modelValue"
             [dataSource]="dataSource"
             [treeControl]="treeControl"
             [autoSelect]="false"
+            [(ngModel)]="modelValue"
         >
             <kbq-tree-option
                 *kbqTreeNodeDef="let node; when: hasChild"
+                kbqTreeNodePadding
                 [selectable]="false"
                 (click)="treeControl.toggle(node)"
                 (keydown.enter)="treeControl.toggle(node)"
-                kbqTreeNodePadding
             >
                 <kbq-tree-node-toggle [node]="node" />
 
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>
             </kbq-tree-option>
 
-            <kbq-tree-option *kbqTreeNodeDef="let node" [disabled]="node.name === 'Disabled Node'" kbqTreeNodePadding>
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbqTreeNodePadding [disabled]="node.name === 'Disabled Node'">
                 <span [innerHTML]="treeControl.getViewValue(node)"></span>
             </kbq-tree-option>
         </kbq-tree-selection>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15700,7 +15700,6 @@ __metadata:
     postcss-discard-comments: "npm:^7.0.4"
     prettier: "npm:^3.6.2"
     prettier-plugin-multiline-arrays: "npm:^3.0.6"
-    prettier-plugin-organize-attributes: "npm:^1.0.0"
     prettier-plugin-organize-imports: "npm:^4.1.0"
     rimraf: "npm:^5.0.5"
     rollup: "npm:^4.44.1"
@@ -18708,15 +18707,6 @@ __metadata:
   peerDependencies:
     prettier: ">=3.0.0"
   checksum: 10c0/4a22a9f7edebbca06360d1092e1b9dbc8775dcf386fbd5f555565d56735b7c1698abcad46008dc1e23f693a9f0cf3dc92e70bebec282462b0480193fb26ead9c
-  languageName: node
-  linkType: hard
-
-"prettier-plugin-organize-attributes@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "prettier-plugin-organize-attributes@npm:1.0.0"
-  peerDependencies:
-    prettier: ^3.0.0
-  checksum: 10c0/eb84691390eadd256ec8ec34ad6946f7ebdbbe7ff0ec26ca569cb9e74f94677c9b4cfe1b34df06d3a01a68700bdab87c9a6d1e8c62dafc8ae53c73fd3d255b60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/angular-eslint/angular-eslint/blob/v18.4.3/packages/eslint-plugin-template/docs/rules/attributes-order.md

Default order: 

```
[
 'STRUCTURAL_DIRECTIVE',
 'TEMPLATE_REFERENCE',
 'ATTRIBUTE_BINDING',
 'INPUT_BINDING',
 'TWO_WAY_BINDING',
 'OUTPUT_BINDING'
]
```