### PR TITLE
fix(tags): focus on SPACE keydown, default selection for single tag (#DS-4299)

### DIFF
--- a/packages/components/tags/tag-list.component.spec.ts
+++ b/packages/components/tags/tag-list.component.spec.ts
@@ -270,11 +270,11 @@ describe(KbqTagList.name, () => {
                 expect(tagListNativeElement.hasAttribute('tabindex')).toBeFalsy();
             });
 
-            it('should focus next tag if first tag is not selectable', () => {
+            it('should focus next tag if first tag is disabled', () => {
                 const arr = tags.toArray();
                 const firstElementIndex = 0;
 
-                arr[firstElementIndex].selectable = false;
+                arr[firstElementIndex].disabled = true;
 
                 tagListInstance.focus();
                 fixture.detectChanges();

--- a/packages/components/tags/tag-list.component.spec.ts
+++ b/packages/components/tags/tag-list.component.spec.ts
@@ -168,17 +168,6 @@ describe(KbqTagList.name, () => {
                 expect(tagListNativeElement.classList).toContain('kbq-tag-list');
             });
 
-            it('should not have the aria-selected attribute when is not selectable', () => {
-                testComponent.selectable = false;
-                fixture.detectChanges();
-
-                const tagsValid = tags
-                    .toArray()
-                    .every((tag) => !tag.selectable && !tag.elementRef.nativeElement.hasAttribute('aria-selected'));
-
-                expect(tagsValid).toBe(true);
-            });
-
             it('should toggle the tags disabled state based on whether it is disabled', () => {
                 expect(tags.toArray().every((tag) => tag.disabled)).toBe(false);
 

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -130,7 +130,7 @@ export class KbqTagList
      *
      * @docs-private
      */
-    get tagFocusChanges(): Observable<KbqTagEvent> {
+    get tagFocusChanges(): Observable<KbqTagFocusEvent> {
         return merge(...this.tags.map((tag) => tag.onFocus));
     }
 
@@ -813,10 +813,11 @@ export class KbqTagList
 
     /** Listens to user-generated selection events on each tag. */
     private listenToTagsFocus(): void {
-        this.tagFocusSubscription = this.tagFocusChanges.subscribe((event) => {
-            const tagIndex: number = this.tags.toArray().indexOf(event.tag);
+        this.tagFocusSubscription = this.tagFocusChanges.subscribe(({ tag, origin }) => {
+            const tagIndex = this.tags.toArray().indexOf(tag);
 
             if (this.isValidIndex(tagIndex)) {
+                this.keyManager.setFocusOrigin(origin);
                 this.keyManager.updateActiveItem(tagIndex);
             }
 

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -35,7 +35,14 @@ import { KbqCleaner, KbqFormFieldControl } from '@koobiq/components/form-field';
 import { merge, Observable, Subject, Subscription } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 import { KbqTagTextControl } from './tag-text-control';
-import { KbqTag, KbqTagDragData, KbqTagEditChange, KbqTagEvent, KbqTagSelectionChange } from './tag.component';
+import {
+    KbqTag,
+    KbqTagDragData,
+    KbqTagEditChange,
+    KbqTagEvent,
+    KbqTagFocusEvent,
+    KbqTagSelectionChange
+} from './tag.component';
 
 // Increasing integer for generating unique ids for tag-list components.
 let nextUniqueId = 0;
@@ -456,7 +463,7 @@ export class KbqTagList
         this.keyManager = new FocusKeyManager<KbqTag>(this.tags)
             .withVerticalOrientation()
             .withHorizontalOrientation(this.dir ? this.dir.value : 'ltr')
-            .skipPredicate((item) => item.disabled || !item.selectable);
+            .skipPredicate(({ disabled }) => disabled);
 
         if (this.dir) {
             this.dir.change

--- a/packages/components/tags/tag.component.spec.ts
+++ b/packages/components/tags/tag.component.spec.ts
@@ -52,6 +52,10 @@ const isTagFocused = (debugElement: DebugElement): boolean => {
     return getTagElement(debugElement).classList.contains('cdk-focused');
 };
 
+const isTagSelectable = (debugElement: DebugElement): boolean => {
+    return getTagElement(debugElement).classList.contains('kbq-tag_selectable');
+};
+
 const isTagEditing = (debugElement: DebugElement): boolean => {
     return getTagElement(debugElement).classList.contains('kbq-tag_editing');
 };
@@ -98,7 +102,47 @@ const getTagRemoveElement = (debugElement: DebugElement): HTMLElement => {
 export class TestTag {
     readonly tag = viewChild.required(KbqTag);
     readonly value = model('Tag');
-    readonly selectable = model(true);
+    readonly selectable = model(false);
+    readonly disabled = model(false);
+    readonly selected = model(false);
+    readonly removable = model(true);
+    readonly editable = model(true);
+    readonly preventEditSubmit = model(false);
+
+    readonly selectionChange = jest.fn();
+    readonly removedChange = jest.fn();
+    readonly editChange = jest.fn();
+}
+
+@Component({
+    standalone: true,
+    selector: 'test-tag',
+    imports: [KbqTagsModule, FormsModule],
+    template: `
+        <kbq-tag-list>
+            <kbq-tag
+                [value]="value()"
+                [selected]="selected()"
+                [disabled]="disabled()"
+                [removable]="removable()"
+                [editable]="editable()"
+                [preventEditSubmit]="preventEditSubmit()"
+                (selectionChange)="selectionChange($event)"
+                (removed)="removedChange($event)"
+                (editChange)="editChange($event)"
+            >
+                {{ value() }}
+                <i kbqTagRemove></i>
+                <input kbqTagEditInput [(ngModel)]="value" />
+                <i kbqTagEditSubmit></i>
+            </kbq-tag>
+        </kbq-tag-list>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TestTagInsideTagList {
+    readonly tag = viewChild.required(KbqTag);
+    readonly value = model('Tag');
     readonly disabled = model(false);
     readonly selected = model(false);
     readonly removable = model(true);
@@ -554,8 +598,8 @@ describe(KbqTag.name, () => {
         expect(isTagEditing(debugElement)).toBeTruthy();
     });
 
-    it('should select tag on Ctrl + click', () => {
-        const { debugElement } = createComponent(TestTag);
+    it('should select tag in tag-list on Ctrl + click', () => {
+        const { debugElement } = createComponent(TestTagInsideTagList);
         const tag = getTagElement(debugElement);
 
         tag.dispatchEvent(new MouseEvent('click', { ctrlKey: true }));
@@ -594,6 +638,9 @@ describe(KbqTag.name, () => {
         const fixture = createComponent(TestTag);
         const { debugElement, componentInstance } = fixture;
 
+        componentInstance.selectable.set(true);
+        fixture.detectChanges();
+
         expect(isTagSelected(debugElement)).toBeFalsy();
 
         componentInstance.tag().select();
@@ -605,6 +652,9 @@ describe(KbqTag.name, () => {
     it('should DEselect tag by deselect() method', () => {
         const fixture = createComponent(TestTag);
         const { debugElement, componentInstance } = fixture;
+
+        componentInstance.selectable.set(true);
+        fixture.detectChanges();
 
         expect(isTagSelected(debugElement)).toBeFalsy();
 
@@ -623,6 +673,9 @@ describe(KbqTag.name, () => {
         const fixture = createComponent(TestTag);
         const { debugElement, componentInstance } = fixture;
 
+        componentInstance.selectable.set(true);
+        fixture.detectChanges();
+
         expect(isTagSelected(debugElement)).toBeFalsy();
 
         componentInstance.tag().toggleSelected();
@@ -631,8 +684,8 @@ describe(KbqTag.name, () => {
         expect(isTagSelected(debugElement)).toBeTruthy();
     });
 
-    it('should select tag on Cmd + click', () => {
-        const { debugElement } = createComponent(TestTag);
+    it('should select tag in tag-list on Cmd + click', () => {
+        const { debugElement } = createComponent(TestTagInsideTagList);
         const tag = getTagElement(debugElement);
 
         tag.dispatchEvent(new MouseEvent('click', { metaKey: true }));
@@ -640,8 +693,8 @@ describe(KbqTag.name, () => {
         expect(isTagSelected(debugElement)).toBeTruthy();
     });
 
-    it('should select tag on Shift + click', () => {
-        const { debugElement } = createComponent(TestTag);
+    it('should select tag in tag-list on Shift + click', () => {
+        const { debugElement } = createComponent(TestTagInsideTagList);
         const tag = getTagElement(debugElement);
 
         tag.dispatchEvent(new MouseEvent('click', { shiftKey: true }));
@@ -649,13 +702,19 @@ describe(KbqTag.name, () => {
         expect(isTagSelected(debugElement)).toBeTruthy();
     });
 
-    it('should NOT select tag on Ctrl + click', () => {
-        const fixture = createComponent(TestTag);
-        const { debugElement, componentInstance } = fixture;
+    it('should NOT select tag on Shift/Cmd/Ctrl + click', () => {
+        const { debugElement } = createComponent(TestTag);
         const tag = getTagElement(debugElement);
 
-        componentInstance.selectable.set(false);
-        fixture.detectChanges();
+        expect(isTagSelected(debugElement)).toBeFalsy();
+
+        tag.dispatchEvent(new MouseEvent('click', { shiftKey: true }));
+
+        expect(isTagSelected(debugElement)).toBeFalsy();
+
+        tag.dispatchEvent(new MouseEvent('click', { metaKey: true }));
+
+        expect(isTagSelected(debugElement)).toBeFalsy();
 
         tag.dispatchEvent(new MouseEvent('click', { ctrlKey: true }));
 
@@ -663,7 +722,7 @@ describe(KbqTag.name, () => {
     });
 
     it('should emit KbqTagSelectionChange event on Ctrl + click', () => {
-        const { debugElement, componentInstance } = createComponent(TestTag);
+        const { debugElement, componentInstance } = createComponent(TestTagInsideTagList);
 
         getTagElement(debugElement).dispatchEvent(new MouseEvent('click', { ctrlKey: true }));
 
@@ -793,7 +852,11 @@ describe(KbqTag.name, () => {
     });
 
     it('should toggle tag selection tag on focus/blur', fakeAsync(() => {
-        const { debugElement } = createComponent(TestTag);
+        const fixture = createComponent(TestTag);
+        const { debugElement, componentInstance } = fixture;
+
+        componentInstance.selectable.set(true);
+        fixture.detectChanges();
 
         expect(isTagFocused(debugElement)).toBeFalsy();
         expect(isTagSelected(debugElement)).toBeFalsy();
@@ -812,8 +875,12 @@ describe(KbqTag.name, () => {
     }));
 
     it('should toggle tag selection on SPACE keydown', () => {
-        const { debugElement } = createComponent(TestTag);
+        const fixture = createComponent(TestTag);
+        const { debugElement, componentInstance } = fixture;
         const tag = getTagElement(debugElement);
+
+        componentInstance.selectable.set(true);
+        fixture.detectChanges();
 
         expect(isTagSelected(debugElement)).toBeFalsy();
 
@@ -827,8 +894,12 @@ describe(KbqTag.name, () => {
     });
 
     it('should emit KbqTagSelectionChange event on SPACE keydown', () => {
-        const { debugElement, componentInstance } = createComponent(TestTag);
+        const fixture = createComponent(TestTag);
+        const { debugElement, componentInstance } = fixture;
         const tag = getTagElement(debugElement);
+
+        componentInstance.selectable.set(true);
+        fixture.detectChanges();
 
         tag.dispatchEvent(new KeyboardEvent('keydown', { keyCode: SPACE }));
 
@@ -848,6 +919,18 @@ describe(KbqTag.name, () => {
         tag.dispatchEvent(new KeyboardEvent('keydown', { keyCode: SPACE }));
 
         expect(isTagFocused(debugElement)).toBeTruthy();
+    });
+
+    it('should NOT be selectable by default', () => {
+        const { debugElement } = createComponent(TestTag);
+
+        expect(isTagSelectable(debugElement)).toBeFalsy();
+    });
+
+    it('should be selectable by default in tag-list', () => {
+        const { debugElement } = createComponent(TestTagInsideTagList);
+
+        expect(isTagSelectable(debugElement)).toBeTruthy();
     });
 });
 

--- a/packages/components/tags/tag.component.spec.ts
+++ b/packages/components/tags/tag.component.spec.ts
@@ -838,6 +838,17 @@ describe(KbqTag.name, () => {
 
         expect(componentInstance.selectionChange).toHaveBeenCalledWith(expect.objectContaining({ selected: false }));
     });
+
+    it('should focus tag on SPACE keydown', () => {
+        const { debugElement } = createComponent(TestTag);
+        const tag = getTagElement(debugElement);
+
+        expect(isTagFocused(debugElement)).toBeFalsy();
+
+        tag.dispatchEvent(new KeyboardEvent('keydown', { keyCode: SPACE }));
+
+        expect(isTagFocused(debugElement)).toBeTruthy();
+    });
 });
 
 @Component({

--- a/packages/components/tags/tag.component.ts
+++ b/packages/components/tags/tag.component.ts
@@ -334,21 +334,18 @@ export class KbqTag
     private _value: any;
 
     /**
-     * Whether or not the tag is selectable. When a tag is not selectable,
-     * changes to its selected state are always ignored. By default a tag is
-     * selectable, and it becomes non-selectable if its parent tag list is
-     * not selectable.
+     * Whether the tag is selectable.
      */
     @Input({ transform: booleanAttribute })
     get selectable(): boolean {
-        return this._selectable && (this.tagList?.selectable ?? true);
+        return this._selectable || !!this.tagList?.selectable;
     }
 
     set selectable(value: boolean) {
         this._selectable = value;
     }
 
-    private _selectable: boolean = true;
+    private _selectable: boolean = false;
 
     /**
      * Determines whether the tag is removable.
@@ -530,7 +527,13 @@ export class KbqTag
             return;
         }
 
-        if (this.selectable && hasModifierKey(event, 'metaKey', 'ctrlKey', 'shiftKey')) {
+        if (
+            // We should toggle selection only if tag inside of a tag list.
+            // Single tag can only be toggled on focus or blur.
+            this.tagList &&
+            this.selectable &&
+            hasModifierKey(event, 'metaKey', 'ctrlKey', 'shiftKey')
+        ) {
             this.toggleSelected(true);
 
             // We should stop event propagation to prevent the tag list from handling the click event.

--- a/packages/components/tags/tag.component.ts
+++ b/packages/components/tags/tag.component.ts
@@ -1,4 +1,4 @@
-import { FocusMonitor } from '@angular/cdk/a11y';
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
 import { CdkDrag } from '@angular/cdk/drag-drop';
 import { BACKSPACE, DELETE, ENTER, ESCAPE, F2, SPACE } from '@angular/cdk/keycodes';
 import {
@@ -41,9 +41,12 @@ import { KbqIcon } from '@koobiq/components/icon';
 import { Subject } from 'rxjs';
 import { KbqTagList } from './tag-list.component';
 
-export interface KbqTagEvent {
+/**
+ * Event object emitted by KbqTag.
+ */
+export type KbqTagEvent = {
     tag: KbqTag;
-}
+};
 
 /**
  * Event object emitted by KbqTag when the tag is edited.
@@ -64,6 +67,13 @@ export class KbqTagSelectionChange {
         public isUserInput = false
     ) {}
 }
+
+/**
+ * Event object emitted when the KbqTag is focused.
+ */
+export type KbqTagFocusEvent = KbqTagEvent & {
+    origin: FocusOrigin;
+};
 
 const TAG_ATTRIBUTE_NAMES = ['kbq-basic-tag'];
 
@@ -227,7 +237,7 @@ export class KbqTag
      *
      * @docs-private
      */
-    readonly onFocus = new Subject<KbqTagEvent>();
+    readonly onFocus = new Subject<KbqTagFocusEvent>();
 
     /**
      * Emits when the tag is blurred.
@@ -545,6 +555,7 @@ export class KbqTag
                 break;
             }
             case SPACE: {
+                this.focusMonitor.focusVia(this.elementRef, 'keyboard');
                 this.toggleSelected(true);
 
                 // Always prevent space from scrolling the page since the list has focus
@@ -652,7 +663,7 @@ export class KbqTag
                 this.hasFocus = hasFocus;
 
                 if (this.hasFocus) {
-                    this.onFocus.next({ tag: this });
+                    this.onFocus.next({ tag: this, origin });
                     if (!this.tagList) this.select();
                 } else {
                     this.onBlur.next({ tag: this });

--- a/packages/components/tags/tag.component.ts
+++ b/packages/components/tags/tag.component.ts
@@ -555,8 +555,8 @@ export class KbqTag
                 break;
             }
             case SPACE: {
-                this.focusMonitor.focusVia(this.elementRef, 'keyboard');
                 this.toggleSelected(true);
+                this.focusMonitor.focusVia(this.elementRef, 'keyboard');
 
                 // Always prevent space from scrolling the page since the list has focus
                 event.preventDefault();

--- a/tools/public_api_guard/components/tags.api.md
+++ b/tools/public_api_guard/components/tags.api.md
@@ -16,6 +16,7 @@ import { ElementRef } from '@angular/core';
 import { ErrorStateMatcher } from '@koobiq/components/core';
 import { EventEmitter } from '@angular/core';
 import { FocusKeyManager } from '@koobiq/cdk/a11y';
+import { FocusOrigin } from '@angular/cdk/a11y';
 import { FormGroupDirective } from '@angular/forms';
 import * as i0 from '@angular/core';
 import * as i1 from '@koobiq/components/core';
@@ -91,7 +92,7 @@ export class KbqTag extends KbqColorDirective implements IFocusableOption, OnDes
     // (undocumented)
     ngOnDestroy(): void;
     readonly onBlur: Subject<KbqTagEvent>;
-    readonly onFocus: Subject<KbqTagEvent>;
+    readonly onFocus: Subject<KbqTagFocusEvent>;
     preventEditSubmit: boolean;
     get removable(): boolean;
     set removable(value: boolean);
@@ -164,11 +165,15 @@ export class KbqTagEditSubmit {
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqTagEditSubmit, never>;
 }
 
-// @public (undocumented)
-export interface KbqTagEvent {
-    // (undocumented)
+// @public
+export type KbqTagEvent = {
     tag: KbqTag;
-}
+};
+
+// @public
+export type KbqTagFocusEvent = KbqTagEvent & {
+    origin: FocusOrigin;
+};
 
 // Warning: (ae-forgotten-export) The symbol "KbqTagTextControl" needs to be exported by the entry point index.d.ts
 //
@@ -317,7 +322,7 @@ export class KbqTagList implements KbqFormFieldControl<any>, ControlValueAccesso
     // @deprecated
     tagChanges: EventEmitter<any>;
     get tagEditChanges(): Observable<KbqTagEditChange>;
-    get tagFocusChanges(): Observable<KbqTagEvent>;
+    get tagFocusChanges(): Observable<KbqTagFocusEvent>;
     get tagRemoveChanges(): Observable<KbqTagEvent>;
     tags: QueryList<KbqTag>;
     get tagSelectionChanges(): Observable<KbqTagSelectionChange>;


### PR DESCRIPTION
- [x] клавиатурный фокус при выделении пробелом
- [x] отключение выделения по умолчанию для single тегов