### PR TITLE
fix(markdown): сhanged default bg to transparent (#DS-3909)

### DIFF
--- a/packages/components/markdown/_markdown-theme.scss
+++ b/packages/components/markdown/_markdown-theme.scss
@@ -7,10 +7,6 @@
         color: var(--kbq-foreground-contrast);
         background: var(--kbq-markdown-bg);
 
-        &.kbq-markdown_transparent {
-            --kbq-markdown-bg: transparent;
-        }
-
         // h1, h2, h3, h4, h5, h6
         @for $i from 1 through 6 {
             .kbq-markdown__h#{$i} {

--- a/packages/components/markdown/_markdown-theme.scss
+++ b/packages/components/markdown/_markdown-theme.scss
@@ -5,7 +5,11 @@
 @mixin kbq-markdown-theme() {
     .kbq-markdown {
         color: var(--kbq-foreground-contrast);
-        background: var(--kbq-background-bg);
+        background: var(--kbq-markdown-bg);
+
+        &.kbq-markdown_transparent {
+            --kbq-markdown-bg: transparent;
+        }
 
         // h1, h2, h3, h4, h5, h6
         @for $i from 1 through 6 {

--- a/packages/components/markdown/markdown-tokens.scss
+++ b/packages/components/markdown/markdown-tokens.scss
@@ -1,5 +1,5 @@
 .kbq-markdown {
-    --kbq-markdown-bg: var(--kbq-background-bg);
+    --kbq-markdown-bg: transparent;
     --kbq-markdown-h1-size-max-width: var(--kbq-markdown-size-max-width);
     --kbq-markdown-h1-size-margin-top: 0;
     --kbq-markdown-h1-size-margin-bottom: var(--kbq-size-l);

--- a/packages/components/markdown/markdown-tokens.scss
+++ b/packages/components/markdown/markdown-tokens.scss
@@ -1,4 +1,5 @@
 .kbq-markdown {
+    --kbq-markdown-bg: var(--kbq-background-bg);
     --kbq-markdown-h1-size-max-width: var(--kbq-markdown-size-max-width);
     --kbq-markdown-h1-size-margin-top: 0;
     --kbq-markdown-h1-size-margin-bottom: var(--kbq-size-l);

--- a/packages/components/markdown/markdown.component.ts
+++ b/packages/components/markdown/markdown.component.ts
@@ -1,5 +1,6 @@
 import {
     afterNextRender,
+    booleanAttribute,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -36,13 +37,17 @@ export const kbqMarkdownMarkedOptionsProvider = (options: MarkedOptions): Provid
         <div class="markdown-output" [innerHtml]="resultHtml"></div>
     `,
     host: {
-        class: 'kbq-markdown'
+        class: 'kbq-markdown',
+        '[class.kbq-markdown_transparent]': 'transparent'
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
 export class KbqMarkdown {
     @ViewChild('contentWrapper', { static: true }) private readonly contentWrapper: ElementRef;
+
+    /** Whether to override default background with transparent. */
+    @Input({ transform: booleanAttribute }) transparent: boolean = false;
 
     /** `Markdown` text. */
     @Input()

--- a/packages/components/markdown/markdown.component.ts
+++ b/packages/components/markdown/markdown.component.ts
@@ -1,6 +1,5 @@
 import {
     afterNextRender,
-    booleanAttribute,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -37,17 +36,13 @@ export const kbqMarkdownMarkedOptionsProvider = (options: MarkedOptions): Provid
         <div class="markdown-output" [innerHtml]="resultHtml"></div>
     `,
     host: {
-        class: 'kbq-markdown',
-        '[class.kbq-markdown_transparent]': 'transparent'
+        class: 'kbq-markdown'
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
 export class KbqMarkdown {
     @ViewChild('contentWrapper', { static: true }) private readonly contentWrapper: ElementRef;
-
-    /** Whether to override default background with transparent. */
-    @Input({ transform: booleanAttribute }) transparent: boolean = false;
 
     /** `Markdown` text. */
     @Input()


### PR DESCRIPTION
## Summary

Set markdown default background as transparent.