### PR TITLE
fix: e2e workflow checkout ref (#DS-4070)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Setup yarn
         uses: ./.github/workflows/actions/setup-yarn


### PR DESCRIPTION
необходимо указать ref ветки [для которой был вызван воркфлоу](https://github.com/koobiq/angular-components/blob/ebea8a6a2ce72cd55482cef64a2323e264568cc2/.github/workflows/e2e.yml#L10) - 'E2E update screenshots'