### PR TITLE
fix(docs): tokens optimization (#DS-3117)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,6 +28,11 @@
                 "build": {
                     "builder": "@angular-devkit/build-angular:application",
                     "options": {
+                        "optimization": {
+                            "styles": {
+                                "inlineCritical": false
+                            }
+                        },
                         "outputPath": {
                             "base": "dist/releases/koobiq-docs"
                         },
@@ -80,10 +85,7 @@
                             "includePaths": ["dist", "apps/docs/src"]
                         },
                         "styles": [
-                            "apps/docs/src/main.scss",
-                            "apps/docs/src/styles/koobiq/default-theme/css-tokens.css",
-                            "apps/docs/src/styles/koobiq/default-theme/css-tokens-dark.css",
-                            "apps/docs/src/styles/koobiq/default-theme/css-tokens-light.css"
+                            "apps/docs/src/main.scss"
                         ],
                         "scripts": [],
                         "namedChunks": true,

--- a/angular.json
+++ b/angular.json
@@ -79,7 +79,12 @@
                         "stylePreprocessorOptions": {
                             "includePaths": ["dist", "apps/docs/src"]
                         },
-                        "styles": ["apps/docs/src/main.scss"],
+                        "styles": [
+                            "apps/docs/src/main.scss",
+                            "apps/docs/src/styles/koobiq/default-theme/css-tokens.css",
+                            "apps/docs/src/styles/koobiq/default-theme/css-tokens-dark.css",
+                            "apps/docs/src/styles/koobiq/default-theme/css-tokens-light.css"
+                        ],
                         "scripts": [],
                         "namedChunks": true,
                         "browser": "apps/docs/src/main.ts",

--- a/apps/docs/src/main.scss
+++ b/apps/docs/src/main.scss
@@ -1,3 +1,4 @@
+@use 'styles/koobiq';
 @use '@koobiq/icons/fonts/kbq-icons';
 @use './styles/fonts';
 @use './styles/theme-kbq';

--- a/apps/docs/src/main.scss
+++ b/apps/docs/src/main.scss
@@ -7,10 +7,6 @@
 @use './styles/examples';
 @use './styles/code-snippet';
 
-@use './styles/koobiq/default-theme/css-tokens.css';
-@use './styles/koobiq/default-theme/css-tokens-dark.css';
-@use './styles/koobiq/default-theme/css-tokens-light.css';
-
 // Import theme
 // https://github.com/koobiq/data-grid/blob/main/packages/ag-grid-angular-theme/README.md
 @use '@koobiq/ag-grid-angular-theme';

--- a/apps/docs/src/styles/koobiq/_index.scss
+++ b/apps/docs/src/styles/koobiq/_index.scss
@@ -1,4 +1,3 @@
-@forward 'typography';
-
-@forward 'default-theme/theme' as default-theme-*;
-@forward 'default-theme/tokens' as default-tokens-*;
+@forward 'default-theme/css-tokens.css';
+@forward 'default-theme/css-tokens-dark.css';
+@forward 'default-theme/css-tokens-light.css';

--- a/apps/docs/src/styles/koobiq/_typography.scss
+++ b/apps/docs/src/styles/koobiq/_typography.scss
@@ -1,9 +1,0 @@
-@use 'sass:meta';
-
-@use 'components/core/styles/typography/typography';
-@use 'default-theme/tokens';
-
-$tokens: meta.module-variables(tokens);
-
-$typography-config: typography.kbq-typography-config($tokens);
-$markdown-typography-config: typography.kbq-markdown-typography-config($tokens);

--- a/apps/docs/src/styles/koobiq/default-theme/_theme.scss
+++ b/apps/docs/src/styles/koobiq/default-theme/_theme.scss
@@ -1,9 +1,0 @@
-@use 'sass:meta';
-
-@use '../dist/components/core/styles/theming/theming';
-@use 'tokens';
-
-$tokens: meta.module-variables(tokens);
-
-$light: theming.kbq-light-theme($tokens);
-$dark: theming.kbq-dark-theme($tokens);

--- a/apps/docs/src/styles/koobiq/default-theme/tokens.scss
+++ b/apps/docs/src/styles/koobiq/default-theme/tokens.scss
@@ -1,4 +1,0 @@
-@forward 'variables';
-@forward 'palette';
-@forward 'typography';
-@forward 'md-typography';

--- a/packages/components-dev/main.scss
+++ b/packages/components-dev/main.scss
@@ -6,9 +6,7 @@
 
 @use '../components/core/styles/common/list';
 
-@use '../../apps/docs/src/styles/koobiq/default-theme/css-tokens.css';
-@use '../../apps/docs/src/styles/koobiq/default-theme/css-tokens-light.css';
-@use '../../apps/docs/src/styles/koobiq/default-theme/css-tokens-dark.css';
+@use '../../apps/docs/src/styles/koobiq';
 
 @use '../../apps/docs/src/styles/fonts';
 

--- a/packages/e2e/main.scss
+++ b/packages/e2e/main.scss
@@ -6,9 +6,7 @@
 
 @use '../components/core/styles/common/list';
 
-@use '../../apps/docs/src/styles/koobiq/default-theme/css-tokens.css';
-@use '../../apps/docs/src/styles/koobiq/default-theme/css-tokens-light.css';
-@use '../../apps/docs/src/styles/koobiq/default-theme/css-tokens-dark.css';
+@use '../../apps/docs/src/styles/koobiq';
 
 @use '../../apps/docs/src/styles/fonts';
 


### PR DESCRIPTION
## Summary

removed styles duplications.

Somehow koobiq css vars where inlined in `<style>` tag and also for bundled external css file.

By saying somehow, I don't mean magic 🙂 

Angular CLI uses critters plugin to analyze build and inline those styles that was qualified as critical.

But that was the problem - styles got duplicated. 

