### PR TITLE
fix(select,tree-select): not hide search if options filtered (#DS-4713)

### DIFF
--- a/packages/components/select/select.component.spec.ts
+++ b/packages/components/select/select.component.spec.ts
@@ -3038,7 +3038,7 @@ describe('KbqSelect', () => {
             expect(fixture.debugElement.query(By.css('input'))).toBeDefined();
         }));
 
-        it('should search filed should be focused after open', fakeAsync(() => {
+        it('should focus search field after open', fakeAsync(() => {
             trigger.click();
             fixture.detectChanges();
             flush();
@@ -3131,6 +3131,28 @@ describe('KbqSelect', () => {
             fixture.detectChanges();
             flush();
 
+            expect(fixture.debugElement.query(By.css('input'))).toBeTruthy();
+        }));
+
+        it('should NOT hide search field if options filtered via search', fakeAsync(() => {
+            const { componentInstance } = fixture;
+
+            componentInstance.minOptionsThreshold = 3;
+            fixture.detectChanges();
+            tick();
+
+            trigger.click();
+            fixture.detectChanges();
+            flush();
+
+            componentInstance.searchCtrl.setValue(OPTIONS[0]);
+            fixture.detectChanges();
+            flush();
+            tick(1);
+
+            const options = fixture.debugElement.queryAll(By.css('kbq-option'));
+
+            expect(options.length).toBe(1);
             expect(fixture.debugElement.query(By.css('input'))).toBeTruthy();
         }));
     });

--- a/packages/components/select/select.component.ts
+++ b/packages/components/select/select.component.ts
@@ -1130,7 +1130,11 @@ export class KbqSelect
 
     /** @docs-private */
     protected shouldShowSearch(): boolean {
-        return isUndefined(this.searchMinOptionsThreshold) || this.options.length >= this.searchMinOptionsThreshold;
+        return (
+            isUndefined(this.searchMinOptionsThreshold) ||
+            !!this.search.value() ||
+            this.options.length >= this.searchMinOptionsThreshold
+        );
     }
 
     private updateLocaleParams = () => {

--- a/packages/components/tree-select/tree-select.component.spec.ts
+++ b/packages/components/tree-select/tree-select.component.spec.ts
@@ -3312,7 +3312,7 @@ describe('KbqTreeSelect', () => {
             expect(fixture.debugElement.query(By.css('input'))).toBeDefined();
         }));
 
-        it('should search filed should be focused after open', fakeAsync(() => {
+        it('should focus search field after open', fakeAsync(() => {
             trigger.click();
             fixture.detectChanges();
             flush();
@@ -3430,6 +3430,28 @@ describe('KbqTreeSelect', () => {
             fixture.detectChanges();
             flush();
 
+            expect(fixture.debugElement.query(By.css('input'))).toBeTruthy();
+        }));
+
+        it('should NOT hide search field if options filtered via search', fakeAsync(() => {
+            const { componentInstance } = fixture;
+
+            componentInstance.searchMinOptionsThreshold = 3;
+            fixture.detectChanges();
+            tick();
+
+            trigger.click();
+            fixture.detectChanges();
+            flush();
+
+            componentInstance.searchControl.setValue('Downloads');
+            fixture.detectChanges();
+            flush();
+            tick(1);
+
+            const options = fixture.debugElement.queryAll(By.css('kbq-tree-option'));
+
+            expect(options.length).toBe(1);
             expect(fixture.debugElement.query(By.css('input'))).toBeTruthy();
         }));
     });

--- a/packages/components/tree-select/tree-select.component.ts
+++ b/packages/components/tree-select/tree-select.component.ts
@@ -1172,7 +1172,11 @@ export class KbqTreeSelect
 
     /** @docs-private */
     protected shouldShowSearch(): boolean {
-        return isUndefined(this.searchMinOptionsThreshold) || this.options.length >= this.searchMinOptionsThreshold;
+        return (
+            isUndefined(this.searchMinOptionsThreshold) ||
+            !!this.search.value() ||
+            this.options.length >= this.searchMinOptionsThreshold
+        );
     }
 
     private updateLocaleParams = () => {

--- a/packages/docs-examples/components/select/select-search/select-search-example.ts
+++ b/packages/docs-examples/components/select/select-search/select-search-example.ts
@@ -5,7 +5,7 @@ import { KbqHighlightModule } from '@koobiq/components/core';
 import { KbqFormFieldModule } from '@koobiq/components/form-field';
 import { KbqIconModule } from '@koobiq/components/icon';
 import { KbqInputModule } from '@koobiq/components/input';
-import { KbqSelectModule } from '@koobiq/components/select';
+import { KbqSelectModule, kbqSelectOptionsProvider } from '@koobiq/components/select';
 import { map, startWith } from 'rxjs/operators';
 
 /**
@@ -52,6 +52,9 @@ import { map, startWith } from 'rxjs/operators';
             width: 320px;
         }
     `,
+    providers: [
+        kbqSelectOptionsProvider({ searchMinOptionsThreshold: 'auto' })
+    ],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SelectSearchExample {


### PR DESCRIPTION
## Summary

Check if search input has value and use hiding logic instead
