### PR TITLE
fix(form-field): aligned hints' margin,gap (#DS-4358)

### DIFF
--- a/packages/components/form-field/fieldset-tokens.scss
+++ b/packages/components/form-field/fieldset-tokens.scss
@@ -1,5 +1,6 @@
 .kbq-fieldset {
     --kbq-fieldset-legend-margin: var(--kbq-size-s);
-    --kbq-form-field-hint-size-margin-top: var(--kbq-size-m);
+    --kbq-form-field-hint-size-margin-top: var(--kbq-size-xs);
     --kbq-form-field-hint-text: var(--kbq-foreground-contrast-secondary);
+    --kbq-form-field-hint-size-gap: var(--kbq-size-xxs);
 }

--- a/packages/components/form-field/form-field-tokens.scss
+++ b/packages/components/form-field/form-field-tokens.scss
@@ -10,8 +10,8 @@
     --kbq-form-field-size-icon-button-size: var(--kbq-size-xxl);
     --kbq-form-field-size-icon-button-margin-left: var(--kbq-size-xxs);
 
-    --kbq-form-field-hint-size-margin-top: var(--kbq-size-m);
-    --kbq-form-field-hint-size-gap: var(--kbq-size-s);
+    --kbq-form-field-hint-size-margin-top: var(--kbq-size-xs);
+    --kbq-form-field-hint-size-gap: var(--kbq-size-xxs);
 
     --kbq-form-field-size-container-vertical-padding: calc(var(--kbq-size-xs) - var(--kbq-size-border-width));
     --kbq-form-field-size-container-left-padding: calc(var(--kbq-size-xs) - var(--kbq-size-border-width));

--- a/packages/components/form-field/form-field.scss
+++ b/packages/components/form-field/form-field.scss
@@ -4,8 +4,16 @@
 @mixin kbq-form-field-hint-geometry {
     display: flex;
     flex-direction: column;
-    gap: var(--kbq-size-s);
+    gap: var(--kbq-form-field-hint-size-gap);
     margin-top: var(--kbq-form-field-hint-size-margin-top);
+
+    &:has(.kbq-reactive-password-hint, .kbq-password-hint) {
+        --kbq-form-field-hint-size-gap: var(--kbq-size-s);
+    }
+
+    &:has(:is(.kbq-reactive-password-hint, .kbq-password-hint):first-child) {
+        --kbq-form-field-hint-size-margin-top: var(--kbq-size-m);
+    }
 }
 
 .kbq-form-field {


### PR DESCRIPTION
## Summary

Introduced CSS variables for the margin and the gap between hints.
Restored the correct values for the default display of hints.
Added rules for password‑input hint messages.

<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

- Завел CSS переменные для марджина и гэпа между хинтами
- Вернул корректные значения для дефолтного отображения хинтов
- Добавил правила для подсказок инпута пароля 

</details>