### PR TITLE
feat(inline-edit): aligned focus order (#DS-4210)

### DIFF
--- a/packages/components/inline-edit/inline-edit.html
+++ b/packages/components/inline-edit/inline-edit.html
@@ -1,69 +1,75 @@
-<div #focusRegion class="kbq-inline-edit__view-focus-region" tabindex="0" [cdkTrapFocus]="false">
-    @if (label()) {
-        <div class="kbq-inline-edit__label">
-            <ng-content select="kbq-label" />
+@if (label()) {
+    <div class="kbq-inline-edit__label">
+        <ng-content select="kbq-label" />
+    </div>
+}
+
+<div class="kbq-inline-edit__view-container">
+    <ng-content select="[kbqInlineEditViewMode]" />
+
+    <div
+        class="kbq-inline-edit__focus_container"
+        style=""
+        cdkMonitorElementFocus
+        [tabIndex]="tabIndex()"
+        (keydown.enter)="onClick($event)"
+    ></div>
+
+    @if (menu() && mode() === 'view') {
+        <div class="kbq-inline-edit__menu-mask kbq-mask">
+            <div class="kbq-inline-edit__menu-mask-fade kbq-mask__fade"></div>
+            <div class="kbq-inline-edit__menu-mask-container kbq-mask__container">
+                <ng-content select="[kbqInlineEditMenu]" />
+            </div>
         </div>
     }
 
-    <div class="kbq-inline-edit__view-container">
-        <ng-content select="[kbqInlineEditViewMode]" />
+    @if (mode() === 'edit') {
+        <div #overlayOrigin cdkOverlayOrigin class="kbq-inline-edit__overlay-origin"></div>
 
-        @if (menu() && mode() === 'view') {
-            <div class="kbq-inline-edit__menu-mask kbq-mask">
-                <div class="kbq-inline-edit__menu-mask-fade kbq-mask__fade"></div>
-                <div class="kbq-inline-edit__menu-mask-container kbq-mask__container">
-                    <ng-content select="[kbqInlineEditMenu]" />
+        <ng-template
+            cdkConnectedOverlay
+            cdkConnectedOverlayLockPosition
+            [cdkConnectedOverlayOpen]="isEditMode()"
+            [cdkConnectedOverlayOrigin]="overlayOrigin"
+            [cdkConnectedOverlayWidth]="overlayWidth()"
+            [cdkConnectedOverlayDisableClose]="true"
+            [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
+            [cdkConnectedOverlayHasBackdrop]="false"
+            (attach)="onAttach()"
+            (overlayOutsideClick)="save($event)"
+            (overlayKeydown)="onOverlayKeydown($event)"
+        >
+            <div #focusTrapInstance="cdkTrapFocus" class="kbq-inline-edit__panel" cdkTrapFocus>
+                <div
+                    class="kbq-inline-edit__control-container"
+                    kbqFocusRegionItem
+                    [kbqTooltipColor]="colors.Error"
+                    [kbqTooltip]="validationTooltip() ?? ''"
+                    [kbqTooltipArrow]="false"
+                    [kbqTrigger]="'manual'"
+                    [kbqPlacement]="tooltipPlacement() ?? placements.TopLeft"
+                >
+                    <ng-content select="[kbqInlineEditEditMode]" />
                 </div>
-            </div>
-        }
 
-        @if (mode() === 'edit') {
-            <div #overlayOrigin cdkOverlayOrigin class="kbq-inline-edit__overlay-origin"></div>
-
-            <ng-template
-                cdkConnectedOverlay
-                cdkConnectedOverlayLockPosition
-                [cdkConnectedOverlayOpen]="isEditMode()"
-                [cdkConnectedOverlayOrigin]="overlayOrigin"
-                [cdkConnectedOverlayWidth]="overlayWidth()"
-                [cdkConnectedOverlayDisableClose]="true"
-                [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
-                [cdkConnectedOverlayHasBackdrop]="false"
-                (attach)="onAttach()"
-                (overlayOutsideClick)="save($event)"
-                (overlayKeydown)="onOverlayKeydown($event)"
-            >
-                <div #focusTrapInstance="cdkTrapFocus" class="kbq-inline-edit__panel" cdkTrapFocus>
-                    <div
-                        class="kbq-inline-edit__control-container"
-                        kbqFocusRegionItem
-                        [kbqTooltipColor]="colors.Error"
-                        [kbqTooltip]="validationTooltip() ?? ''"
-                        [kbqTooltipArrow]="false"
-                        [kbqTrigger]="'manual'"
-                        [kbqPlacement]="tooltipPlacement() ?? placements.TopLeft"
-                    >
-                        <ng-content select="[kbqInlineEditEditMode]" />
+                @if (showActions()) {
+                    <div class="kbq-inline-edit__action-buttons" role="group" [@panelAnimation]>
+                        <button kbq-button [color]="'contrast'" (click)="save($event)">
+                            <i kbq-icon="kbq-check_16"></i>
+                        </button>
+                        <button
+                            kbqFocusRegionItem
+                            kbq-button
+                            [color]="'contrast-fade'"
+                            (click)="cancel()"
+                            (keydown.enter)="cancel()"
+                        >
+                            <i kbq-icon="kbq-xmark_16"></i>
+                        </button>
                     </div>
-
-                    @if (showActions()) {
-                        <div class="kbq-inline-edit__action-buttons" role="group" [@panelAnimation]>
-                            <button kbq-button [color]="'contrast'" (click)="save($event)">
-                                <i kbq-icon="kbq-check_16"></i>
-                            </button>
-                            <button
-                                kbqFocusRegionItem
-                                kbq-button
-                                [color]="'contrast-fade'"
-                                (click)="cancel()"
-                                (keydown.enter)="cancel()"
-                            >
-                                <i kbq-icon="kbq-xmark_16"></i>
-                            </button>
-                        </div>
-                    }
-                </div>
-            </ng-template>
-        }
-    </div>
+                }
+            </div>
+        </ng-template>
+    }
 </div>

--- a/packages/components/inline-edit/inline-edit.html
+++ b/packages/components/inline-edit/inline-edit.html
@@ -1,67 +1,76 @@
-@if (label()) {
-    <div class="kbq-inline-edit__label">
-        <ng-content select="kbq-label" />
-    </div>
-}
-
-<div class="kbq-inline-edit__view-container">
-    <ng-content select="[kbqInlineEditViewMode]" />
-
-    @if (menu() && mode() === 'view') {
-        <div class="kbq-inline-edit__menu-mask kbq-mask">
-            <div class="kbq-inline-edit__menu-mask-fade kbq-mask__fade"></div>
-            <div class="kbq-inline-edit__menu-mask-container kbq-mask__container">
-                <ng-content select="[kbqInlineEditMenu]" />
-            </div>
+<div
+    #element
+    #focusTrap="cdkTrapFocus"
+    class="kbq-inline-edit__view-focus-region"
+    tabindex="0"
+    [cdkTrapFocus]="false"
+    (focus)="afterFocus($event, focusTrap)"
+>
+    @if (label()) {
+        <div class="kbq-inline-edit__label">
+            <ng-content select="kbq-label" />
         </div>
     }
 
-    @if (mode() === 'edit') {
-        <div #overlayOrigin cdkOverlayOrigin class="kbq-inline-edit__overlay-origin"></div>
+    <div class="kbq-inline-edit__view-container">
+        <ng-content select="[kbqInlineEditViewMode]" />
 
-        <ng-template
-            cdkConnectedOverlay
-            cdkConnectedOverlayLockPosition
-            [cdkConnectedOverlayOpen]="isEditMode()"
-            [cdkConnectedOverlayOrigin]="overlayOrigin"
-            [cdkConnectedOverlayWidth]="overlayWidth()"
-            [cdkConnectedOverlayDisableClose]="true"
-            [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
-            [cdkConnectedOverlayHasBackdrop]="false"
-            (attach)="onAttach()"
-            (overlayOutsideClick)="save($event)"
-            (overlayKeydown)="onOverlayKeydown($event)"
-        >
-            <div class="kbq-inline-edit__panel" cdkTrapFocus cdkTrapFocusAutoCapture>
-                <div
-                    class="kbq-inline-edit__control-container"
-                    kbqFocusRegionItem
-                    [kbqTooltipColor]="colors.Error"
-                    [kbqTooltip]="validationTooltip() ?? ''"
-                    [kbqTooltipArrow]="false"
-                    [kbqTrigger]="'manual'"
-                    [kbqPlacement]="tooltipPlacement() ?? placements.TopLeft"
-                >
-                    <ng-content select="[kbqInlineEditEditMode]" />
+        @if (menu() && mode() === 'view') {
+            <div class="kbq-inline-edit__menu-mask kbq-mask">
+                <div class="kbq-inline-edit__menu-mask-fade kbq-mask__fade"></div>
+                <div class="kbq-inline-edit__menu-mask-container kbq-mask__container">
+                    <ng-content select="[kbqInlineEditMenu]" />
                 </div>
-
-                @if (showActions()) {
-                    <div class="kbq-inline-edit__action-buttons" role="group" [@panelAnimation]>
-                        <button kbq-button [color]="'contrast'" (click)="save($event)">
-                            <i kbq-icon="kbq-check_16"></i>
-                        </button>
-                        <button
-                            kbqFocusRegionItem
-                            kbq-button
-                            [color]="'contrast-fade'"
-                            (click)="cancel()"
-                            (keydown.enter)="cancel()"
-                        >
-                            <i kbq-icon="kbq-xmark_16"></i>
-                        </button>
-                    </div>
-                }
             </div>
-        </ng-template>
-    }
+        }
+
+        @if (mode() === 'edit') {
+            <div #overlayOrigin cdkOverlayOrigin class="kbq-inline-edit__overlay-origin"></div>
+
+            <ng-template
+                cdkConnectedOverlay
+                cdkConnectedOverlayLockPosition
+                [cdkConnectedOverlayOpen]="isEditMode()"
+                [cdkConnectedOverlayOrigin]="overlayOrigin"
+                [cdkConnectedOverlayWidth]="overlayWidth()"
+                [cdkConnectedOverlayDisableClose]="true"
+                [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
+                [cdkConnectedOverlayHasBackdrop]="false"
+                (attach)="onAttach()"
+                (overlayOutsideClick)="save($event)"
+                (overlayKeydown)="onOverlayKeydown($event)"
+            >
+                <div class="kbq-inline-edit__panel" cdkTrapFocus cdkTrapFocusAutoCapture>
+                    <div
+                        class="kbq-inline-edit__control-container"
+                        kbqFocusRegionItem
+                        [kbqTooltipColor]="colors.Error"
+                        [kbqTooltip]="validationTooltip() ?? ''"
+                        [kbqTooltipArrow]="false"
+                        [kbqTrigger]="'manual'"
+                        [kbqPlacement]="tooltipPlacement() ?? placements.TopLeft"
+                    >
+                        <ng-content select="[kbqInlineEditEditMode]" />
+                    </div>
+
+                    @if (showActions()) {
+                        <div class="kbq-inline-edit__action-buttons" role="group" [@panelAnimation]>
+                            <button kbq-button [color]="'contrast'" (click)="save($event)">
+                                <i kbq-icon="kbq-check_16"></i>
+                            </button>
+                            <button
+                                kbqFocusRegionItem
+                                kbq-button
+                                [color]="'contrast-fade'"
+                                (click)="cancel()"
+                                (keydown.enter)="cancel()"
+                            >
+                                <i kbq-icon="kbq-xmark_16"></i>
+                            </button>
+                        </div>
+                    }
+                </div>
+            </ng-template>
+        }
+    </div>
 </div>

--- a/packages/components/inline-edit/inline-edit.html
+++ b/packages/components/inline-edit/inline-edit.html
@@ -39,7 +39,7 @@
         (overlayOutsideClick)="save($event)"
         (overlayKeydown)="onOverlayKeydown($event)"
     >
-        <div #focusTrapInstance="cdkTrapFocus" class="kbq-inline-edit__panel" cdkTrapFocus cdkTrapFocusAutoCapture>
+        <div class="kbq-inline-edit__panel" cdkTrapFocus cdkTrapFocusAutoCapture>
             <div
                 class="kbq-inline-edit__control-container"
                 kbqFocusRegionItem

--- a/packages/components/inline-edit/inline-edit.html
+++ b/packages/components/inline-edit/inline-edit.html
@@ -8,9 +8,10 @@
     <ng-content select="[kbqInlineEditViewMode]" />
 
     <div
-        class="kbq-inline-edit__focus_container"
-        style=""
+        #overlayOrigin
+        class="kbq-inline-edit__focus_container kbq-inline-edit__overlay-origin"
         cdkMonitorElementFocus
+        cdkOverlayOrigin
         [tabIndex]="tabIndex()"
         (keydown.enter)="onClick($event)"
     ></div>
@@ -24,52 +25,49 @@
         </div>
     }
 
-    @if (mode() === 'edit') {
-        <div #overlayOrigin cdkOverlayOrigin class="kbq-inline-edit__overlay-origin"></div>
-
-        <ng-template
-            cdkConnectedOverlay
-            cdkConnectedOverlayLockPosition
-            [cdkConnectedOverlayOpen]="isEditMode()"
-            [cdkConnectedOverlayOrigin]="overlayOrigin"
-            [cdkConnectedOverlayWidth]="overlayWidth()"
-            [cdkConnectedOverlayDisableClose]="true"
-            [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
-            [cdkConnectedOverlayHasBackdrop]="false"
-            (attach)="onAttach()"
-            (overlayOutsideClick)="save($event)"
-            (overlayKeydown)="onOverlayKeydown($event)"
-        >
-            <div #focusTrapInstance="cdkTrapFocus" class="kbq-inline-edit__panel" cdkTrapFocus>
-                <div
-                    class="kbq-inline-edit__control-container"
-                    kbqFocusRegionItem
-                    [kbqTooltipColor]="colors.Error"
-                    [kbqTooltip]="validationTooltip() ?? ''"
-                    [kbqTooltipArrow]="false"
-                    [kbqTrigger]="'manual'"
-                    [kbqPlacement]="tooltipPlacement() ?? placements.TopLeft"
-                >
-                    <ng-content select="[kbqInlineEditEditMode]" />
-                </div>
-
-                @if (showActions()) {
-                    <div class="kbq-inline-edit__action-buttons" role="group" [@panelAnimation]>
-                        <button kbq-button [color]="'contrast'" (click)="save($event)">
-                            <i kbq-icon="kbq-check_16"></i>
-                        </button>
-                        <button
-                            kbqFocusRegionItem
-                            kbq-button
-                            [color]="'contrast-fade'"
-                            (click)="cancel()"
-                            (keydown.enter)="cancel()"
-                        >
-                            <i kbq-icon="kbq-xmark_16"></i>
-                        </button>
-                    </div>
-                }
+    <ng-template
+        cdkConnectedOverlay
+        cdkConnectedOverlayLockPosition
+        [cdkConnectedOverlayOpen]="isEditMode()"
+        [cdkConnectedOverlayOrigin]="overlayOrigin"
+        [cdkConnectedOverlayOffsetY]="-overlayOrigin.offsetHeight"
+        [cdkConnectedOverlayWidth]="overlayWidth()"
+        [cdkConnectedOverlayDisableClose]="true"
+        [cdkConnectedOverlayScrollStrategy]="scrollStrategy()"
+        [cdkConnectedOverlayHasBackdrop]="false"
+        (attach)="onAttach()"
+        (overlayOutsideClick)="save($event)"
+        (overlayKeydown)="onOverlayKeydown($event)"
+    >
+        <div #focusTrapInstance="cdkTrapFocus" class="kbq-inline-edit__panel" cdkTrapFocus cdkTrapFocusAutoCapture>
+            <div
+                class="kbq-inline-edit__control-container"
+                kbqFocusRegionItem
+                [kbqTooltipColor]="colors.Error"
+                [kbqTooltip]="validationTooltip() ?? ''"
+                [kbqTooltipArrow]="false"
+                [kbqTrigger]="'manual'"
+                [kbqPlacement]="tooltipPlacement() ?? placements.TopLeft"
+            >
+                <ng-content select="[kbqInlineEditEditMode]" />
             </div>
-        </ng-template>
-    }
+
+            @if (showActions()) {
+                <div class="kbq-inline-edit__action-buttons" role="group" [@panelAnimation]>
+                    <button kbq-button [color]="'contrast'" (click)="save($event)">
+                        <i kbq-icon="kbq-check_16"></i>
+                    </button>
+                    <button
+                        kbqFocusRegionItem
+                        kbq-button
+                        [color]="'contrast-fade'"
+                        (click)="cancel()"
+                        (keydown.enter)="cancel()"
+                    >
+                        <i kbq-icon="kbq-xmark_16"></i>
+                    </button>
+                </div>
+            }
+        </div>
+    </ng-template>
 </div>

--- a/packages/components/inline-edit/inline-edit.html
+++ b/packages/components/inline-edit/inline-edit.html
@@ -1,11 +1,4 @@
-<div
-    #element
-    #focusTrap="cdkTrapFocus"
-    class="kbq-inline-edit__view-focus-region"
-    tabindex="0"
-    [cdkTrapFocus]="false"
-    (focus)="afterFocus($event, focusTrap)"
->
+<div #focusRegion class="kbq-inline-edit__view-focus-region" tabindex="0" [cdkTrapFocus]="false">
     @if (label()) {
         <div class="kbq-inline-edit__label">
             <ng-content select="kbq-label" />
@@ -40,7 +33,7 @@
                 (overlayOutsideClick)="save($event)"
                 (overlayKeydown)="onOverlayKeydown($event)"
             >
-                <div class="kbq-inline-edit__panel" cdkTrapFocus cdkTrapFocusAutoCapture>
+                <div #focusTrapInstance="cdkTrapFocus" class="kbq-inline-edit__panel" cdkTrapFocus>
                     <div
                         class="kbq-inline-edit__control-container"
                         kbqFocusRegionItem

--- a/packages/components/inline-edit/inline-edit.scss
+++ b/packages/components/inline-edit/inline-edit.scss
@@ -39,8 +39,6 @@
 }
 
 @mixin _inline-edit-theme {
-    background: var(--kbq-inline-edit-background);
-
     &.kbq-inline-edit_view {
         &:not(.kbq-inline-edit_disabled) {
             &:hover {
@@ -70,6 +68,9 @@
     }
 
     .kbq-inline-edit__focus_container {
+        background: var(--kbq-inline-edit-background);
+        border-color: var(--kbq-inline-edit-background);
+
         &:focus-visible {
             outline: none;
         }
@@ -136,14 +137,14 @@
 
     @include _mask(
         (
-            'top': calc(-1 * var(--kbq-size-border-width)),
-            'right': calc(-1 * var(--kbq-size-border-width))
+            'top': 0,
+            'right': 0
         )
     );
 
     .kbq-inline-edit__menu-mask {
         opacity: 0;
-        height: calc(100% + 2 * var(--kbq-size-border-width));
+        height: 100%;
         justify-content: flex-end;
         border-top-right-radius: var(--kbq-size-border-radius);
         border-bottom-right-radius: var(--kbq-size-border-radius);
@@ -178,6 +179,8 @@
         height: calc(100% - 2 * var(--kbq-size-border-width));
         border: var(--kbq-size-border-width) solid transparent;
         border-radius: var(--kbq-size-border-radius);
+        // set z-index to hide mask borders
+        z-index: 1;
     }
 }
 

--- a/packages/components/inline-edit/inline-edit.scss
+++ b/packages/components/inline-edit/inline-edit.scss
@@ -168,6 +168,7 @@
             display: inline-flex;
             align-self: flex-start;
             padding: var(--kbq-size-s);
+            z-index: 2;
         }
     }
 

--- a/packages/components/inline-edit/inline-edit.scss
+++ b/packages/components/inline-edit/inline-edit.scss
@@ -41,10 +41,6 @@
 @mixin _inline-edit-theme {
     background: var(--kbq-inline-edit-background);
 
-    &:focus-visible {
-        outline: none;
-    }
-
     &.kbq-inline-edit_view {
         &:not(.kbq-inline-edit_disabled) {
             &:hover {
@@ -67,17 +63,22 @@
                 --kbq-mask-background: var(--kbq-background-bg);
             }
         }
+    }
+
+    .kbq-label {
+        color: var(--kbq-inline-edit-label-color);
+    }
+
+    .kbq-inline-edit__focus_container {
+        &:focus-visible {
+            outline: none;
+        }
 
         &.cdk-keyboard-focused {
             $focused-color: var(--kbq-states-line-focus-theme);
             outline: 1px solid $focused-color;
             border-color: $focused-color;
-            overflow: hidden;
         }
-    }
-
-    .kbq-label {
-        color: var(--kbq-inline-edit-label-color);
     }
 }
 
@@ -89,7 +90,6 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    border: var(--kbq-size-border-width) solid transparent;
     border-radius: var(--kbq-size-border-radius);
     padding: var(--kbq-inline-edit-padding-vertical) var(--kbq-inline-edit-padding-horizontal);
     box-sizing: border-box;
@@ -126,6 +126,13 @@
 
         .kbq-inline-edit__view-container {
             text-overflow: ellipsis;
+        }
+    }
+
+    &:hover,
+    &.cdk-keyboard-focused {
+        .kbq-inline-edit__menu-mask {
+            opacity: 1;
         }
     }
 
@@ -169,11 +176,14 @@
         }
     }
 
-    &:hover,
-    &.cdk-keyboard-focused {
-        .kbq-inline-edit__menu-mask {
-            opacity: 1;
-        }
+    .kbq-inline-edit__focus_container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border: var(--kbq-size-border-width) solid transparent;
+        border-radius: var(--kbq-size-border-radius);
     }
 
     .kbq-inline-edit__overlay-origin {

--- a/packages/components/inline-edit/inline-edit.scss
+++ b/packages/components/inline-edit/inline-edit.scss
@@ -92,6 +92,7 @@
     justify-content: center;
     border-radius: var(--kbq-size-border-radius);
     padding: var(--kbq-inline-edit-padding-vertical) var(--kbq-inline-edit-padding-horizontal);
+    min-height: var(--kbq-inline-edit-height);
     box-sizing: border-box;
 
     @include _inline-edit-theme();
@@ -99,11 +100,6 @@
 
     &:not(.kbq-inline-edit_with-label) {
         --kbq-inline-edit-padding-horizontal: calc(var(--kbq-size-m) - var(--kbq-size-border-width));
-
-        .kbq-inline-edit__overlay-origin {
-            top: calc(-1 * var(--kbq-size-border-width));
-            left: calc(-1 * var(--kbq-size-border-width));
-        }
     }
 
     &.kbq-inline-edit_with-label {
@@ -122,8 +118,6 @@
     }
 
     &.kbq-inline-edit_view {
-        min-height: var(--kbq-inline-edit-height);
-
         .kbq-inline-edit__view-container {
             text-overflow: ellipsis;
         }
@@ -180,18 +174,10 @@
         position: absolute;
         top: 0;
         left: 0;
-        width: 100%;
-        height: 100%;
+        width: calc(100% - 2 * var(--kbq-size-border-width));
+        height: calc(100% - 2 * var(--kbq-size-border-width));
         border: var(--kbq-size-border-width) solid transparent;
         border-radius: var(--kbq-size-border-radius);
-    }
-
-    .kbq-inline-edit__overlay-origin {
-        position: absolute;
-        top: 0;
-        left: 0;
-        height: 0;
-        width: 100%;
     }
 }
 

--- a/packages/components/inline-edit/inline-edit.spec.ts
+++ b/packages/components/inline-edit/inline-edit.spec.ts
@@ -30,6 +30,7 @@ const setup = <T>(component: Type<T>, providers: Provider[] = []): ComponentFixt
 
 const componentCssClasses = {
     panel: '.kbq-inline-edit__panel',
+    focusContainer: '.kbq-inline-edit__focus_container',
     terminalButtons: '.kbq-inline-edit__action-buttons',
     menuMask: '.kbq-inline-edit__menu-mask',
     menu: '.kbq-inline-edit__menu',
@@ -45,6 +46,10 @@ const simulateKeyboardFocus = <T>(fixture: ComponentFixture<T>, debugElement: De
 
 const getInlineEditDebugElement = (debugElement: DebugElement): DebugElement => {
     return debugElement.query(By.directive(KbqInlineEdit));
+};
+
+const getInlineEditFocusContainerDebugElement = (debugElement: DebugElement): DebugElement => {
+    return debugElement.query(By.css(componentCssClasses.focusContainer));
 };
 
 const getMaskDebugElement = (debugElement: DebugElement): DebugElement => {
@@ -116,11 +121,11 @@ describe('KbqInlineEdit', () => {
     it('should add css class on keyboard focus', () => {
         const fixture = setup(TestComponent);
         const { debugElement } = fixture;
-        const inlineEditDebugElement: DebugElement = getInlineEditDebugElement(debugElement);
+        const focusContainer: DebugElement = getInlineEditFocusContainerDebugElement(debugElement);
 
-        simulateKeyboardFocus(fixture, inlineEditDebugElement);
+        simulateKeyboardFocus(fixture, focusContainer);
 
-        expect(inlineEditDebugElement.classes['cdk-keyboard-focused']).toBeTruthy();
+        expect(focusContainer.classes['cdk-keyboard-focused']).toBeTruthy();
     });
 
     it('should have terminal buttons when provided', () => {

--- a/packages/components/inline-edit/inline-edit.ts
+++ b/packages/components/inline-edit/inline-edit.ts
@@ -360,7 +360,6 @@ export class KbqInlineEdit {
     private saveAndFocusNextInlineEdit(event: KeyboardEvent): void {
         this.save(event);
         if (this.isInvalid()) return;
-        this.kbqFocusMonitor.focusVia(this.overlayOrigin().elementRef, 'keyboard');
 
         setTimeout(() => {
             const activeElement = this.document.activeElement;

--- a/packages/components/inline-edit/inline-edit.ts
+++ b/packages/components/inline-edit/inline-edit.ts
@@ -112,13 +112,6 @@ export class KbqInlineEditMenu {
     protected readonly dropdownTrigger = inject(KbqDropdownTrigger, { optional: true });
 }
 
-@Directive({
-    standalone: true,
-    selector: '[kbqInlineEditViewModeInteractive]',
-    exportAs: 'kbqInlineEditViewModeInteractive'
-})
-export class KbqInlineEditViewModeInteractive {}
-
 /**
  * Customizable component that enables edit-in-place logic for specified control and it's view.
  * This component is projecting edit/view mode templates and adds keyboard/pointer handlers.
@@ -209,8 +202,6 @@ export class KbqInlineEdit {
     protected readonly overlayDir = viewChild(CdkConnectedOverlay);
     /** @docs-private */
     protected readonly regionItems = viewChildren(KbqFocusRegionItem);
-    /** @docs-private */
-    protected readonly focusTrapInstance = viewChild<CdkTrapFocus>('focusTrapInstance');
 
     /** @docs-private */
     protected readonly mode = signal<'view' | 'edit'>('view');
@@ -253,7 +244,7 @@ export class KbqInlineEdit {
 
         event.preventDefault();
         event.stopPropagation();
-        this.kbqFocusMonitor.focusVia(this.elementRef.nativeElement, 'program');
+        this.kbqFocusMonitor.focusVia(this.overlayOrigin().elementRef, 'program');
 
         this.toggleMode();
     }
@@ -282,10 +273,6 @@ export class KbqInlineEdit {
             const input = this.getInputNativeElement();
 
             if (this.initialValue) input?.select();
-
-            if (!formFieldRef) {
-                this.focusTrapInstance()?.focusTrap.focusFirstTabbableElement();
-            }
 
             if (formFieldRef) {
                 this.openPanel(formFieldRef);
@@ -373,10 +360,7 @@ export class KbqInlineEdit {
     private saveAndFocusNextInlineEdit(event: KeyboardEvent): void {
         this.save(event);
         if (this.isInvalid()) return;
-        this.kbqFocusMonitor.focusVia(
-            this.elementRef.nativeElement.querySelector('.kbq-inline-edit__focus_container') as HTMLElement,
-            'keyboard'
-        );
+        this.kbqFocusMonitor.focusVia(this.overlayOrigin().elementRef, 'keyboard');
 
         setTimeout(() => {
             const activeElement = this.document.activeElement;
@@ -447,7 +431,7 @@ export class KbqInlineEdit {
         }
 
         const elementRef: ElementRef<HTMLElement> | undefined = this.label()
-            ? this.overlayOrigin()?.elementRef
+            ? this.overlayOrigin().elementRef
             : this.elementRef;
 
         this.overlayWidth.set(elementRef?.nativeElement.offsetWidth ?? '');

--- a/packages/components/inline-edit/inline-edit.ts
+++ b/packages/components/inline-edit/inline-edit.ts
@@ -202,9 +202,9 @@ export class KbqInlineEdit {
     protected readonly formFieldRef = contentChild(KbqFormField);
 
     /** @docs-private */
-    protected readonly tooltipTrigger = viewChild(KbqTooltipTrigger);
+    protected readonly overlayOrigin = viewChild.required(CdkOverlayOrigin);
     /** @docs-private */
-    protected readonly overlayOrigin = viewChild(CdkOverlayOrigin);
+    protected readonly tooltipTrigger = viewChild(KbqTooltipTrigger);
     /** @docs-private */
     protected readonly overlayDir = viewChild(CdkConnectedOverlay);
     /** @docs-private */

--- a/packages/docs-examples/components/inline-edit/inline-edit-controls/inline-edit-controls-example.ts
+++ b/packages/docs-examples/components/inline-edit/inline-edit-controls/inline-edit-controls-example.ts
@@ -8,6 +8,7 @@ import { KbqFormFieldModule } from '@koobiq/components/form-field';
 import { KbqInlineEditModule } from '@koobiq/components/inline-edit';
 import { KbqInputModule } from '@koobiq/components/input';
 import { KbqSelectModule } from '@koobiq/components/select';
+import { KbqTagsModule } from '@koobiq/components/tags';
 import { KbqTextareaModule } from '@koobiq/components/textarea';
 
 /**
@@ -25,7 +26,8 @@ import { KbqTextareaModule } from '@koobiq/components/textarea';
         KbqTextareaModule,
         KbqOptionModule,
         KbqSelectModule,
-        KbqBadgeModule
+        KbqBadgeModule,
+        KbqTagsModule
     ],
     selector: 'inline-edit-controls-example',
     template: `
@@ -77,9 +79,13 @@ import { KbqTextareaModule } from '@koobiq/components/textarea';
                             style="flex-wrap: wrap"
                         >
                             @if (form.controls.selectMultiple.value!.length > 0) {
-                                @for (badge of form.controls.selectMultiple.value; track badge) {
-                                    <kbq-badge>{{ badge }}</kbq-badge>
-                                }
+                                <kbq-tag-list>
+                                    @for (tag of form.controls.selectMultiple.value; track tag) {
+                                        <kbq-tag [value]="tag">
+                                            {{ tag }}
+                                        </kbq-tag>
+                                    }
+                                </kbq-tag-list>
                             } @else {
                                 <span kbqInlineEditPlaceholder>{{ placeholder }}</span>
                             }

--- a/packages/docs-examples/components/inline-edit/inline-edit-controls/inline-edit-controls-example.ts
+++ b/packages/docs-examples/components/inline-edit/inline-edit-controls/inline-edit-controls-example.ts
@@ -79,13 +79,9 @@ import { KbqTextareaModule } from '@koobiq/components/textarea';
                             style="flex-wrap: wrap"
                         >
                             @if (form.controls.selectMultiple.value!.length > 0) {
-                                <kbq-tag-list>
-                                    @for (tag of form.controls.selectMultiple.value; track tag) {
-                                        <kbq-tag [value]="tag">
-                                            {{ tag }}
-                                        </kbq-tag>
-                                    }
-                                </kbq-tag-list>
+                                @for (badge of form.controls.selectMultiple.value; track badge) {
+                                    <kbq-badge>{{ badge }}</kbq-badge>
+                                }
                             } @else {
                                 <span kbqInlineEditPlaceholder>{{ placeholder }}</span>
                             }

--- a/tools/public_api_guard/components/inline-edit.api.md
+++ b/tools/public_api_guard/components/inline-edit.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AfterContentInit } from '@angular/core';
 import { CdkConnectedOverlay } from '@angular/cdk/overlay';
 import { CdkOverlayOrigin } from '@angular/cdk/overlay';
 import * as i0 from '@angular/core';
@@ -38,7 +37,7 @@ export class KbqFocusRegionItem {
 }
 
 // @public
-export class KbqInlineEdit implements AfterContentInit {
+export class KbqInlineEdit {
     constructor();
     protected cancel(): void;
     protected readonly canceled: OutputEmitterRef<void>;
@@ -54,13 +53,11 @@ export class KbqInlineEdit implements AfterContentInit {
     protected readonly mode: WritableSignal<"view" | "edit">;
     readonly modeAsReadonly: Signal<"view" | "edit">;
     protected readonly modeChange: OutputEmitterRef<"view" | "edit">;
-    // (undocumented)
-    ngAfterContentInit(): void;
     protected onAttach(): void;
     protected onClick(event: Event): void;
     protected onOverlayKeydown(event: KeyboardEvent): void;
     protected readonly overlayDir: Signal<CdkConnectedOverlay | undefined>;
-    protected readonly overlayOrigin: Signal<CdkOverlayOrigin | undefined>;
+    protected readonly overlayOrigin: Signal<CdkOverlayOrigin>;
     protected readonly overlayWidth: WritableSignal<string | number>;
     protected readonly placements: typeof PopUpPlacements;
     protected readonly regionItems: Signal<readonly KbqFocusRegionItem[]>;


### PR DESCRIPTION
Redesigned the focus logic, following the UX principle: 'content first, everything else after.'
Initially wanted to implement it using `CdkFocusTrap` and focus delegation, but realized that this approach works differently across browsers.
In the end, implemented it natively by adding an overlay that renders the focus border.
This way, the focus order became correct:
> Content -> Overlay (with focus border) -> Menu

<hr />


<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

Переделал логику фокусировки, следуя UX-правилу: "сначала контент, потом все остальное".

Сначала хотел реализовать с помощью `CdkFocusTrap` и прокидыванием фокуса, но понял, что такой подход в браузерах работает по-разному.

По итогу, реализовал нативно, добавив оверлей, который отрисовывает рамку фокуса.

Таким образом, порядок фокусировки стал верный: 

> Контент -> Оверлей (с рамкой фокуса) -> Меню
</details>
