### PR TITLE
chore(docs,file-upload): add mixed validation example (#DS-4115)

### DIFF
--- a/packages/components-dev/file-upload/module.ts
+++ b/packages/components-dev/file-upload/module.ts
@@ -298,6 +298,10 @@ export class DevFileUploadStateAndStyle {
         <file-upload-single-accept-validation-example />
         <hr />
         <file-upload-multiple-accept-validation-example />
+        <hr />
+        <file-upload-multiple-mixed-validation-example />
+        <hr />
+        <file-upload-single-mixed-validation-example />
     `,
     host: {
         class: 'layout-column'

--- a/packages/components/file-upload/examples.file-upload.en.md
+++ b/packages/components/file-upload/examples.file-upload.en.md
@@ -8,6 +8,8 @@ Configuring text via the input property `[localeConfig]` allows you to change on
 
 <!-- example(file-upload-custom-text-via-input) -->
 
+### Indeterminate progress indicator
+
 An example of file upload with indeterminate progress:
 
 <!-- example(file-upload-indeterminate-loading-overview) -->

--- a/packages/components/file-upload/examples.file-upload.en.md
+++ b/packages/components/file-upload/examples.file-upload.en.md
@@ -19,13 +19,15 @@ After uploading, the file is highlighted as having an issue — this is a simula
 
 <!-- example(file-upload-single-with-signal) -->
 
-## Reactive Forms
+## Reactive forms
 
 An example of a file uploader using [`FormControl`](https://angular.dev/api/forms/FormControl).
 
-### Validation: Additional Examples
+### Validation: additional examples
 
-#### Required Field
+The examples use [FileValidators](https://github.com/koobiq/angular-components/blob/main/packages/components/core/forms/validators.ts), a set of static methods for validating file upload fields.
+
+#### Required field
 
 - **Single File**: An example of a file uploader that ensures a file must be uploaded.
 
@@ -35,9 +37,7 @@ An example of a file uploader using [`FormControl`](https://angular.dev/api/form
 
 <!-- example(file-upload-multiple-required-reactive-validation) -->
 
-#### File Size Validation
-
-The examples use [FileValidators](https://github.com/koobiq/angular-components/blob/main/packages/components/core/forms/validators.ts), a set of static methods for validating file upload fields.
+#### File size validation
 
 - **Single File**: An example of uploading a single file with Reactive Forms-based validation.
 
@@ -49,8 +49,6 @@ The examples use [FileValidators](https://github.com/koobiq/angular-components/b
 
 #### File type or extension validation
 
-The examples use [FileValidators](https://github.com/koobiq/angular-components/blob/main/packages/components/core/forms/validators.ts).
-
 - **Single file**: example of uploading a single file using `Reactive Forms` with validation.
 
 <!-- example(file-upload-single-accept-validation) -->
@@ -58,3 +56,13 @@ The examples use [FileValidators](https://github.com/koobiq/angular-components/b
 - **Multiple files**: Example of uploading multiple files using `Reactive Forms` with validation.
 
 <!-- example(file-upload-multiple-accept-validation) -->
+
+#### Mixed validation: required and extension
+
+- **Single file**: example of uploading a single file using `Reactive Forms` with validation.
+
+<!-- example(file-upload-single-mixed-validation) -->
+
+- **Multiple files**: Example of uploading multiple files using `Reactive Forms` with validation.
+
+<!-- example(file-upload-multiple-mixed-validation) -->

--- a/packages/components/file-upload/examples.file-upload.ru.md
+++ b/packages/components/file-upload/examples.file-upload.ru.md
@@ -27,6 +27,8 @@
 
 ### Валидация: дополнительные примеры
 
+В примерах используется [FileValidators](https://github.com/koobiq/angular-components/blob/main/packages/components/core/forms/validators.ts) - это набор статических методов для валидации поля загрузки файлов.
+
 #### Обязательное поле
 
 - **Один файл**: Пример загрузчика, проверяющего, что файл обязательно должен быть загружен.
@@ -39,8 +41,6 @@
 
 #### Валидация размера файла
 
-В примерах используется [FileValidators](https://github.com/koobiq/angular-components/blob/main/packages/components/core/forms/validators.ts) - это набор статических методов для валидации поля загрузки файлов.
-
 - **Один файл**: Пример загрузки одного файла с применением `Reactive Forms` для проверки данных.
 
 <!-- example(file-upload-single-validation-reactive-forms-overview) -->
@@ -51,8 +51,6 @@
 
 #### Валидация типа или расширения файла
 
-В примерах используется [FileValidators](https://github.com/koobiq/angular-components/blob/main/packages/components/core/forms/validators.ts).
-
 - **Один файл**: Пример загрузки одного файла с применением `Reactive Forms` для проверки данных.
 
 <!-- example(file-upload-single-accept-validation) -->
@@ -60,3 +58,13 @@
 - **Несколько файлов**: Пример загрузки нескольких файлов с использованием `Reactive Forms` и валидации.
 
 <!-- example(file-upload-multiple-accept-validation) -->
+
+#### Проверка файла: обязательность и расширение
+
+- **Один файл**: Пример загрузки одного файла с применением `Reactive Forms` для проверки данных.
+
+<!-- example(file-upload-single-mixed-validation) -->
+
+- **Несколько файлов**: Пример загрузки нескольких файлов с использованием `Reactive Forms` и валидации.
+
+<!-- example(file-upload-multiple-mixed-validation) -->

--- a/packages/components/file-upload/examples.file-upload.ru.md
+++ b/packages/components/file-upload/examples.file-upload.ru.md
@@ -8,6 +8,8 @@
 
 <!-- example(file-upload-custom-text-via-input) -->
 
+### Неопределенный индикатор прогресса
+
 Пример загрузки файлов с неопределенным по завершенности прогрессом:
 
 <!-- example(file-upload-indeterminate-loading-overview) -->

--- a/packages/docs-examples/components/file-upload/file-upload-indeterminate-loading-overview/file-upload-indeterminate-loading-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-indeterminate-loading-overview/file-upload-indeterminate-loading-overview-example.ts
@@ -29,7 +29,10 @@ import { take } from 'rxjs/operators';
         @if (isLoading) {
             <p class="kbq-text-big">Immediately load to backend...</p>
         }
-    `
+    `,
+    host: {
+        class: 'layout-column layout-gap-l'
+    }
 })
 export class FileUploadIndeterminateLoadingOverviewExample {
     isLoading: boolean;

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-accept-validation/file-upload-multiple-accept-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-accept-validation/file-upload-multiple-accept-validation-example.ts
@@ -23,7 +23,7 @@ import { KbqIconModule } from '@koobiq/components/icon';
                 }
             </ng-template>
 
-            <kbq-hint>Files with .txt extension are allowed</kbq-hint>
+            <kbq-hint>Files with TXT extension are allowed</kbq-hint>
 
             @for (control of fileList.controls; track $index) {
                 <kbq-hint color="error">

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-mixed-validation/file-upload-multiple-mixed-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-mixed-validation/file-upload-multiple-mixed-validation-example.ts
@@ -1,0 +1,96 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { KbqButtonModule } from '@koobiq/components/button';
+import { FileValidators, KbqFileTypeSpecifier, ShowOnFormSubmitErrorStateMatcher } from '@koobiq/components/core';
+import { KbqFileItem, KbqFileUploadModule } from '@koobiq/components/file-upload';
+import { KbqFormFieldModule } from '@koobiq/components/form-field';
+import { KbqIconModule } from '@koobiq/components/icon';
+
+/**
+ * @title File upload multiple mixed validation example
+ */
+@Component({
+    standalone: true,
+    selector: 'file-upload-multiple-mixed-validation-example',
+    template: `
+        <form [formGroup]="formMultiple">
+            <kbq-file-upload
+                #kbqFileUpload
+                class="layout-margin-bottom-s"
+                multiple
+                formControlName="fileUpload"
+                [errorStateMatcher]="customErrorStateMatcher"
+                [progressMode]="'indeterminate'"
+                (fileRemoved)="onFileRemoved($event)"
+                (filesAdded)="onFilesAdded($event)"
+            >
+                <ng-template #kbqFileIcon>
+                    <i kbq-icon="kbq-file-o_16"></i>
+                </ng-template>
+                @if (kbqFileUpload.invalid && formMultiple.controls.fileUpload.hasError('required')) {
+                    <kbq-hint color="error">File required</kbq-hint>
+                }
+                <kbq-hint>Files with .txt extension are allowed</kbq-hint>
+
+                @for (control of fileList.controls; track $index) {
+                    <kbq-hint color="error">
+                        @if (control.hasError('fileExtensionMismatch')) {
+                            {{ control.value?.file?.name }} - {{ fileExtensionMismatchErrorMessage }}
+                        }
+                    </kbq-hint>
+                }
+            </kbq-file-upload>
+            <button class="layout-margin-top-m" kbq-button type="submit">Submit</button>
+        </form>
+    `,
+    imports: [
+        ReactiveFormsModule,
+        KbqFileUploadModule,
+        KbqFormFieldModule,
+        KbqButtonModule,
+        KbqIconModule
+    ],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FileUploadMultipleMixedValidationExample {
+    protected readonly customErrorStateMatcher = new ShowOnFormSubmitErrorStateMatcher();
+    protected accept: KbqFileTypeSpecifier = ['.txt'];
+    protected fileExtensionMismatchErrorMessage = 'Provide valid extension';
+    protected cdr = inject(ChangeDetectorRef);
+
+    formMultiple = new FormGroup({
+        fileUpload: new FormControl<FileList | KbqFileItem[]>([], Validators.required),
+        fileList: new FormArray<FormControl<KbqFileItem | null>>([], Validators.required)
+    });
+
+    get fileList() {
+        return this.formMultiple.controls.fileList;
+    }
+
+    constructor() {
+        this.fileList.statusChanges.pipe(takeUntilDestroyed()).subscribe(() => {
+            this.fileList.controls.forEach((control) => {
+                if (control?.value && 'hasError' in control.value) {
+                    control.value.hasError = control.invalid;
+                }
+            });
+        });
+    }
+
+    onFileRemoved([
+        _,
+        index
+    ]: [
+        KbqFileItem,
+        number
+    ]): void {
+        this.fileList.removeAt(index);
+    }
+
+    onFilesAdded($event: KbqFileItem[]): void {
+        for (const fileItem of $event.slice()) {
+            this.fileList.push(new FormControl(fileItem, FileValidators.isCorrectExtension(this.accept)));
+        }
+    }
+}

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-mixed-validation/file-upload-multiple-mixed-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-mixed-validation/file-upload-multiple-mixed-validation-example.ts
@@ -55,16 +55,16 @@ import { KbqIconModule } from '@koobiq/components/icon';
 })
 export class FileUploadMultipleMixedValidationExample {
     protected readonly customErrorStateMatcher = new ShowOnFormSubmitErrorStateMatcher();
-    protected accept: KbqFileTypeSpecifier = ['.txt'];
-    protected fileExtensionMismatchErrorMessage = 'Provide valid extension';
-    protected cdr = inject(ChangeDetectorRef);
+    protected readonly accept: KbqFileTypeSpecifier = ['.txt'];
+    protected readonly fileExtensionMismatchErrorMessage = 'Provide valid extension';
+    protected readonly cdr = inject(ChangeDetectorRef);
 
-    formMultiple = new FormGroup({
+    protected readonly formMultiple = new FormGroup({
         fileUpload: new FormControl<FileList | KbqFileItem[]>([], Validators.required),
         fileList: new FormArray<FormControl<KbqFileItem | null>>([], Validators.required)
     });
 
-    get fileList() {
+    protected get fileList() {
         return this.formMultiple.controls.fileList;
     }
 

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-mixed-validation/file-upload-multiple-mixed-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-mixed-validation/file-upload-multiple-mixed-validation-example.ts
@@ -28,10 +28,10 @@ import { KbqIconModule } from '@koobiq/components/icon';
                 <ng-template #kbqFileIcon>
                     <i kbq-icon="kbq-file-o_16"></i>
                 </ng-template>
+
                 @if (kbqFileUpload.invalid && formMultiple.controls.fileUpload.hasError('required')) {
                     <kbq-hint color="error">File required</kbq-hint>
                 }
-                <kbq-hint>Files with .txt extension are allowed</kbq-hint>
 
                 @for (control of fileList.controls; track $index) {
                     <kbq-hint color="error">
@@ -40,6 +40,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
                         }
                     </kbq-hint>
                 }
+
+                <kbq-hint>Files with TXT extension are allowed</kbq-hint>
             </kbq-file-upload>
             <button class="layout-margin-top-m" kbq-button type="submit">Submit</button>
         </form>

--- a/packages/docs-examples/components/file-upload/file-upload-multiple-required-reactive-validation/file-upload-multiple-required-reactive-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-multiple-required-reactive-validation/file-upload-multiple-required-reactive-validation-example.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { KbqButtonModule } from '@koobiq/components/button';
-import { kbqErrorStateMatcherProvider, ShowOnFormSubmitErrorStateMatcher } from '@koobiq/components/core';
+import { ShowOnFormSubmitErrorStateMatcher } from '@koobiq/components/core';
 import { KbqFileItem, KbqFileUploadModule } from '@koobiq/components/file-upload';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
 import { KbqIconModule } from '@koobiq/components/icon';
 
 /**
- * @title File Upload Multiple Required Reactive Validation Example
+ * @title File upload multiple required reactive validation example
  */
 @Component({
     standalone: true,
@@ -19,12 +19,13 @@ import { KbqIconModule } from '@koobiq/components/icon';
                 class="layout-margin-bottom-s"
                 formControlName="fileUpload"
                 multiple
+                [errorStateMatcher]="customErrorStateMatcher"
                 [progressMode]="'indeterminate'"
             >
                 <ng-template #kbqFileIcon>
                     <i kbq-icon="kbq-file-o_16"></i>
                 </ng-template>
-                @if (kbqFileUpload.invalid) {
+                @if (kbqFileUpload.invalid && formMultiple.controls.fileUpload.hasError('required')) {
                     <kbq-hint color="error">File required</kbq-hint>
                 }
             </kbq-file-upload>
@@ -38,16 +39,14 @@ import { KbqIconModule } from '@koobiq/components/icon';
         KbqButtonModule,
         KbqIconModule
     ],
-    providers: [kbqErrorStateMatcherProvider(ShowOnFormSubmitErrorStateMatcher)],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileUploadMultipleRequiredReactiveValidationExample {
-    formMultiple = new FormGroup(
-        {
-            fileUpload: new FormControl<FileList | KbqFileItem[]>([], Validators.required)
-        },
-        { updateOn: 'submit' }
-    );
+    protected readonly customErrorStateMatcher = new ShowOnFormSubmitErrorStateMatcher();
+
+    protected readonly formMultiple = new FormGroup({
+        fileUpload: new FormControl<FileList | KbqFileItem[]>([], Validators.required)
+    });
 
     onSubmit() {
         console.log('perform action on submit');

--- a/packages/docs-examples/components/file-upload/file-upload-single-accept-validation/file-upload-single-accept-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-accept-validation/file-upload-single-accept-validation-example.ts
@@ -22,11 +22,11 @@ import { KbqIconModule } from '@koobiq/components/icon';
                     <i kbq-icon="kbq-exclamation-triangle_16"></i>
                 }
 
-                <kbq-hint>File with .txt extension is allowed</kbq-hint>
-
                 @if (formGroup.get('fileControl')?.hasError('fileExtensionMismatch')) {
                     <kbq-hint color="error">Provide valid extension</kbq-hint>
                 }
+
+                <kbq-hint>File with TXT extension is allowed</kbq-hint>
             </kbq-file-upload>
         </form>
     `,

--- a/packages/docs-examples/components/file-upload/file-upload-single-mixed-validation/file-upload-single-mixed-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-mixed-validation/file-upload-single-mixed-validation-example.ts
@@ -23,8 +23,6 @@ import { KbqIconModule } from '@koobiq/components/icon';
             >
                 <i kbq-icon="kbq-file-o_16"></i>
 
-                <kbq-hint>Files with .txt extension are allowed</kbq-hint>
-
                 @if (kbqFileUpload.invalid && form.controls.fileUpload.hasError('required')) {
                     <kbq-hint color="error">File required</kbq-hint>
                 }
@@ -32,6 +30,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
                 @if (form.controls.fileUpload.hasError('fileExtensionMismatch')) {
                     <kbq-hint color="error">Provide valid extension</kbq-hint>
                 }
+
+                <kbq-hint>Files with TXT extension are allowed</kbq-hint>
             </kbq-file-upload>
             <button class="layout-margin-top-m" kbq-button type="submit">Submit</button>
         </form>

--- a/packages/docs-examples/components/file-upload/file-upload-single-mixed-validation/file-upload-single-mixed-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-mixed-validation/file-upload-single-mixed-validation-example.ts
@@ -46,17 +46,17 @@ import { KbqIconModule } from '@koobiq/components/icon';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileUploadSingleMixedValidationExample {
-    protected customErrorStateMatcher = new ShowOnFormSubmitErrorStateMatcher();
-    protected accept: KbqFileTypeSpecifier = ['.txt'];
+    protected readonly customErrorStateMatcher = new ShowOnFormSubmitErrorStateMatcher();
+    protected readonly accept: KbqFileTypeSpecifier = ['.txt'];
 
-    form = new FormGroup({
+    protected readonly form = new FormGroup({
         fileUpload: new FormControl<KbqFileItem | null>(null, [
             Validators.required,
             FileValidators.isCorrectExtension(['.txt'])
         ])
     });
 
-    onSubmit() {
+    onSubmit(): void {
         console.log('perform action on submit');
     }
 }

--- a/packages/docs-examples/components/file-upload/file-upload-single-mixed-validation/file-upload-single-mixed-validation-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-mixed-validation/file-upload-single-mixed-validation-example.ts
@@ -1,17 +1,17 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { KbqButtonModule } from '@koobiq/components/button';
-import { ShowOnFormSubmitErrorStateMatcher } from '@koobiq/components/core';
+import { FileValidators, KbqFileTypeSpecifier, ShowOnFormSubmitErrorStateMatcher } from '@koobiq/components/core';
 import { KbqFileItem, KbqFileUploadModule } from '@koobiq/components/file-upload';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
 import { KbqIconModule } from '@koobiq/components/icon';
 
 /**
- * @title File upload single required reactive validation example
+ * @title File upload single mixed validation example
  */
 @Component({
     standalone: true,
-    selector: 'file-upload-single-required-reactive-validation-example',
+    selector: 'file-upload-single-mixed-validation-example',
     template: `
         <form [formGroup]="form" (ngSubmit)="onSubmit()">
             <kbq-file-upload
@@ -23,8 +23,14 @@ import { KbqIconModule } from '@koobiq/components/icon';
             >
                 <i kbq-icon="kbq-file-o_16"></i>
 
+                <kbq-hint>Files with .txt extension are allowed</kbq-hint>
+
                 @if (kbqFileUpload.invalid && form.controls.fileUpload.hasError('required')) {
                     <kbq-hint color="error">File required</kbq-hint>
+                }
+
+                @if (form.controls.fileUpload.hasError('fileExtensionMismatch')) {
+                    <kbq-hint color="error">Provide valid extension</kbq-hint>
                 }
             </kbq-file-upload>
             <button class="layout-margin-top-m" kbq-button type="submit">Submit</button>
@@ -39,11 +45,15 @@ import { KbqIconModule } from '@koobiq/components/icon';
     ],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FileUploadSingleRequiredReactiveValidationExample {
-    protected readonly customErrorStateMatcher = new ShowOnFormSubmitErrorStateMatcher();
+export class FileUploadSingleMixedValidationExample {
+    protected customErrorStateMatcher = new ShowOnFormSubmitErrorStateMatcher();
+    protected accept: KbqFileTypeSpecifier = ['.txt'];
 
-    protected readonly form = new FormGroup({
-        fileUpload: new FormControl<KbqFileItem | null>(null, Validators.required)
+    form = new FormGroup({
+        fileUpload: new FormControl<KbqFileItem | null>(null, [
+            Validators.required,
+            FileValidators.isCorrectExtension(['.txt'])
+        ])
     });
 
     onSubmit() {

--- a/packages/docs-examples/components/file-upload/file-upload-single-validation-reactive-forms-overview/file-upload-single-validation-reactive-forms-overview-example.ts
+++ b/packages/docs-examples/components/file-upload/file-upload-single-validation-reactive-forms-overview/file-upload-single-validation-reactive-forms-overview-example.ts
@@ -24,11 +24,11 @@ const MAX_FILE_SIZE = 5 * 2 ** 20;
                     <i kbq-icon="kbq-exclamation-triangle_16"></i>
                 }
 
-                <kbq-hint>The file size should not exceed 5 MB</kbq-hint>
-
                 @if (formGroup.get('fileControl')?.hasError('maxFileSize')) {
                     <kbq-hint color="error">The file size must not exceed the limit</kbq-hint>
                 }
+
+                <kbq-hint>The file size should not exceed 5 MB</kbq-hint>
             </kbq-file-upload>
         </form>
     `,

--- a/packages/docs-examples/components/file-upload/index.ts
+++ b/packages/docs-examples/components/file-upload/index.ts
@@ -8,9 +8,11 @@ import { FileUploadMultipleCustomTextOverviewExample } from './file-upload-multi
 import { FileUploadMultipleDefaultOverviewExample } from './file-upload-multiple-default-overview/file-upload-multiple-default-overview-example';
 import { FileUploadMultipleDefaultValidationReactiveFormsOverviewExample } from './file-upload-multiple-default-validation-reactive-forms-overview/file-upload-multiple-default-validation-reactive-forms-overview-example';
 import { FileUploadMultipleErrorOverviewExample } from './file-upload-multiple-error-overview/file-upload-multiple-error-overview-example';
+import { FileUploadMultipleMixedValidationExample } from './file-upload-multiple-mixed-validation/file-upload-multiple-mixed-validation-example';
 import { FileUploadMultipleRequiredReactiveValidationExample } from './file-upload-multiple-required-reactive-validation/file-upload-multiple-required-reactive-validation-example';
 import { FileUploadSingleAcceptValidationExample } from './file-upload-single-accept-validation/file-upload-single-accept-validation-example';
 import { FileUploadSingleErrorOverviewExample } from './file-upload-single-error-overview/file-upload-single-error-overview-example';
+import { FileUploadSingleMixedValidationExample } from './file-upload-single-mixed-validation/file-upload-single-mixed-validation-example';
 import { FileUploadSingleOverviewExample } from './file-upload-single-overview/file-upload-single-overview-example';
 import { FileUploadSingleRequiredReactiveValidationExample } from './file-upload-single-required-reactive-validation/file-upload-single-required-reactive-validation-example';
 import { FileUploadSingleValidationReactiveFormsOverviewExample } from './file-upload-single-validation-reactive-forms-overview/file-upload-single-validation-reactive-forms-overview-example';
@@ -26,9 +28,11 @@ export {
     FileUploadMultipleDefaultOverviewExample,
     FileUploadMultipleDefaultValidationReactiveFormsOverviewExample,
     FileUploadMultipleErrorOverviewExample,
+    FileUploadMultipleMixedValidationExample,
     FileUploadMultipleRequiredReactiveValidationExample,
     FileUploadSingleAcceptValidationExample,
     FileUploadSingleErrorOverviewExample,
+    FileUploadSingleMixedValidationExample,
     FileUploadSingleOverviewExample,
     FileUploadSingleRequiredReactiveValidationExample,
     FileUploadSingleValidationReactiveFormsOverviewExample,
@@ -51,7 +55,9 @@ const EXAMPLES = [
     FileUploadMultipleRequiredReactiveValidationExample,
     FileUploadSingleWithSignalExample,
     FileUploadSingleAcceptValidationExample,
-    FileUploadMultipleAcceptValidationExample
+    FileUploadMultipleAcceptValidationExample,
+    FileUploadSingleMixedValidationExample,
+    FileUploadMultipleMixedValidationExample
 ];
 
 @NgModule({


### PR DESCRIPTION
Поправил примеры в соответствии с комментариями:
- сузил использование ErrorStateMatcher внутри FileUpload через инпут-свойство вместо провайдинга с помощью InjectionToken
- Добавил пример совместной валидации на обязательность и по расширению файла 