### PR TITLE
fix(file-upload): lowered hint color specificity order (#DS-4114)

### DIFF
--- a/packages/components/file-upload/_file-upload-theme.scss
+++ b/packages/components/file-upload/_file-upload-theme.scss
@@ -220,7 +220,7 @@
     }
 
     .kbq-file-upload__hint {
-        .kbq-hint {
+        :where(& .kbq-hint) {
             color: var(--kbq-foreground-contrast-secondary);
         }
     }


### PR DESCRIPTION
баг возникал из-за того что 2 селектора (условно `file-upload_hint kbq-hint` и `kbq-hint.kbq-error`) имели одинаковый вес и порядок появления стилей нельзя установить. Поэтому уменьшил специфичность селектора в file-upload