### PR TITLE
fix(breadcrumbs): removed invalid layout (#DS-4180)

### DIFF
--- a/packages/components/breadcrumbs/breadcrumbs.html
+++ b/packages/components/breadcrumbs/breadcrumbs.html
@@ -42,8 +42,8 @@ resolved SSR issue with official hack https://github.com/angular/angular/issues/
                 <kbq-dropdown #hiddenBreadcrumbsDropdown="kbqDropdown">
                     @for (item of items; track item) {
                         @if (kbqOverflowItems.hiddenItemIDs().has($index)) {
-                            <a class="kbq-breadcrumb-item__link-behavior" [routerLink]="item.routerLink?.urlTree">
-                                <button kbq-dropdown-item [disabled]="item.disabled">{{ item.text }}</button>
+                            <a kbq-dropdown-item [routerLink]="item.routerLink?.urlTree" [disabled]="item.disabled">
+                                {{ item.text }}
                             </a>
                         }
                     }
@@ -66,18 +66,18 @@ resolved SSR issue with official hack https://github.com/angular/angular/issues/
     @if (item.customTemplateRef) {
         <ng-container [ngTemplateOutlet]="item.customTemplateRef" />
     } @else {
-        <a tabindex="-1" class="kbq-breadcrumb-item__link-behavior" [routerLink]="item.routerLink?.urlTree">
-            <button
-                kbq-button
-                kbq-title
-                kbqBreadcrumb
-                [attr.aria-current]="last ? 'page' : null"
-                [disabled]="item.disabled || last"
-                [kbqPlacementPriority]="PopUpPlacements.Bottom"
-                [kbqTooltipArrow]="false"
-            >
-                {{ item.text }}
-            </button>
+        <a
+            kbq-button
+            kbq-title
+            kbqBreadcrumb
+            [focusable]="!item.disabled && !last"
+            [routerLink]="item.routerLink?.urlTree"
+            [attr.aria-current]="last ? 'page' : null"
+            [disabled]="item.disabled || last"
+            [kbqPlacementPriority]="PopUpPlacements.Bottom"
+            [kbqTooltipArrow]="false"
+        >
+            {{ item.text }}
         </a>
     }
 </ng-template>

--- a/packages/components/breadcrumbs/breadcrumbs.scss
+++ b/packages/components/breadcrumbs/breadcrumbs.scss
@@ -69,6 +69,10 @@
             --kbq-button-size-horizontal-padding: var(--kbq-breadcrumb-item-horizontal-padding);
             --kbq-button-size-border-radius: var(--kbq-breadcrumb-item-border-radius);
         }
+
+        &:focus-visible {
+            outline-offset: unset;
+        }
     }
 
     .kbq-breadcrumb__expand {
@@ -208,8 +212,4 @@
     @include _kbq-breadcrumbs-geometry();
     @include _kbq-breadcrumbs-theme();
     @include _kbq-breadcrumbs-typography();
-}
-
-.kbq-breadcrumb-item__link-behavior {
-    text-decoration: none;
 }

--- a/packages/components/breadcrumbs/breadcrumbs.ts
+++ b/packages/components/breadcrumbs/breadcrumbs.ts
@@ -72,7 +72,12 @@ export class KbqBreadcrumbsSeparator {
     standalone: true,
     selector: '[kbq-button][kbqBreadcrumb]',
     host: { class: 'kbq-breadcrumb-item' },
-    hostDirectives: [RdxRovingFocusItemDirective]
+    hostDirectives: [
+        {
+            directive: RdxRovingFocusItemDirective,
+            inputs: ['focusable']
+        }
+    ]
 })
 export class KbqBreadcrumbButton implements OnInit {
     private readonly button = inject(KbqButton, { optional: true, self: true });
@@ -106,7 +111,10 @@ export class KbqBreadcrumbView {
     template: `
         <ng-content />
     `,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        '[attr.tabIndex]': 'null'
+    }
 })
 export class KbqBreadcrumbItem {
     /**

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-custom-template/breadcrumbs-custom-template-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-custom-template/breadcrumbs-custom-template-example.ts
@@ -14,11 +14,18 @@ import { KbqIconModule } from '@koobiq/components/icon';
         <nav kbq-breadcrumbs>
             @for (breadcrumb of breadcrumbs; track breadcrumb; let last = $last) {
                 <kbq-breadcrumb-item [routerLink]="breadcrumb.url" [text]="breadcrumb.label">
-                    <a *kbqBreadcrumbView tabindex="-1" [routerLink]="breadcrumb.url">
-                        <button kbq-button kbqBreadcrumb [disabled]="last" [attr.aria-current]="last ? 'page' : null">
-                            {{ breadcrumb.label }}
-                            <i kbq-icon="kbq-file-code-o_16"></i>
-                        </button>
+                    <a
+                        *kbqBreadcrumbView
+                        tabindex="-1"
+                        kbq-button
+                        kbqBreadcrumb
+                        [focusable]="!last"
+                        [routerLink]="breadcrumb.url"
+                        [disabled]="last"
+                        [attr.aria-current]="last ? 'page' : null"
+                    >
+                        {{ breadcrumb.label }}
+                        <i kbq-icon="kbq-file-code-o_16"></i>
                     </a>
                 </kbq-breadcrumb-item>
             }

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-dropdown/breadcrumbs-dropdown-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-dropdown/breadcrumbs-dropdown-example.ts
@@ -50,8 +50,8 @@ import { KbqIconModule } from '@koobiq/components/icon';
         </nav>
 
         <kbq-dropdown #siblingsListDropdown="kbqDropdown">
-            <button kbq-dropdown-item routerLink="./RBAC">RBAC</button>
-            <button kbq-dropdown-item routerLink="./ABAC">ABAC</button>
+            <a kbq-dropdown-item routerLink="./RBAC">RBAC</a>
+            <a kbq-dropdown-item routerLink="./ABAC">ABAC</a>
         </kbq-dropdown>
     `,
     imports: [

--- a/tools/public_api_guard/components/breadcrumbs.api.md
+++ b/tools/public_api_guard/components/breadcrumbs.api.md
@@ -26,7 +26,7 @@ export class KbqBreadcrumbButton implements OnInit {
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<KbqBreadcrumbButton, "[kbq-button][kbqBreadcrumb]", never, {}, {}, never, never, true, [{ directive: typeof i1.RdxRovingFocusItemDirective; inputs: {}; outputs: {}; }]>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<KbqBreadcrumbButton, "[kbq-button][kbqBreadcrumb]", never, {}, {}, never, never, true, [{ directive: typeof i1.RdxRovingFocusItemDirective; inputs: { "focusable": "focusable"; }; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqBreadcrumbButton, never>;
 }


### PR DESCRIPTION
## Summary

Fixed layout applying valid html semantics.

<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

Исправил разметку на валидную

</details>


```diff
- <a><button kbq-button></button></a>
+ <a kbq-button></a>
```