### PR TITLE
fix(tags): add emitOnTagChanges to control change emissions (#DS-4634)

### DIFF
--- a/apps/docs/src/app/structure.ts
+++ b/apps/docs/src/app/structure.ts
@@ -1103,8 +1103,7 @@ const structure: DocsStructure = makeStructure({
                     },
                     svgPreview: 'validation',
                     hasApi: false,
-                    hasExamples: false,
-                    isNew: expiresAt('2025-08-17')
+                    hasExamples: true
                 }
             ]
         }

--- a/packages/components-dev/validation/module.ts
+++ b/packages/components-dev/validation/module.ts
@@ -41,6 +41,7 @@ function ldapLoginValidator(loginRegex: RegExp): ValidatorFn {
     selector: 'dev-examples',
     imports: [ValidationExamplesModule],
     template: `
+        <validation-tag-list-example />
         <validation-on-open-example />
         <validation-optional-label-example />
         <validation-required-label-example />
@@ -198,11 +199,14 @@ export class DevApp {
     }
 
     reactiveInputOnCreate(event: KbqTagInputEvent): void {
+        console.log(event);
         const input = event.input;
         const value = event.value;
+        const control = this.reactiveForm.controls['reactiveTypeaheadValue'];
 
         if ((value || '').trim()) {
             this.reactiveTypeaheadItems.push(value.trim());
+            control.patchValue(this.reactiveTypeaheadItems);
         }
 
         if (input) {
@@ -226,16 +230,22 @@ export class DevApp {
     reactiveInputOnRemoveTag(tag: string): void {
         const index = this.reactiveTypeaheadItems.indexOf(tag);
 
+        const control = this.reactiveForm.controls['reactiveTypeaheadValue'];
+
         if (index >= 0) {
             this.reactiveTypeaheadItems.splice(index, 1);
+            control.patchValue(this.reactiveTypeaheadItems.slice());
         }
     }
 
     reactiveFormControlInputOnRemoveTag(tag: string): void {
         const index = this.reactiveFormControlTypeaheadItems.indexOf(tag);
 
+        const control = this.reactiveForm.controls['reactiveTypeaheadValue'];
+
         if (index >= 0) {
             this.reactiveFormControlTypeaheadItems.splice(index, 1);
+            control.patchValue(this.reactiveFormControlTypeaheadItems.slice());
         }
     }
 

--- a/packages/components/core/validation/examples.validation.en.md
+++ b/packages/components/core/validation/examples.validation.en.md
@@ -1,0 +1,1 @@
+<!-- example(validation-tag-list) -->

--- a/packages/components/core/validation/examples.validation.ru.md
+++ b/packages/components/core/validation/examples.validation.ru.md
@@ -1,0 +1,1 @@
+<!-- example(validation-tag-list) -->

--- a/packages/components/tags/tag-list.component.spec.ts
+++ b/packages/components/tags/tag-list.component.spec.ts
@@ -826,14 +826,26 @@ describe(KbqTagList.name, () => {
             expect(fixture.componentInstance.control.touched).toBe(false);
         });
 
-        // todo need rethink this selection logic
-        xit('should not set the control to dirty when the value changes programmatically', () => {
+        it('should not set the control to dirty when the value changes programmatically', () => {
             expect(fixture.componentInstance.control.dirty).toEqual(false);
 
             fixture.componentInstance.control.setValue(['pizza-1']);
 
             expect(fixture.componentInstance.control.dirty).toEqual(false);
         });
+
+        it('should not set the control to dirty when rendered tags changed programmatically', fakeAsync(() => {
+            expect(fixture.componentInstance.control.dirty).toEqual(false);
+
+            fixture.componentInstance.emitOnTagChanges = false;
+            fixture.detectChanges();
+            fixture.componentInstance.foods = [...fixture.componentInstance.foods, 'pizza-1'];
+
+            fixture.detectChanges();
+            tick(100);
+
+            expect(fixture.componentInstance.control.dirty).toEqual(false);
+        }));
 
         xit('should set an asterisk after the placeholder if the control is required', () => {
             let requiredMarker = fixture.debugElement.query(By.css('.kbq-form-field-required-marker'));
@@ -1610,7 +1622,13 @@ class BasicTagList {
     ],
     template: `
         <kbq-form-field>
-            <kbq-tag-list #tagList1 placeholder="Food" [formControl]="control" [required]="isRequired">
+            <kbq-tag-list
+                #tagList1
+                placeholder="Food"
+                [formControl]="control"
+                [required]="isRequired"
+                [emitOnTagChanges]="emitOnTagChanges"
+            >
                 @for (food of foods; track food) {
                     <kbq-tag [value]="food.value" (removed)="remove(food)">
                         {{ food.viewValue }}
@@ -1628,6 +1646,7 @@ class BasicTagList {
     `
 })
 class InputTagList {
+    emitOnTagChanges = true;
     foods: any[] = [
         { value: 'steak-0', viewValue: 'Steak' },
         { value: 'pizza-1', viewValue: 'Pizza' },

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -315,6 +315,12 @@ export class KbqTagList
     /** Whether the tags in the list are editable. */
     @Input({ transform: booleanAttribute }) editable = false;
 
+    /**
+     * Whether to emit change events when tags are added/removed.
+     * Set to `false` to prevent the form control from being marked as dirty during programmatic updates.
+     */
+    @Input({ transform: booleanAttribute }) emitOnTagChanges = true;
+
     /** Whether the tags in the list are removable. */
     @Input({ transform: booleanAttribute })
     get removable(): boolean {
@@ -503,7 +509,7 @@ export class KbqTagList
                     this.stateChanges.next();
 
                     // do not call on initial
-                    if (currentTags) {
+                    if (currentTags && this.emitOnTagChanges) {
                         this.propagateTagsChanges();
                     }
                 });

--- a/packages/docs-examples/components/validation/index.ts
+++ b/packages/docs-examples/components/validation/index.ts
@@ -10,6 +10,7 @@ import { ValidationOnSubmitExample } from './validation-on-submit/validation-on-
 import { ValidationOnTypeExample } from './validation-on-type/validation-on-type-example';
 import { ValidationOptionalLabelExample } from './validation-optional-label/validation-optional-label-example';
 import { ValidationRequiredLabelExample } from './validation-required-label/validation-required-label-example';
+import { ValidationTagListExample } from './validation-tag-list/validation-tag-list-example';
 
 export {
     ValidationMessageForSpecificFieldExample,
@@ -22,7 +23,8 @@ export {
     ValidationOnSubmitExample,
     ValidationOnTypeExample,
     ValidationOptionalLabelExample,
-    ValidationRequiredLabelExample
+    ValidationRequiredLabelExample,
+    ValidationTagListExample
 };
 
 const EXAMPLES = [
@@ -36,7 +38,8 @@ const EXAMPLES = [
     ValidationRequiredLabelExample,
     ValidationMessageForSpecificFieldExample,
     ValidationMessageGlobalExample,
-    ValidationNoMessageExample
+    ValidationNoMessageExample,
+    ValidationTagListExample
 ];
 
 @NgModule({

--- a/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
+++ b/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
@@ -10,7 +10,7 @@ import {
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
 import { KbqIcon } from '@koobiq/components/icon';
 import { KbqInputModule } from '@koobiq/components/input';
-import { KbqTag, KbqTagInput, KbqTagInputEvent, KbqTagList, KbqTagRemove } from '@koobiq/components/tags';
+import { KbqTagInputEvent, KbqTagsModule } from '@koobiq/components/tags';
 import { KbqToolTipModule } from '@koobiq/components/tooltip';
 
 /**
@@ -25,10 +25,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
         KbqToolTipModule,
         KbqButtonModule,
         KbqIcon,
-        KbqTag,
-        KbqTagInput,
-        KbqTagList,
-        KbqTagRemove
+        KbqTagsModule
     ],
     template: `
         <form
@@ -38,7 +35,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
             (ngSubmit)="onSubmitReactiveForm(reactiveForm)"
         >
             <kbq-form-field class="layout-margin-bottom-l">
-                <kbq-tag-list #inputTagList formControlName="reactiveTypeaheadValue">
+                <kbq-tag-list #inputTagList formControlName="reactiveTypeaheadValue" [emitOnTagChanges]="false">
                     @for (tag of reactiveForm.controls['reactiveTypeaheadValue'].value; track tag) {
                         <kbq-tag [value]="tag" (removed)="reactiveInputOnRemoveTag(tag)">
                             {{ tag }}
@@ -54,7 +51,9 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
                     />
                 </kbq-tag-list>
 
-                <kbq-error>asd</kbq-error>
+                @if (inputTagList.errorState) {
+                    <kbq-error>Required</kbq-error>
+                }
 
                 <kbq-hint>Provide only latin letters</kbq-hint>
             </kbq-form-field>
@@ -113,6 +112,7 @@ export class ValidationTagListExample implements OnInit {
         if (index >= 0) {
             controlValue.splice(index, 1);
             control.patchValue(controlValue);
+            control.markAsDirty();
         }
     }
 

--- a/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
+++ b/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
@@ -1,0 +1,122 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { COMMA, ENTER } from '@koobiq/cdk/keycodes';
+import { KbqButtonModule } from '@koobiq/components/button';
+import {
+    kbqDisableLegacyValidationDirectiveProvider,
+    kbqErrorStateMatcherProvider,
+    ShowOnFormSubmitErrorStateMatcher
+} from '@koobiq/components/core';
+import { KbqFormFieldModule } from '@koobiq/components/form-field';
+import { KbqIcon } from '@koobiq/components/icon';
+import { KbqInputModule } from '@koobiq/components/input';
+import { KbqTag, KbqTagInput, KbqTagInputEvent, KbqTagList, KbqTagRemove } from '@koobiq/components/tags';
+import { KbqToolTipModule } from '@koobiq/components/tooltip';
+
+/**
+ * @title Validation tag list
+ */
+@Component({
+    selector: 'validation-tag-list-example',
+    imports: [
+        ReactiveFormsModule,
+        KbqFormFieldModule,
+        KbqInputModule,
+        KbqToolTipModule,
+        KbqButtonModule,
+        KbqIcon,
+        KbqTag,
+        KbqTagInput,
+        KbqTagList,
+        KbqTagRemove
+    ],
+    template: `
+        <form
+            novalidate
+            style="width: 320px"
+            [formGroup]="reactiveForm"
+            (ngSubmit)="onSubmitReactiveForm(reactiveForm)"
+        >
+            <kbq-form-field class="layout-margin-bottom-l">
+                <kbq-tag-list #inputTagList formControlName="reactiveTypeaheadValue">
+                    @for (tag of reactiveForm.controls['reactiveTypeaheadValue'].value; track tag) {
+                        <kbq-tag [value]="tag" (removed)="reactiveInputOnRemoveTag(tag)">
+                            {{ tag }}
+                            <i kbq-icon="kbq-xmark-s_16" kbqTagRemove></i>
+                        </kbq-tag>
+                    }
+                    <input
+                        formControlName="tagInputFormControl"
+                        placeholder="New tag..."
+                        [kbqTagInputFor]="inputTagList"
+                        [kbqTagInputSeparatorKeyCodes]="separatorKeysCodes"
+                        (kbqTagInputTokenEnd)="reactiveInputOnCreate($event)"
+                    />
+                </kbq-tag-list>
+
+                <kbq-error>asd</kbq-error>
+
+                <kbq-hint>Provide only latin letters</kbq-hint>
+            </kbq-form-field>
+
+            <button type="submit" kbq-button>Submit</button>
+        </form>
+    `,
+    host: {
+        class: 'layout-margin-5xl layout-align-center-center layout-row'
+    },
+    providers: [
+        kbqDisableLegacyValidationDirectiveProvider(),
+        kbqErrorStateMatcherProvider(ShowOnFormSubmitErrorStateMatcher)
+    ],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ValidationTagListExample implements OnInit {
+    protected readonly reactiveForm: FormGroup;
+    protected readonly separatorKeysCodes: number[] = [ENTER, COMMA];
+
+    private readonly formBuilder = inject(FormBuilder);
+
+    constructor() {
+        this.reactiveForm = this.formBuilder.group({
+            reactiveTypeaheadValue: this.formBuilder.control([], Validators.required),
+            tagInputFormControl: this.formBuilder.control('', [Validators.pattern('[a-zA-Z]*')])
+        });
+    }
+
+    ngOnInit(): void {
+        setTimeout(() => {
+            this.reactiveForm.controls['reactiveTypeaheadValue'].setValue(['asd', 'efd']);
+        });
+    }
+
+    reactiveInputOnCreate({ input, value }: KbqTagInputEvent): void {
+        const control = this.reactiveForm.controls.reactiveTypeaheadValue;
+        const updatedControlValue: string[] = control.value.slice();
+
+        if ((value || '').trim()) {
+            updatedControlValue.push(value.trim());
+            control.patchValue(updatedControlValue);
+            control.markAsDirty();
+        }
+
+        if (input) {
+            input.value = '';
+        }
+    }
+
+    reactiveInputOnRemoveTag(tag: string): void {
+        const control = this.reactiveForm.controls['reactiveTypeaheadValue'];
+        const controlValue: string[] = control.value.slice();
+        const index = controlValue.indexOf(tag);
+
+        if (index >= 0) {
+            controlValue.splice(index, 1);
+            control.patchValue(controlValue);
+        }
+    }
+
+    onSubmitReactiveForm(form: FormGroup) {
+        console.log('onSubmitReactiveForm: ', form);
+    }
+}

--- a/packages/docs-examples/example-module.ts
+++ b/packages/docs-examples/example-module.ts
@@ -5867,6 +5867,18 @@ export const EXAMPLE_COMPONENTS: {[id: string]: LiveExample} = {
     "additionalComponents": [],
     "primaryFile": "validation-required-label-example.ts",
     "importPath": "components/validation"
+  },
+  "validation-tag-list": {
+    "packagePath": "components/validation/validation-tag-list",
+    "title": "Validation tag list",
+    "componentName": "ValidationTagListExample",
+    "files": [
+      "validation-tag-list-example.ts"
+    ],
+    "selector": "validation-tag-list-example",
+    "additionalComponents": [],
+    "primaryFile": "validation-tag-list-example.ts",
+    "importPath": "components/validation"
   }
 };
 export async function loadExample(id: string): Promise<any> {
@@ -6818,6 +6830,8 @@ return import('@koobiq/docs-examples/components/validation');
   case 'validation-optional-label':
 return import('@koobiq/docs-examples/components/validation');
   case 'validation-required-label':
+return import('@koobiq/docs-examples/components/validation');
+  case 'validation-tag-list':
 return import('@koobiq/docs-examples/components/validation');
     default:
 return undefined;

--- a/tools/public_api_guard/components/tags.api.md
+++ b/tools/public_api_guard/components/tags.api.md
@@ -253,6 +253,7 @@ export class KbqTagList implements KbqFormFieldControl<any>, ControlValueAccesso
     editable: boolean;
     // (undocumented)
     protected elementRef: ElementRef<HTMLElement>;
+    emitOnTagChanges: boolean;
     get empty(): boolean;
     errorState: boolean;
     errorStateMatcher: ErrorStateMatcher;
@@ -271,6 +272,8 @@ export class KbqTagList implements KbqFormFieldControl<any>, ControlValueAccesso
     static ngAcceptInputType_draggable: unknown;
     // (undocumented)
     static ngAcceptInputType_editable: unknown;
+    // (undocumented)
+    static ngAcceptInputType_emitOnTagChanges: unknown;
     // (undocumented)
     static ngAcceptInputType_multiple: unknown;
     // (undocumented)
@@ -336,7 +339,7 @@ export class KbqTagList implements KbqFormFieldControl<any>, ControlValueAccesso
     readonly valueChange: EventEmitter<any>;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqTagList, "kbq-tag-list", ["kbqTagList"], { "multiple": { "alias": "multiple"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "value": { "alias": "value"; "required": false; }; "required": { "alias": "required"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "draggable": { "alias": "draggable"; "required": false; }; "selectable": { "alias": "selectable"; "required": false; }; "editable": { "alias": "editable"; "required": false; }; "removable": { "alias": "removable"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "orientation": { "alias": "orientation"; "required": false; }; }, { "dropped": "dropped"; "valueChange": "valueChange"; "change": "change"; }, ["cleaner", "tags"], ["*", "kbq-cleaner"], true, [{ directive: typeof i1.CdkDropList; inputs: {}; outputs: {}; }]>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqTagList, "kbq-tag-list", ["kbqTagList"], { "multiple": { "alias": "multiple"; "required": false; }; "compareWith": { "alias": "compareWith"; "required": false; }; "value": { "alias": "value"; "required": false; }; "required": { "alias": "required"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "draggable": { "alias": "draggable"; "required": false; }; "selectable": { "alias": "selectable"; "required": false; }; "editable": { "alias": "editable"; "required": false; }; "emitOnTagChanges": { "alias": "emitOnTagChanges"; "required": false; }; "removable": { "alias": "removable"; "required": false; }; "tabIndex": { "alias": "tabIndex"; "required": false; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "orientation": { "alias": "orientation"; "required": false; }; }, { "dropped": "dropped"; "valueChange": "valueChange"; "change": "change"; }, ["cleaner", "tags"], ["*", "kbq-cleaner"], true, [{ directive: typeof i1.CdkDropList; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqTagList, [null, null, null, { optional: true; }, { optional: true; }, { optional: true; }, { optional: true; self: true; }]>;
 }


### PR DESCRIPTION
## Summary

tag-list calls onChange when the tags QueryList changes, including when tags are updated programmatically via writeValue/patchValue.

The problem is that when formControl is updated asynchronously, onChange also fires, causing the formControl to be marked as dirty even when the value is set programmatically (e.g. inside setTimeout).

Added `emitOnTagChanges` flag - when false, the component won't call onChange. This allows programmatic tag updates without the side effect of marking the form as dirty.

Example:
<kbq-tag-list [emitOnTagChanges]="false" formControlName="tags">


<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

tag-list вызывает onChange при изменениях в QueryList тегов, в том числе когда теги обновляются программно через writeValue/patchValue. 

Проблема в том, что при асинхронном обновлении formControl, onChange тоже срабатывает, из-за чего formControl помечается как dirty даже если значение устанавливается программно (например в setTimeout).

Добавил флаг `emitOnTagChanges` - когда false, компонент не будет вызывать onChange. Это позволяет программно обновлять теги без побочки в виде dirty state у формы.

Пример:
<kbq-tag-list [emitOnTagChanges]="false" formControlName="tags">

</details>





