### PR TITLE
chore(file-upload): refactoring, updated imports, docs (#DS-3748)

### DIFF
--- a/packages/components/file-upload/file-upload.ts
+++ b/packages/components/file-upload/file-upload.ts
@@ -24,6 +24,10 @@ export interface KbqFileItem {
     progress?: BehaviorSubject<number>;
 }
 
+/**
+ * @docs-private
+ * @deprecated Will be removed in next major release
+ */
 export interface KbqInputFile {
     disabled: boolean;
     accept?: string[];

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -24,8 +24,8 @@ import { ControlValueAccessor } from '@angular/forms';
 import { ErrorStateMatcher, KbqDataSizePipe, ruRULocaleData } from '@koobiq/components/core';
 import { KbqEllipsisCenterDirective } from '@koobiq/components/ellipsis-center';
 import { KbqHint } from '@koobiq/components/form-field';
-import { KbqIconModule } from '@koobiq/components/icon';
-import { KbqLinkModule } from '@koobiq/components/link';
+import { KbqIcon, KbqIconButton } from '@koobiq/components/icon';
+import { KbqLink } from '@koobiq/components/link';
 import { KbqListModule } from '@koobiq/components/list';
 import { KbqProgressSpinnerModule, ProgressSpinnerMode } from '@koobiq/components/progress-spinner';
 import { BehaviorSubject, skip } from 'rxjs';
@@ -35,7 +35,6 @@ import {
     KbqFileItem,
     KbqFileUploadBase,
     KbqFileValidatorFn,
-    KbqInputFile,
     KbqInputFileLabel
 } from './file-upload';
 import { KbqFileDropDirective, KbqFileList, KbqFileLoader, KbqFileUploadContext } from './primitives';
@@ -61,14 +60,15 @@ const fileSizeCellPadding = 16;
 @Component({
     selector: 'kbq-multiple-file-upload,kbq-file-upload[multiple]',
     imports: [
+        AsyncPipe,
+        NgTemplateOutlet,
         KbqFileDropDirective,
-        KbqIconModule,
-        KbqLinkModule,
+        KbqIconButton,
+        KbqIcon,
+        KbqLink,
         KbqListModule,
         KbqDataSizePipe,
         KbqProgressSpinnerModule,
-        AsyncPipe,
-        NgTemplateOutlet,
         KbqEllipsisCenterDirective,
         KbqFileLoader
     ],
@@ -89,7 +89,7 @@ const fileSizeCellPadding = 16;
 })
 export class KbqMultipleFileUploadComponent
     extends KbqFileUploadBase
-    implements AfterViewInit, KbqInputFile, ControlValueAccessor, DoCheck
+    implements AfterViewInit, ControlValueAccessor, DoCheck
 {
     /**
      * A value responsible for progress spinner type.

--- a/packages/components/file-upload/primitives/file-picker.ts
+++ b/packages/components/file-upload/primitives/file-picker.ts
@@ -87,6 +87,7 @@ export class KbqFileLoader {
     /** Event fires when file selected in file-picker. */
     readonly fileChange = output<Event>();
 
+    /** Underlying file input element */
     readonly input = viewChild.required<ElementRef<HTMLInputElement>>('input');
 
     /** @docs-private */

--- a/packages/components/file-upload/single-file-upload.component.ts
+++ b/packages/components/file-upload/single-file-upload.component.ts
@@ -23,8 +23,8 @@ import { ControlValueAccessor, FormControlStatus } from '@angular/forms';
 import { ErrorStateMatcher, KbqDataSizePipe, ruRULocaleData } from '@koobiq/components/core';
 import { KbqEllipsisCenterDirective } from '@koobiq/components/ellipsis-center';
 import { KbqHint } from '@koobiq/components/form-field';
-import { KbqIconModule } from '@koobiq/components/icon';
-import { KbqLinkModule } from '@koobiq/components/link';
+import { KbqIcon, KbqIconButton } from '@koobiq/components/icon';
+import { KbqLink } from '@koobiq/components/link';
 import { KbqProgressSpinner, ProgressSpinnerMode } from '@koobiq/components/progress-spinner';
 import { BehaviorSubject, skip } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
@@ -34,7 +34,6 @@ import {
     KbqFileItem,
     KbqFileUploadBase,
     KbqFileValidatorFn,
-    KbqInputFile,
     KbqInputFileLabel
 } from './file-upload';
 import { KbqFileDropDirective, KbqFileList, KbqFileLoader, KbqFileUploadContext } from './primitives';
@@ -46,11 +45,12 @@ export const KBQ_SINGLE_FILE_UPLOAD_DEFAULT_CONFIGURATION: KbqInputFileLabel = r
 @Component({
     selector: 'kbq-single-file-upload,kbq-file-upload:not([multiple])',
     imports: [
-        KbqFileDropDirective,
-        KbqLinkModule,
-        KbqIconModule,
-        KbqProgressSpinner,
         AsyncPipe,
+        KbqFileDropDirective,
+        KbqLink,
+        KbqIcon,
+        KbqIconButton,
+        KbqProgressSpinner,
         KbqEllipsisCenterDirective,
         KbqDataSizePipe,
         KbqFileLoader
@@ -72,7 +72,7 @@ export const KBQ_SINGLE_FILE_UPLOAD_DEFAULT_CONFIGURATION: KbqInputFileLabel = r
 })
 export class KbqSingleFileUploadComponent
     extends KbqFileUploadBase
-    implements AfterViewInit, KbqInputFile, ControlValueAccessor, DoCheck
+    implements AfterViewInit, ControlValueAccessor, DoCheck
 {
     /**
      * A value responsible for progress spinner type.
@@ -270,6 +270,19 @@ export class KbqSingleFileUploadComponent
     }
 
     /** @docs-private */
+    onFileDropped(files: KbqFile[]): void {
+        if (this.disabled) return;
+
+        if (files?.length) {
+            this.file = this.mapToFileItem(files[0]);
+            this.fileChange.emit(this.file);
+        }
+
+        // mark as touched after file drop even if file wasn't correct
+        this.onTouched();
+    }
+
+    /** @docs-private */
     deleteItem(event?: MouseEvent, origin?: FocusOrigin): void {
         if (this.disabled) return;
 
@@ -291,21 +304,6 @@ export class KbqSingleFileUploadComponent
 
             return;
         }
-    }
-
-    /** @docs-private */
-    onFileDropped(files: KbqFile[]): void {
-        if (this.disabled) {
-            return;
-        }
-
-        if (files?.length) {
-            this.file = this.mapToFileItem(files[0]);
-            this.fileChange.emit(this.file);
-        }
-
-        // mark as touched after file drop even if file wasn't correct
-        this.onTouched();
     }
 
     private updateLocaleParams = () => {

--- a/tools/public_api_guard/components/file-upload.api.md
+++ b/tools/public_api_guard/components/file-upload.api.md
@@ -113,7 +113,6 @@ export class KbqFileLoader {
     protected readonly innerFor: Signal<string | null>;
     protected readonly innerMultiple: Signal<boolean | null>;
     protected readonly innerOnlyDirectory: Signal<boolean | null>;
-    // (undocumented)
     readonly input: Signal<ElementRef<HTMLInputElement>>;
     multiple: InputSignal<boolean | null>;
     onlyDirectory: InputSignal<boolean | null>;
@@ -178,7 +177,7 @@ export class KbqFileUploadModule {
 // @public @deprecated (undocumented)
 export type KbqFileValidatorFn = (file: File) => string | null;
 
-// @public (undocumented)
+// @public @deprecated
 export interface KbqInputFile {
     // (undocumented)
     accept?: string[];
@@ -216,7 +215,7 @@ export interface KbqInputFileMultipleLabel extends KbqInputFileLabel {
 }
 
 // @public (undocumented)
-export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements AfterViewInit, KbqInputFile, ControlValueAccessor, DoCheck {
+export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements AfterViewInit, ControlValueAccessor, DoCheck {
     constructor();
     accept?: string[];
     get acceptedFiles(): string;
@@ -276,7 +275,7 @@ export class KbqMultipleFileUploadComponent extends KbqFileUploadBase implements
 }
 
 // @public (undocumented)
-export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements AfterViewInit, KbqInputFile, ControlValueAccessor, DoCheck {
+export class KbqSingleFileUploadComponent extends KbqFileUploadBase implements AfterViewInit, ControlValueAccessor, DoCheck {
     constructor();
     accept?: string[];
     get acceptedFiles(): string;


### PR DESCRIPTION
## Summary

- Updated imports (Components instead of modules where possible)
- Deprecated `KbqInputFile` - it's not needed

<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

- Обновил импорты (Компоненты вместо модулей где возможно)
- Задепрекейтил `KbqInputFile` - он не нужен

</details>

