### PR TITLE
fix(sidepanel): close panel on indent click (#DS-4053)

### DIFF
--- a/packages/components/sidepanel/sidepanel-container.component.html
+++ b/packages/components/sidepanel/sidepanel-container.component.html
@@ -1,6 +1,6 @@
 <div class="kbq-sidepanel-wrapper">
     @if (withIndent) {
-        <div class="kbq-sidepanel-indent" (click)="exit()"></div>
+        <div class="kbq-sidepanel-indent" (click)="indentClick$.next($event)"></div>
     }
 
     <div class="kbq-sidepanel-content" [cdkTrapFocus]="trapFocus" [cdkTrapFocusAutoCapture]="trapFocusAutoCapture">

--- a/packages/components/sidepanel/sidepanel-container.component.html
+++ b/packages/components/sidepanel/sidepanel-container.component.html
@@ -1,6 +1,6 @@
 <div class="kbq-sidepanel-wrapper">
     @if (withIndent) {
-        <div class="kbq-sidepanel-indent" (click)="indentClick$.next($event)"></div>
+        <div class="kbq-sidepanel-indent" (click)="indentClickEmitter.next($event)"></div>
     }
 
     <div class="kbq-sidepanel-content" [cdkTrapFocus]="trapFocus" [cdkTrapFocusAutoCapture]="trapFocusAutoCapture">

--- a/packages/components/sidepanel/sidepanel-container.component.ts
+++ b/packages/components/sidepanel/sidepanel-container.component.ts
@@ -14,9 +14,10 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
 import {
-    KbqSidepanelAnimationState,
     kbqSidepanelAnimations,
+    KbqSidepanelAnimationState,
     kbqSidepanelTransformAnimation
 } from './sidepanel-animations';
 import { KbqSidepanelConfig, KbqSidepanelPosition } from './sidepanel-config';
@@ -74,6 +75,9 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
         return this.sidepanelConfig.trapFocus ?? !!this.sidepanelConfig.hasBackdrop;
     }
 
+    /** @docs-private */
+    protected readonly indentClick$ = new Subject<MouseEvent>();
+
     /** Whether the component has been destroyed. */
     private destroyed: boolean;
 
@@ -89,6 +93,15 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
 
     ngOnDestroy(): void {
         this.destroyed = true;
+    }
+
+    /**
+     * Gets an observable that emits when the indent has been clicked.
+     *
+     * @docs-private
+     */
+    indentClick(): Observable<MouseEvent> {
+        return this.indentClick$.asObservable();
     }
 
     /** Attach a component portal as content to this sidepanel container. */

--- a/packages/components/sidepanel/sidepanel-container.component.ts
+++ b/packages/components/sidepanel/sidepanel-container.component.ts
@@ -76,7 +76,7 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
     }
 
     /** @docs-private */
-    protected readonly indentClick$ = new Subject<MouseEvent>();
+    protected readonly indentClickEmitter = new Subject<MouseEvent>();
 
     /** Whether the component has been destroyed. */
     private destroyed: boolean;
@@ -101,7 +101,7 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
      * @docs-private
      */
     indentClick(): Observable<MouseEvent> {
-        return this.indentClick$.asObservable();
+        return this.indentClickEmitter.asObservable();
     }
 
     /** Attach a component portal as content to this sidepanel container. */

--- a/packages/components/sidepanel/sidepanel-ref.ts
+++ b/packages/components/sidepanel/sidepanel-ref.ts
@@ -61,7 +61,8 @@ export class KbqSidepanelRef<T = any, R = any> {
                 overlayRef.keydownEvents().pipe(
                     // keyCode is deprecated, but IE11 and Edge don't support code property, which we need use instead
                     filter((event) => event.keyCode === ESCAPE)
-                )
+                ),
+                this.containerInstance.indentClick()
             ).subscribe(() => this.close());
         }
     }

--- a/packages/components/sidepanel/sidepanel.spec.ts
+++ b/packages/components/sidepanel/sidepanel.spec.ts
@@ -260,6 +260,40 @@ describe('KbqSidepanelService', () => {
         expect(overlayContainerElement.querySelectorAll('.kbq-sidepanel-indent').length).toBe(1);
     });
 
+    it('should close sidepanel on indent click', fakeAsync(() => {
+        sidepanelService.open(SimpleSidepanelExample);
+
+        expect(overlayContainerElement.querySelectorAll('.kbq-sidepanel-indent').length).toBe(0);
+
+        sidepanelService.open(SimpleSidepanelExample);
+
+        expect(overlayContainerElement.querySelectorAll('.kbq-sidepanel-indent').length).toBe(1);
+
+        overlayContainerElement.querySelectorAll<HTMLDivElement>('.kbq-sidepanel-indent')[0]!.click();
+
+        rootComponentFixture.detectChanges();
+        tick();
+
+        expect(overlayContainerElement.querySelectorAll('.kbq-sidepanel-indent').length).toBe(0);
+    }));
+
+    it('should NOT close sidepanel on indent click', fakeAsync(() => {
+        sidepanelService.open(SimpleSidepanelExample);
+
+        expect(overlayContainerElement.querySelectorAll('.kbq-sidepanel-indent').length).toBe(0);
+
+        sidepanelService.open(SimpleSidepanelExample, { disableClose: true });
+
+        expect(overlayContainerElement.querySelectorAll('.kbq-sidepanel-indent').length).toBe(1);
+
+        overlayContainerElement.querySelectorAll<HTMLDivElement>('.kbq-sidepanel-indent')[0]!.click();
+
+        rootComponentFixture.detectChanges();
+        tick();
+
+        expect(overlayContainerElement.querySelectorAll('.kbq-sidepanel-indent').length).toBe(1);
+    }));
+
     it('should not add indent when open more than one sidepanel with different position', () => {
         sidepanelService.open(SimpleSidepanelExample);
 

--- a/tools/public_api_guard/components/sidepanel.api.md
+++ b/tools/public_api_guard/components/sidepanel.api.md
@@ -30,6 +30,7 @@ import { OnInit } from '@angular/core';
 import { Overlay } from '@angular/cdk/overlay';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { SimpleChanges } from '@angular/core';
+import { Subject } from 'rxjs';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { TemplateRef } from '@angular/core';
 
@@ -114,6 +115,8 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
     enter(): void;
     exit(): void;
     id: string;
+    protected readonly indentClick$: Subject<MouseEvent>;
+    indentClick(): Observable<MouseEvent>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/sidepanel.api.md
+++ b/tools/public_api_guard/components/sidepanel.api.md
@@ -115,8 +115,8 @@ export class KbqSidepanelContainerComponent extends BasePortalOutlet implements 
     enter(): void;
     exit(): void;
     id: string;
-    protected readonly indentClick$: Subject<MouseEvent>;
     indentClick(): Observable<MouseEvent>;
+    protected readonly indentClickEmitter: Subject<MouseEvent>;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)


### PR DESCRIPTION
we can close the panel even if it is specified `disableClose`