### PR TITLE
fix(dropdown): aligned visibility on small viewport (#DS-4460)

### DIFF
--- a/packages/components/dropdown/dropdown-trigger.directive.ts
+++ b/packages/components/dropdown/dropdown-trigger.directive.ts
@@ -444,9 +444,7 @@ export class KbqDropdownTrigger implements AfterContentInit, OnDestroy {
             positionStrategy: this.overlay
                 .position()
                 .flexibleConnectedTo(this.elementRef)
-                .withLockedPosition()
-                .withTransformOriginOn('.kbq-dropdown__panel')
-                .withFlexibleDimensions(false),
+                .withTransformOriginOn('.kbq-dropdown__panel'),
             backdropClass: this.dropdown.backdropClass || 'cdk-overlay-transparent-backdrop',
             scrollStrategy: this.scrollStrategy(),
             direction: this.dir

--- a/packages/components/dropdown/dropdown.scss
+++ b/packages/components/dropdown/dropdown.scss
@@ -32,6 +32,7 @@
 }
 
 .kbq-dropdown__panel {
+    overflow: auto;
     min-width: var(--kbq-dropdown-size-container-width-min);
     max-width: var(--kbq-dropdown-size-container-width-max);
 

--- a/packages/docs-examples/components/modal/modal-component/modal-component-example.ts
+++ b/packages/docs-examples/components/modal/modal-component/modal-component-example.ts
@@ -1,17 +1,86 @@
 import { ChangeDetectionStrategy, Component, inject, Input } from '@angular/core';
 import { KbqButtonModule } from '@koobiq/components/button';
+import { KbqOptgroup } from '@koobiq/components/core';
+import { KbqDivider } from '@koobiq/components/divider';
+import { KbqDropdownModule } from '@koobiq/components/dropdown';
+import { KbqIcon } from '@koobiq/components/icon';
 import { KbqModalModule, KbqModalRef, KbqModalService } from '@koobiq/components/modal';
+import { KbqTitleDirective } from '@koobiq/components/title';
 
 @Component({
     selector: 'custom-modal',
     imports: [
         KbqModalModule,
-        KbqButtonModule
+        KbqButtonModule,
+        KbqDivider,
+        KbqDropdownModule,
+        KbqIcon,
+        KbqOptgroup,
+        KbqTitleDirective
     ],
     template: `
         <kbq-modal-title>{{ title }}</kbq-modal-title>
 
-        <kbq-modal-body>{{ subtitle }}</kbq-modal-body>
+        <kbq-modal-body>
+            <div class="layout-margin-bottom-l">{{ subtitle }}</div>
+            <button kbq-button [kbqDropdownTriggerFor]="appDropdown">
+                dropdown
+                <i kbq-icon="kbq-chevron-down-s_16"></i>
+            </button>
+
+            <kbq-dropdown #appDropdown="kbqDropdown">
+                <button kbq-dropdown-item>Text Normal</button>
+
+                <button kbq-dropdown-item>
+                    <i kbq-icon="kbq-circle-info_16" [color]="'contrast'"></i>
+                    Text Normal
+                </button>
+
+                <button kbq-dropdown-item>
+                    Text Normal
+                    <div class="kbq-dropdown-item__caption">Caption</div>
+                </button>
+
+                <button kbq-dropdown-item>
+                    <i kbq-icon="kbq-circle-info_16" [color]="'contrast'"></i>
+                    Text Normal
+                    <div class="kbq-dropdown-item__caption">Caption</div>
+                </button>
+
+                <button kbq-dropdown-item>
+                    <i kbq-icon="kbq-circle-xs_16" [color]="'contrast'"></i>
+                    Text Normal
+                </button>
+
+                <button kbq-dropdown-item kbq-title>
+                    Text Normal and very long text Text Normal and very long text Text Normal and very long text Text
+                    Normal and very long text
+                </button>
+
+                <kbq-divider />
+
+                <div class="kbq-dropdown__group-header">Header</div>
+
+                <button disabled kbq-dropdown-item>Disabled</button>
+
+                <kbq-divider />
+
+                <kbq-optgroup label="Subheading" />
+
+                <button disabled kbq-dropdown-item>
+                    <i kbq-icon="kbq-circle-xs_16" [color]="'contrast'"></i>
+                    Disabled with icon
+                </button>
+
+                <kbq-divider />
+
+                <button kbq-dropdown-item>Point 2</button>
+
+                <button kbq-dropdown-item>Point 3</button>
+
+                <button kbq-dropdown-item>Link</button>
+            </kbq-dropdown>
+        </kbq-modal-body>
 
         <div kbq-modal-footer>
             <button kbq-button [color]="'contrast'" (click)="destroyModal('save')">Save</button>


### PR DESCRIPTION
## Summary

Removed `withLockedPosition` - to not use `reapplyLastPosition` on scroll and to not introduce side effects.


<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

Удален параметр `withLockedPosition` - чтобы не применялся метод `reapplyLastPosition` и не вызывались сайд эффекты

</details>


https://github.com/user-attachments/assets/f5249db7-7a90-49e5-bd2a-cdd9f6157a3a


https://github.com/user-attachments/assets/1b635146-3503-4469-821d-c4e9f28bb1a6


