### PR TITLE
chore(list): added dev example & refactored tests (#DS-4272)

### DIFF
--- a/packages/components-dev/list/module.ts
+++ b/packages/components-dev/list/module.ts
@@ -1,6 +1,6 @@
 import { Clipboard } from '@angular/cdk/clipboard';
 import { AsyncPipe, JsonPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, ViewEncapsulation } from '@angular/core';
 import { FormsModule, UntypedFormControl } from '@angular/forms';
 import { PopUpPlacements } from '@koobiq/components/core';
 import { KbqDropdownModule } from '@koobiq/components/dropdown';
@@ -48,6 +48,7 @@ export class DevExamples {}
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DevApp {
+    list = signal(Array.from({ length: 5 }, (_, i) => `Item ${i}`));
     popUpPlacements = PopUpPlacements;
 
     typesOfShoes = ['Boots', 'Clogs', 'Loafers', 'Moccasins', 'Sneakers'];
@@ -79,5 +80,9 @@ export class DevApp {
     onCopy($event) {
         console.log('onCopy', $event);
         this.clipboard.copy($event.option.value);
+    }
+
+    onRemove(item: string) {
+        this.list.update((list) => list.filter((listItem) => listItem !== item));
     }
 }

--- a/packages/components-dev/list/template.html
+++ b/packages/components-dev/list/template.html
@@ -118,6 +118,20 @@
 <br />
 <div>multipleSelectedCheckbox: {{ multipleSelectedCheckbox | json }}</div>
 
+<h2 class="kbq-title">Multiple selection with remove on backspace</h2>
+
+<kbq-list-selection
+    multiple="checkbox"
+    [(ngModel)]="multipleSelectedCheckbox"
+    (selectionChange)="onSelectionChange($event)"
+>
+    @for (item of list(); track item) {
+        <kbq-list-option [value]="item" (keydown.backspace)="onRemove(item)">
+            {{ item }}
+        </kbq-list-option>
+    }
+</kbq-list-selection>
+
 <br />
 <br />
 <br />

--- a/packages/components/list/list-selection.component.spec.ts
+++ b/packages/components/list/list-selection.component.spec.ts
@@ -947,13 +947,13 @@ describe('KbqListSelection keyboard interaction', () => {
 
 @Component({
     template: `
-        <mat-selection-list [compareWith]="compareWith" [(ngModel)]="selectedOptions">
+        <kbq-list-selection [compareWith]="compareWith" [(ngModel)]="selectedOptions">
             @for (option of options; track option) {
-                <mat-list-option [value]="option">
+                <kbq-list-option [value]="option">
                     {{ option.label }}
-                </mat-list-option>
+                </kbq-list-option>
             }
-        </mat-selection-list>
+        </kbq-list-selection>
     `
 })
 class SelectionListWithCustomComparator {

--- a/packages/components/list/list.component.spec.ts
+++ b/packages/components/list/list.component.spec.ts
@@ -8,21 +8,21 @@ describe('KbqList', () => {
         TestBed.configureTestingModule({
             imports: [KbqListModule],
             declarations: [
-                ListWithOneAnchorItem,
-                ListWithOneItem,
-                ListWithTwoLineItem,
-                ListWithThreeLineItem,
-                ListWithAvatar,
-                ListWithItemWithCssClass,
-                ListWithDynamicNumberOfLines,
-                ListWithMultipleItems,
-                ListWithManyLines
+                TestListWithOneAnchorItem,
+                TestListWithOneItem,
+                TestListWithTwoLineItem,
+                TestListWithThreeLineItem,
+                TestListWithAvatar,
+                TestListWithItemWithCssClass,
+                TestListWithDynamicNumberOfLines,
+                TestListWithMultipleItems,
+                TestListWithManyLines
             ]
         }).compileComponents();
     });
 
     it('should add and remove focus class on focus/blur', () => {
-        const fixture = TestBed.createComponent(ListWithOneAnchorItem);
+        const fixture = TestBed.createComponent(TestListWithOneAnchorItem);
 
         fixture.detectChanges();
         const listItem = fixture.debugElement.query(By.directive(KbqListItem));
@@ -40,7 +40,7 @@ describe('KbqList', () => {
     });
 
     it('should not apply any additional class to a list without lines', () => {
-        const fixture = TestBed.createComponent(ListWithOneItem);
+        const fixture = TestBed.createComponent(TestListWithOneItem);
         const listItem = fixture.debugElement.query(By.css('kbq-list-item'));
 
         fixture.detectChanges();
@@ -48,7 +48,7 @@ describe('KbqList', () => {
     });
 
     it('should not clear custom classes provided by user', () => {
-        const fixture = TestBed.createComponent(ListWithItemWithCssClass);
+        const fixture = TestBed.createComponent(TestListWithItemWithCssClass);
 
         fixture.detectChanges();
 
@@ -58,7 +58,7 @@ describe('KbqList', () => {
     });
 
     it('should add aria roles properly', () => {
-        const fixture = TestBed.createComponent(ListWithMultipleItems);
+        const fixture = TestBed.createComponent(TestListWithMultipleItems);
 
         fixture.detectChanges();
 
@@ -88,7 +88,7 @@ class BaseTestList {
         </kbq-list>
     `
 })
-class ListWithOneAnchorItem extends BaseTestList {
+class TestListWithOneAnchorItem extends BaseTestList {
     // This needs to be declared directly on the class; if declared on the BaseTestList superclass,
     // it doesn't get populated.
     @ViewChildren(KbqListItem) listItems: QueryList<KbqListItem>;
@@ -102,7 +102,7 @@ class ListWithOneAnchorItem extends BaseTestList {
         </kbq-list>
     `
 })
-class ListWithOneItem extends BaseTestList {}
+class TestListWithOneItem extends BaseTestList {}
 
 @Component({
     selector: 'test-list-with-two-line-item',
@@ -118,7 +118,7 @@ class ListWithOneItem extends BaseTestList {}
         </kbq-list>
     `
 })
-class ListWithTwoLineItem extends BaseTestList {}
+class TestListWithTwoLineItem extends BaseTestList {}
 
 @Component({
     selector: 'test-list-with-three-line-item',
@@ -134,7 +134,7 @@ class ListWithTwoLineItem extends BaseTestList {}
         </kbq-list>
     `
 })
-class ListWithThreeLineItem extends BaseTestList {
+class TestListWithThreeLineItem extends BaseTestList {
     avoidCollisionMockTarget() {}
 }
 
@@ -153,7 +153,7 @@ class ListWithThreeLineItem extends BaseTestList {
         </kbq-list>
     `
 })
-class ListWithManyLines extends BaseTestList {}
+class TestListWithManyLines extends BaseTestList {}
 
 @Component({
     selector: 'test-list-with-avatar',
@@ -167,7 +167,7 @@ class ListWithManyLines extends BaseTestList {}
         </kbq-list>
     `
 })
-class ListWithAvatar extends BaseTestList {}
+class TestListWithAvatar extends BaseTestList {}
 
 @Component({
     selector: 'test-list-with-item-with-css-class',
@@ -182,7 +182,7 @@ class ListWithAvatar extends BaseTestList {}
         </kbq-list>
     `
 })
-class ListWithItemWithCssClass extends BaseTestList {}
+class TestListWithItemWithCssClass extends BaseTestList {}
 
 @Component({
     selector: 'test-list-with-dynamic-number-of-lines',
@@ -200,7 +200,7 @@ class ListWithItemWithCssClass extends BaseTestList {}
         </kbq-list>
     `
 })
-class ListWithDynamicNumberOfLines extends BaseTestList {}
+class TestListWithDynamicNumberOfLines extends BaseTestList {}
 
 @Component({
     selector: 'test-list-with-multiple-items',
@@ -214,4 +214,4 @@ class ListWithDynamicNumberOfLines extends BaseTestList {}
         </kbq-list>
     `
 })
-class ListWithMultipleItems extends BaseTestList {}
+class TestListWithMultipleItems extends BaseTestList {}

--- a/packages/components/list/list.component.spec.ts
+++ b/packages/components/list/list.component.spec.ts
@@ -14,9 +14,7 @@ describe('KbqList', () => {
                 TestListWithThreeLineItem,
                 TestListWithAvatar,
                 TestListWithItemWithCssClass,
-                TestListWithDynamicNumberOfLines,
-                TestListWithMultipleItems,
-                TestListWithManyLines
+                TestListWithMultipleItems
             ]
         }).compileComponents();
     });
@@ -81,7 +79,6 @@ class BaseTestList {
 }
 
 @Component({
-    selector: 'test-list-with-one-anchor-item',
     template: `
         <kbq-list>
             <a kbq-list-item>Paprika</a>
@@ -95,7 +92,6 @@ class TestListWithOneAnchorItem extends BaseTestList {
 }
 
 @Component({
-    selector: 'test-list-with-one-item',
     template: `
         <kbq-list>
             <kbq-list-item>Paprika</kbq-list-item>
@@ -105,7 +101,6 @@ class TestListWithOneAnchorItem extends BaseTestList {
 class TestListWithOneItem extends BaseTestList {}
 
 @Component({
-    selector: 'test-list-with-two-line-item',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -121,7 +116,6 @@ class TestListWithOneItem extends BaseTestList {}
 class TestListWithTwoLineItem extends BaseTestList {}
 
 @Component({
-    selector: 'test-list-with-three-line-item',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -139,24 +133,6 @@ class TestListWithThreeLineItem extends BaseTestList {
 }
 
 @Component({
-    selector: 'test-list-with-many-lines',
-    template: `
-        <kbq-list>
-            @for (item of items; track item) {
-                <kbq-list-item>
-                    <h3 kbq-line>Line 1</h3>
-                    <p kbq-line>Line 2</p>
-                    <p kbq-line>Line 3</p>
-                    <p kbq-line>Line 4</p>
-                </kbq-list-item>
-            }
-        </kbq-list>
-    `
-})
-class TestListWithManyLines extends BaseTestList {}
-
-@Component({
-    selector: 'test-list-with-avatar',
     template: `
         <kbq-list>
             <kbq-list-item>
@@ -170,7 +146,6 @@ class TestListWithManyLines extends BaseTestList {}
 class TestListWithAvatar extends BaseTestList {}
 
 @Component({
-    selector: 'test-list-with-item-with-css-class',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -185,30 +160,11 @@ class TestListWithAvatar extends BaseTestList {}
 class TestListWithItemWithCssClass extends BaseTestList {}
 
 @Component({
-    selector: 'test-list-with-dynamic-number-of-lines',
     template: `
         <kbq-list>
             @for (item of items; track item) {
                 <kbq-list-item>
                     <h3 kbq-line>{{ item.name }}</h3>
-                    <p kbq-line>{{ item.description }}</p>
-                    @if (showThirdLine) {
-                        <p kbq-line>Some other text</p>
-                    }
-                </kbq-list-item>
-            }
-        </kbq-list>
-    `
-})
-class TestListWithDynamicNumberOfLines extends BaseTestList {}
-
-@Component({
-    selector: 'test-list-with-multiple-items',
-    template: `
-        <kbq-list>
-            @for (item of items; track item) {
-                <kbq-list-item>
-                    {{ item.name }}
                 </kbq-list-item>
             }
         </kbq-list>

--- a/packages/components/list/list.component.spec.ts
+++ b/packages/components/list/list.component.spec.ts
@@ -81,6 +81,7 @@ class BaseTestList {
 }
 
 @Component({
+    selector: 'ListWithOneAnchorItem',
     template: `
         <kbq-list>
             <a kbq-list-item>Paprika</a>
@@ -94,6 +95,7 @@ class ListWithOneAnchorItem extends BaseTestList {
 }
 
 @Component({
+    selector: 'ListWithOneItem',
     template: `
         <kbq-list>
             <kbq-list-item>Paprika</kbq-list-item>
@@ -103,6 +105,7 @@ class ListWithOneAnchorItem extends BaseTestList {
 class ListWithOneItem extends BaseTestList {}
 
 @Component({
+    selector: 'ListWithTwoLineItem',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -118,6 +121,7 @@ class ListWithOneItem extends BaseTestList {}
 class ListWithTwoLineItem extends BaseTestList {}
 
 @Component({
+    selector: 'ListWithThreeLineItem',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -135,6 +139,7 @@ class ListWithThreeLineItem extends BaseTestList {
 }
 
 @Component({
+    selector: 'ListWithManyLines',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -152,6 +157,7 @@ class ListWithManyLines extends BaseTestList {}
 
 @Component({
     template: `
+        selector: 'ListWithAvatar',
         <kbq-list>
             <kbq-list-item>
                 <img alt="" src="" kbq-list-avatar />
@@ -164,6 +170,7 @@ class ListWithManyLines extends BaseTestList {}
 class ListWithAvatar extends BaseTestList {}
 
 @Component({
+    selector: 'ListWithItemWithCssClass',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -178,6 +185,7 @@ class ListWithAvatar extends BaseTestList {}
 class ListWithItemWithCssClass extends BaseTestList {}
 
 @Component({
+    selector: 'ListWithDynamicNumberOfLines',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -195,6 +203,7 @@ class ListWithItemWithCssClass extends BaseTestList {}
 class ListWithDynamicNumberOfLines extends BaseTestList {}
 
 @Component({
+    selector: 'ListWithMultipleItems',
     template: `
         <kbq-list>
             @for (item of items; track item) {

--- a/packages/components/list/list.component.spec.ts
+++ b/packages/components/list/list.component.spec.ts
@@ -81,7 +81,7 @@ class BaseTestList {
 }
 
 @Component({
-    selector: 'ListWithOneAnchorItem',
+    selector: 'test-list-with-one-anchor-item',
     template: `
         <kbq-list>
             <a kbq-list-item>Paprika</a>
@@ -95,7 +95,7 @@ class ListWithOneAnchorItem extends BaseTestList {
 }
 
 @Component({
-    selector: 'ListWithOneItem',
+    selector: 'test-list-with-one-item',
     template: `
         <kbq-list>
             <kbq-list-item>Paprika</kbq-list-item>
@@ -105,7 +105,7 @@ class ListWithOneAnchorItem extends BaseTestList {
 class ListWithOneItem extends BaseTestList {}
 
 @Component({
-    selector: 'ListWithTwoLineItem',
+    selector: 'test-list-with-two-line-item',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -121,7 +121,7 @@ class ListWithOneItem extends BaseTestList {}
 class ListWithTwoLineItem extends BaseTestList {}
 
 @Component({
-    selector: 'ListWithThreeLineItem',
+    selector: 'test-list-with-three-line-item',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -139,7 +139,7 @@ class ListWithThreeLineItem extends BaseTestList {
 }
 
 @Component({
-    selector: 'ListWithManyLines',
+    selector: 'test-list-with-many-lines',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -156,8 +156,8 @@ class ListWithThreeLineItem extends BaseTestList {
 class ListWithManyLines extends BaseTestList {}
 
 @Component({
+    selector: 'test-list-with-avatar',
     template: `
-        selector: 'ListWithAvatar',
         <kbq-list>
             <kbq-list-item>
                 <img alt="" src="" kbq-list-avatar />
@@ -170,7 +170,7 @@ class ListWithManyLines extends BaseTestList {}
 class ListWithAvatar extends BaseTestList {}
 
 @Component({
-    selector: 'ListWithItemWithCssClass',
+    selector: 'test-list-with-item-with-css-class',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -185,7 +185,7 @@ class ListWithAvatar extends BaseTestList {}
 class ListWithItemWithCssClass extends BaseTestList {}
 
 @Component({
-    selector: 'ListWithDynamicNumberOfLines',
+    selector: 'test-list-with-dynamic-number-of-lines',
     template: `
         <kbq-list>
             @for (item of items; track item) {
@@ -203,7 +203,7 @@ class ListWithItemWithCssClass extends BaseTestList {}
 class ListWithDynamicNumberOfLines extends BaseTestList {}
 
 @Component({
-    selector: 'ListWithMultipleItems',
+    selector: 'test-list-with-multiple-items',
     template: `
         <kbq-list>
             @for (item of items; track item) {


### PR DESCRIPTION
- removed component name collision in `list.component.spec.ts`
- added dev example with list-option destroy on keydown