### PR TITLE
fix(docs): destroy examples before fetching new document (#DS-4159)

### DIFF
--- a/apps/docs/src/app/components/example-viewer/example-viewer.ts
+++ b/apps/docs/src/app/components/example-viewer/example-viewer.ts
@@ -62,6 +62,7 @@ export class DocsExampleViewerComponent implements OnDestroy {
             return;
         }
 
+        this.clearLiveExamples();
         this.fetchDocument(url);
     }
 

--- a/apps/docs/src/app/components/live-example/docs-live-example.ts
+++ b/apps/docs/src/app/components/live-example/docs-live-example.ts
@@ -67,6 +67,7 @@ export class DocsLiveExampleComponent extends DocsLocaleState implements OnDestr
             return;
         }
 
+        this.clearLiveExamples();
         this.getDocument(url);
     }
 


### PR DESCRIPTION
при переходе на новую страницу не происходит "destroy" компонента-примера