### PR TITLE
chore(docs): reload button (#DS-2993)

### DIFF
--- a/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.html
+++ b/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.html
@@ -1,6 +1,10 @@
 <div class="docs-live-example__container">
     @if (exampleData) {
-        <div class="docs-live-example__example docs-live-example__example_{{ exampleId }}">
+        <div
+            #exampleElement
+            class="docs-live-example__example docs-live-example__example_{{ exampleId }}"
+            [style.height.px]="exampleHeight()"
+        >
             @if (exampleComponentType) {
                 <ng-template [ngComponentOutlet]="exampleComponentType" />
             }
@@ -20,7 +24,11 @@
             }}
         </span>
 
-        <docs-stackblitz-button [exampleId]="exampleId" />
+        <div class="layout-row layout-gap-xxs layout-align-center-center">
+            <i kbq-icon-button="kbq-arrow-rotate-left_16" [color]="'theme'" (click)="reload()"></i>
+            <kbq-divider class="docs-live-example-footer__divider" [vertical]="true" />
+            <docs-stackblitz-button [exampleId]="exampleId" />
+        </div>
     </div>
 </div>
 

--- a/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.html
+++ b/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.html
@@ -24,8 +24,18 @@
             }}
         </span>
 
-        <div class="layout-row layout-gap-xxs layout-align-center-center">
-            <i kbq-icon-button="kbq-arrow-rotate-left_16" [color]="'theme'" (click)="reload()"></i>
+        <div class="layout-row layout-align-center-center">
+            <button
+                kbq-button
+                class="docs-live-example-footer__reload-button"
+                [color]="'theme'"
+                [kbqStyle]="'transparent'"
+                [kbqTooltip]="isRuLocale() ? 'Сбросить состояние' : 'Reset state'"
+                [kbqPlacement]="'bottom'"
+                (click)="reload()"
+            >
+                <i kbq-icon="kbq-arrow-rotate-left_16"></i>
+            </button>
             <kbq-divider class="docs-live-example-footer__divider" [vertical]="true" />
             <docs-stackblitz-button [exampleId]="exampleId" />
         </div>

--- a/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.scss
+++ b/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.scss
@@ -27,6 +27,10 @@
     justify-content: space-between;
 
     padding: var(--kbq-size-m) var(--kbq-size-xl);
