### PR TITLE
chore(inline-edit): added info about validation in FormGroup (#DS-4802)

### DIFF
--- a/packages/components/inline-edit/inline-edit.en.md
+++ b/packages/components/inline-edit/inline-edit.en.md
@@ -33,6 +33,24 @@ For fields without labels, the placeholder can include the field name, e.g., _De
 
 ### Validation
 
+<div class="kbq-callout kbq-callout_theme">
+<div class="kbq-callout__header">Usage inside FormGroup</div>
+<div class="kbq-callout__content kbq-docs-element-last-child-margin-bottom-0">
+
+If the component is used inside a form, add `kbqDisableLegacyValidationDirectiveProvider` to your providers.
+Otherwise, validation won't work - the component will wait for form submission and will never show an error.
+
+```typescript
+import { kbqDisableLegacyValidationDirectiveProvider } from '@koobiq/components/core';
+
+@NgModule({
+    providers: [kbqDisableLegacyValidationDirectiveProvider()]
+})
+```
+
+</div>
+</div>
+
 Exiting edit mode attempts to save changes. If the new value is invalid, the system displays an error message, highlights the field, and keeps focus in the input.
 
 When certain characters are always invalid (e.g., letters in an IP address), block their input directly. Prevented characters do not appear, and a yellow tooltip explains why.

--- a/packages/components/inline-edit/inline-edit.ru.md
+++ b/packages/components/inline-edit/inline-edit.ru.md
@@ -30,6 +30,23 @@
 
 ### Валидация
 
+<div class="kbq-callout kbq-callout_theme">
+<div class="kbq-callout__header">Использование внутри FormGroup</div>
+<div class="kbq-callout__content kbq-docs-element-last-child-margin-bottom-0">
+
+Если компонент используется внутри формы, добавьте в провайдеры `kbqDisableLegacyValidationDirectiveProvider`.
+
+Иначе валидация не заработает - компонент будет ждать отправки формы и никогда не покажет ошибку.
+
+```typescript
+import { kbqDisableLegacyValidationDirectiveProvider } from '@koobiq/components/core';
+
+providers: [kbqDisableLegacyValidationDirectiveProvider()];
+```
+
+</div>
+</div>
+
 Выход из режима редактирования запускает попытку применить изменения. Если новое значение невалидно, то показывается сообщение об ошибке, поле подсвечивается, фокус остается в поле.
 
 <!-- example(inline-edit-validation) -->


### PR DESCRIPTION


## Summary


Added a callout to the Inline Edit documentation about using `kbqDisableLegacyValidationDirectiveProvider` inside forms.

When Inline Edit is placed inside a `FormGroup`, `KbqValidateDirective` waits for form submission to trigger validation. This means the component never becomes invalid on its own, and users see no validation errors. Adding `kbqDisableLegacyValidationDirectiveProvider` to providers disables this behavior and lets validation work as expected.


<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

Добавлен callout в документацию Inline Edit про использование `kbqDisableLegacyValidationDirectiveProvider` внутри форм.

Когда Inline Edit находится внутри `FormGroup`, `KbqValidateDirective` ждёт сабмита формы для запуска валидации. Из-за этого компонент никогда не становится невалидным и пользователь не видит ошибок. Добавление `kbqDisableLegacyValidationDirectiveProvider` в провайдеры отключает это поведение и валидация работает как ожидается.

</details>
