### PR TITLE
fix(progress-spinner): scrollbar shows because of spinner overflow (#DS-4565)

### DIFF
--- a/packages/components-dev/progress-spinner/styles.scss
+++ b/packages/components-dev/progress-spinner/styles.scss
@@ -21,4 +21,8 @@
     .dev-spinner-container {
         margin-top: 16px;
     }
+
+    .dev-spinner-container__with-overflow {
+        overflow-y: auto;
+    }
 }

--- a/packages/components-dev/progress-spinner/template.html
+++ b/packages/components-dev/progress-spinner/template.html
@@ -20,6 +20,12 @@
                 </kbq-progress-spinner>
             </li>
 
+            <li class="dev-spinner-container dev-spinner-container__with-overflow">
+                <kbq-progress-spinner [mode]="mode" [value]="percent">
+                    <div kbq-progress-spinner-text>kbq-progress-spinner-text with overflow in parent container</div>
+                </kbq-progress-spinner>
+            </li>
+
             <li class="dev-spinner-container">
                 <kbq-progress-spinner [mode]="mode" [value]="percent">
                     <div kbq-progress-spinner-text>kbq-progress-spinner-text</div>

--- a/packages/components/progress-spinner/progress-spinner.scss
+++ b/packages/components/progress-spinner/progress-spinner.scss
@@ -13,6 +13,7 @@
 .kbq-progress-spinner {
     display: flex;
     flex-direction: row;
+    overflow-y: hidden;
 }
 
 .kbq-progress-spinner__circle {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
-->

## Summary

In case progress-spinner is placed in a container with `overflow-y: auto` (`.kbq-modal-body` for example) it will cause scrollbar to appear when hovering over with mouse:

<img width="416" height="573" alt="image" src="https://github.com/user-attachments/assets/1e9b488d-43f2-489f-850d-b1dfd8f3df6e" />

## List of notable changes:



## What should reviewers focus on?