+
+    .docs-live-example-footer__divider {
+        height: var(--kbq-size-s);
+    }
 }
 
 .docs-example-vertical-margin {

--- a/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.scss
+++ b/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.scss
@@ -28,8 +28,15 @@
 
     padding: var(--kbq-size-m) var(--kbq-size-xl);
 
-    .docs-live-example-footer__divider {
+    .docs-live-example-footer__reload-button {
+        --kbq-button-size-height: var(--kbq-size-xxl);
+        width: var(--kbq-size-xxl);
+    }
+
+    .docs-live-example-footer__divider.kbq-divider {
         height: var(--kbq-size-s);
+        --kbq-divider-size-vertical-margin-horizontal: var(--kbq-size-s);
+        margin-left: var(--kbq-size-xxs);
     }
 }
 

--- a/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.ts
+++ b/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.ts
@@ -97,9 +97,9 @@ export class DocsLiveExampleViewerComponent extends DocsLocaleState {
     private readonly httpClient = inject(HttpClient);
     private readonly cdr = inject(ChangeDetectorRef);
     private readonly window = inject(KBQ_WINDOW);
-    private readonly sidepanelService = inject(KbqSidepanelService);
-    private readonly modalService = inject(KbqModalService);
-    private readonly toastService = inject(KbqToastService);
+    private readonly sidepanelService = inject(KbqSidepanelService, { optional: true });
+    private readonly modalService = inject(KbqModalService, { optional: true });
+    private readonly toastService = inject(KbqToastService, { optional: true });
 
     toggleSourceView() {
         this.isSourceShown = !this.isSourceShown;
@@ -119,9 +119,9 @@ export class DocsLiveExampleViewerComponent extends DocsLocaleState {
         this._example = '';
         this.exampleComponentType = null;
 
-        this.sidepanelService.closeAll();
-        this.modalService.closeAll();
-        this.toastService.toasts.forEach(({ instance }) => this.toastService.hide(instance.id));
+        this.sidepanelService?.closeAll();
+        this.modalService?.closeAll();
+        this.toastService?.toasts.forEach(({ instance }) => this.toastService?.hide(instance.id));
 
         this.example = previous;
     }

--- a/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.ts
+++ b/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.ts
@@ -16,6 +16,9 @@ import { KBQ_WINDOW } from '@koobiq/components/core';
 import { KbqDivider } from '@koobiq/components/divider';
 import { KbqIconButton } from '@koobiq/components/icon';
 import { KbqLinkModule } from '@koobiq/components/link';
+import { KbqModalService } from '@koobiq/components/modal';
+import { KbqSidepanelService } from '@koobiq/components/sidepanel';
+import { KbqToastService } from '@koobiq/components/toast';
 import { EXAMPLE_COMPONENTS, LiveExample, loadExample } from '@koobiq/docs-examples';
 import { forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -94,6 +97,9 @@ export class DocsLiveExampleViewerComponent extends DocsLocaleState {
     private readonly httpClient = inject(HttpClient);
     private readonly cdr = inject(ChangeDetectorRef);
     private readonly window = inject(KBQ_WINDOW);
+    private readonly sidepanelService = inject(KbqSidepanelService);
+    private readonly modalService = inject(KbqModalService);
+    private readonly toastService = inject(KbqToastService);
 
     toggleSourceView() {
         this.isSourceShown = !this.isSourceShown;
@@ -112,6 +118,10 @@ export class DocsLiveExampleViewerComponent extends DocsLocaleState {
 
         this._example = '';
         this.exampleComponentType = null;
+
+        this.sidepanelService.closeAll();
+        this.modalService.closeAll();
+        this.toastService.toasts.forEach(({ instance }) => this.toastService.hide(instance.id));
 
         this.example = previous;
     }

--- a/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.ts
+++ b/apps/docs/src/app/components/live-example-viewer/docs-live-example-viewer.ts
@@ -11,14 +11,16 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
+import { KbqButton, KbqButtonCssStyler } from '@koobiq/components/button';
 import { KbqCodeBlockFile, KbqCodeBlockModule } from '@koobiq/components/code-block';
 import { KBQ_WINDOW } from '@koobiq/components/core';
 import { KbqDivider } from '@koobiq/components/divider';
-import { KbqIconButton } from '@koobiq/components/icon';
+import { KbqIcon } from '@koobiq/components/icon';
 import { KbqLinkModule } from '@koobiq/components/link';
 import { KbqModalService } from '@koobiq/components/modal';
 import { KbqSidepanelService } from '@koobiq/components/sidepanel';
 import { KbqToastService } from '@koobiq/components/toast';
+import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { EXAMPLE_COMPONENTS, LiveExample, loadExample } from '@koobiq/docs-examples';
 import { forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -41,8 +43,11 @@ interface ExampleFileData {
         KbqLinkModule,
         KbqCodeBlockModule,
         NgComponentOutlet,
-        KbqIconButton,
-        KbqDivider
+        KbqButton,
+        KbqButtonCssStyler,
+        KbqIcon,
+        KbqDivider,
+        KbqTooltipTrigger
     ],
     templateUrl: './docs-live-example-viewer.html',
     styleUrls: ['./docs-live-example-viewer.scss'],


### PR DESCRIPTION
## Summary

* Store the previous `example` value before reset.
* Clear `_example` and `exampleComponentType` to force full component re-creation.
* Restore the previous example to trigger re-render.
* Recalculate actual content height (excluding paddings) and update `exampleHeight` to prevent layout jumps.
* Reset `exampleHeight` after async load completes.

<details>
  <summary><strong>Press for description in ru-RU</strong></summary>


Добавлена функциональность перезагрузки example.

* Сохраняем предыдущее значение `example` перед сбросом.
* Очищаем `_example` и `exampleComponentType`, чтобы принудительно пересоздать компонент.
* Восстанавливаем предыдущее значение для повторного рендера.
* Пересчитываем фактическую высоту контента (без паддингов) и обновляем `exampleHeight`, чтобы контент не прыгал.
* Сбрасываем `exampleHeight` после завершения асинхронной загрузки.

</details>