### PR TITLE
fix(input): parsing and validation of fractional values (#DS-4474)

### DIFF
--- a/packages/components/input/input-number.spec.ts
+++ b/packages/components/input/input-number.spec.ts
@@ -936,6 +936,32 @@ describe('KbqNumberInput', () => {
             expect(fixture.componentInstance.value).toBeNull();
         }));
 
+        it('should allow enter fraction separator char after integer part', fakeAsync(() => {
+            const fixture = createComponent(KbqNumberInputMaxMinStep);
+            const localeService = fixture.debugElement.injector.get(KbqLocaleService);
+
+            localeService.setLocale('ru-RU');
+            fixture.detectChanges();
+            flush();
+
+            const fractionSeparator = localeService.current.input.number.fractionSeparator;
+
+            const inputElementDebug = fixture.debugElement.query(By.directive(KbqInput));
+            const inputElement = inputElementDebug.nativeElement;
+
+            inputElement.value = '123';
+            dispatchFakeEvent(inputElement, 'input');
+            fixture.detectChanges();
+            flush();
+
+            inputElement.value = `${inputElement.value}${fractionSeparator}`;
+            dispatchFakeEvent(inputElement, 'input');
+            fixture.detectChanges();
+            flush();
+
+            expect(inputElement.value).toContain(localeService?.current.input.number.fractionSeparator);
+        }));
+
         describe('negative values', () => {
             let fixture: ComponentFixture<KbqNumberInputMaxMinStepInput>;
             let inputElementDebug;

--- a/packages/components/input/input-number.ts
+++ b/packages/components/input/input-number.ts
@@ -517,17 +517,20 @@ export class KbqNumberInput implements KbqFormFieldControl<any>, ControlValueAcc
         const localeId = !this.localeService || this.localeService.id === 'es-LA' ? 'ru-RU' : this.localeService.id;
 
         const formatter = new Intl.NumberFormat(localeId, formatOptions);
-        let formattedFractionPart: string = '';
-
-        for (const numChar of fractionPart || '') {
-            formattedFractionPart += formatter.format(+numChar);
-        }
 
         const formattedIntPart = formatNumberWithLocale(intPart, formatter, this.config);
 
-        return formattedFractionPart === ''
-            ? formattedIntPart
-            : `${formattedIntPart}${this.fractionSeparator}${formattedFractionPart}`;
+        if (fractionPart === undefined) {
+            return formattedIntPart;
+        }
+
+        let formattedFractionPart: string = '';
+
+        for (const numChar of fractionPart) {
+            formattedFractionPart += formatter.format(+numChar);
+        }
+
+        return `${formattedIntPart}${this.fractionSeparator}${formattedFractionPart}`;
     }
 
     private updateLocaleParams = () => {


### PR DESCRIPTION
## Summary

Only skip fraction part when it's undefined.

<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

Не добавлять разделитель и число после запятой , только если на предыдущем этапе `fractionPart === undefined`

</details>

