### PR TITLE
feat(tags): call onChange only on UI-initiated changes (#DS-4742)

### DIFF
--- a/packages/components/tags/tag-input.ts
+++ b/packages/components/tags/tag-input.ts
@@ -270,7 +270,7 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
             items = items.filter((item) => !tagValues.includes(item));
         }
 
-        if (items.length > 0) {
+        if (items.length) {
             this._tagList?.notifyPendingTagChange();
         }
 

--- a/packages/components/tags/tag-input.ts
+++ b/packages/components/tags/tag-input.ts
@@ -224,6 +224,7 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
         if (!this.hasControl() || (this.hasControl() && !this.ngControl.invalid)) {
             if (this.distinct && this.hasDuplicates) return;
 
+            this._tagList?.notifyPendingTagChange();
             this.tagEnd.emit({ input: this.inputElement, value: this.trimValue(this.inputElement.value) });
         }
     }
@@ -267,6 +268,10 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
             const tagValues: string[] = this._tagList.tags.map(({ value }) => value);
 
             items = items.filter((item) => !tagValues.includes(item));
+        }
+
+        if (items.length > 0) {
+            this._tagList?.notifyPendingTagChange();
         }
 
         items.forEach((item) => this.tagEnd.emit({ input: this.inputElement, value: item }));

--- a/packages/components/tags/tag-list.component.spec.ts
+++ b/packages/components/tags/tag-list.component.spec.ts
@@ -962,7 +962,7 @@ describe(KbqTagList.name, () => {
             fixture.componentInstance.foods = [...fixture.componentInstance.foods, 'pizza-1'];
 
             fixture.detectChanges();
-            tick(100);
+            tick();
 
             expect(fixture.componentInstance.control.dirty).toEqual(false);
         }));

--- a/packages/components/tags/tag-list.component.spec.ts
+++ b/packages/components/tags/tag-list.component.spec.ts
@@ -986,7 +986,6 @@ describe(KbqTagList.name, () => {
 
         it('should set the control to dirty when a tag is added via input', fakeAsync(() => {
             expect(fixture.componentInstance.control.dirty).toEqual(false);
-            jest.spyOn(fixture.componentInstance, 'add');
 
             const nativeInput: HTMLInputElement = fixture.nativeElement.querySelector('input');
 

--- a/packages/components/tags/tag-list.component.spec.ts
+++ b/packages/components/tags/tag-list.component.spec.ts
@@ -959,14 +959,46 @@ describe(KbqTagList.name, () => {
         it('should not set the control to dirty when rendered tags changed programmatically', fakeAsync(() => {
             expect(fixture.componentInstance.control.dirty).toEqual(false);
 
-            fixture.componentInstance.emitOnTagChanges = false;
-            fixture.detectChanges();
             fixture.componentInstance.foods = [...fixture.componentInstance.foods, 'pizza-1'];
 
             fixture.detectChanges();
             tick(100);
 
             expect(fixture.componentInstance.control.dirty).toEqual(false);
+        }));
+
+        it('should set the control to dirty when a tag is removed via UI (BACKSPACE)', fakeAsync(() => {
+            expect(fixture.componentInstance.control.dirty).toEqual(false);
+
+            const tagListDebugEl = fixture.debugElement.query(By.directive(KbqTagList));
+            const tagListInst: KbqTagList = tagListDebugEl.componentInstance;
+            const firstTag = tagListInst.tags.first;
+
+            firstTag.focus();
+            tick();
+
+            dispatchKeyboardEvent(firstTag.elementRef.nativeElement, 'keydown', BACKSPACE);
+            fixture.detectChanges();
+            tick(100);
+
+            expect(fixture.componentInstance.control.dirty).toEqual(true);
+        }));
+
+        it('should set the control to dirty when a tag is added via input', fakeAsync(() => {
+            expect(fixture.componentInstance.control.dirty).toEqual(false);
+            jest.spyOn(fixture.componentInstance, 'add');
+
+            const nativeInput: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+            nativeInput.focus();
+            typeInElement('new-tag', nativeInput);
+            fixture.detectChanges();
+
+            nativeInput.dispatchEvent(createKeyboardEvent('keydown', ENTER, nativeInput, 'Enter'));
+            fixture.detectChanges();
+            tick(100);
+
+            expect(fixture.componentInstance.control.dirty).toEqual(true);
         }));
 
         xit('should set an asterisk after the placeholder if the control is required', () => {

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -157,6 +157,7 @@ export class KbqTagList
 
     /**
      * Combined stream of all of the child tags' remove change events.
+     * Fires after the tag leaves the DOM.
      *
      * @docs-private
      */
@@ -165,8 +166,7 @@ export class KbqTagList
     }
 
     /**
-     * `removed` fires only on user-initiated removal (click or keyboard).
-     * Set the pending flag so the subsequent `tags.changes` is treated as UI-initiated.
+     * `tag.removed` fires only on user-initiated removal (click or keyboard).
      *
      * @docs-private
      */
@@ -443,7 +443,7 @@ export class KbqTagList
     private tagInput: KbqTagTextControl;
 
     /** True when the next `tags.changes` emission is triggered by a UI action, not programmatic update. */
-    private _pendingUIChange = false;
+    private pendingUIChange = false;
 
     /**
      * When a tag is destroyed, we store the index of the destroyed tag until the tags
@@ -529,8 +529,8 @@ export class KbqTagList
                 Promise.resolve().then(() => {
                     this.stateChanges.next();
 
-                    if (currentTags && this.emitOnTagChanges && this._pendingUIChange) {
-                        this._pendingUIChange = false;
+                    if (currentTags && this.emitOnTagChanges && this.pendingUIChange) {
+                        this.pendingUIChange = false;
                         this.propagateTagsChanges();
                     }
                 });
@@ -569,7 +569,7 @@ export class KbqTagList
 
     /** Notifies that the next `tags.changes` emission is UI-initiated. */
     notifyPendingTagChange(): void {
-        this._pendingUIChange = true;
+        this.pendingUIChange = true;
     }
 
     /**
@@ -885,8 +885,8 @@ export class KbqTagList
 
     private listenToTagsRemoved(): void {
         this.tagRemoveSubscription = merge(
-            this.tagBeforeRemoveChanges.pipe(tap(() => (this._pendingUIChange = true))),
-            // `destroyed` fires after the tag leaves the DOM.
+            // Set the pending flag so the subsequent `tags.changes` is treated as UI-initiated.
+            this.tagBeforeRemoveChanges.pipe(tap(() => (this.pendingUIChange = true))),
             this.tagRemoveChanges.pipe(
                 tap((event) => {
                     const tag = event.tag;
@@ -935,7 +935,7 @@ export class KbqTagList
         this.dropList.dropped
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe(({ currentIndex, previousIndex, event, item }) => {
-                this._pendingUIChange = true;
+                this.pendingUIChange = true;
 
                 const { tag }: KbqTagDragData = item.data;
 

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -156,8 +156,7 @@ export class KbqTagList
     }
 
     /**
-     * Combined stream of all of the child tags' remove change events.
-     * Fires after the tag leaves the DOM.
+     * Combined stream of all of the child tags' destroyed events.
      *
      * @docs-private
      */
@@ -166,7 +165,7 @@ export class KbqTagList
     }
 
     /**
-     * `tag.removed` fires only on user-initiated removal (click or keyboard).
+     * Combined stream of all of the child tags' remove events.
      *
      * @docs-private
      */
@@ -529,7 +528,7 @@ export class KbqTagList
                 Promise.resolve().then(() => {
                     this.stateChanges.next();
 
-                    if (currentTags && this.emitOnTagChanges && this.pendingUIChange) {
+                    if (currentTags && this.pendingUIChange) {
                         this.pendingUIChange = false;
                         this.propagateTagsChanges();
                     }

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -38,8 +38,8 @@ import {
     KbqOrientation
 } from '@koobiq/components/core';
 import { KbqCleaner, KbqFormFieldControl } from '@koobiq/components/form-field';
-import { merge, Observable, Subject, Subscription } from 'rxjs';
-import { filter, startWith, tap } from 'rxjs/operators';
+import { merge, Observable, Subject } from 'rxjs';
+import { filter, startWith, takeUntil } from 'rxjs/operators';
 import { KbqTagTextControl } from './tag-text-control';
 import {
     KbqTag,
@@ -165,7 +165,7 @@ export class KbqTagList
     }
 
     /**
-     * Combined stream of all of the child tags' remove events.
+     * Combined stream of all of the child tags' removal request events.
      *
      * @docs-private
      */
@@ -451,17 +451,8 @@ export class KbqTagList
      */
     private lastDestroyedTagIndex: number | null = null;
 
-    /** Subscription to focus changes in the tags. */
-    private tagFocusSubscription: Subscription | null;
-
-    /** Subscription to blur changes in the tags. */
-    private tagBlurSubscription: Subscription | null;
-
-    /** Subscription to remove changes in tags. */
-    private tagRemoveSubscription: Subscription | null;
-
-    /** Subscription to edit changes in tags. */
-    private tagEditSubscription: Subscription | null;
+    /** Triggers unsubscription from all per-tags streams when tags are reset. */
+    private readonly tagsSubscriptions$ = new Subject<void>();
 
     constructor(
         protected elementRef: ElementRef<HTMLElement>,
@@ -834,37 +825,15 @@ export class KbqTagList
     }
 
     private resetTags(): void {
-        this.dropSubscriptions();
+        this.tagsSubscriptions$.next();
         this.listenToTagsFocus();
         this.listenToTagsRemoved();
         this.listenToTagsEdit();
     }
 
-    private dropSubscriptions() {
-        if (this.tagFocusSubscription) {
-            this.tagFocusSubscription.unsubscribe();
-            this.tagFocusSubscription = null;
-        }
-
-        if (this.tagBlurSubscription) {
-            this.tagBlurSubscription.unsubscribe();
-            this.tagBlurSubscription = null;
-        }
-
-        if (this.tagRemoveSubscription) {
-            this.tagRemoveSubscription.unsubscribe();
-            this.tagRemoveSubscription = null;
-        }
-
-        if (this.tagEditSubscription) {
-            this.tagEditSubscription.unsubscribe();
-            this.tagEditSubscription = null;
-        }
-    }
-
     /** Listens to user-generated selection events on each tag. */
     private listenToTagsFocus(): void {
-        this.tagFocusSubscription = this.tagFocusChanges.subscribe(({ tag, origin }) => {
+        this.tagFocusChanges.pipe(takeUntil(this.tagsSubscriptions$)).subscribe(({ tag, origin }) => {
             const tagIndex = this.tags.toArray().indexOf(tag);
 
             if (this.isValidIndex(tagIndex)) {
@@ -875,7 +844,7 @@ export class KbqTagList
             this.stateChanges.next();
         });
 
-        this.tagBlurSubscription = this.tagBlurChanges.subscribe(() => {
+        this.tagBlurChanges.pipe(takeUntil(this.tagsSubscriptions$)).subscribe(() => {
             this.blur();
 
             this.stateChanges.next();
@@ -883,28 +852,30 @@ export class KbqTagList
     }
 
     private listenToTagsRemoved(): void {
-        this.tagRemoveSubscription = merge(
-            // Set the pending flag so the subsequent `tags.changes` is treated as UI-initiated.
-            this.tagBeforeRemoveChanges.pipe(tap(() => (this.pendingUIChange = true))),
-            this.tagRemoveChanges.pipe(
-                tap((event) => {
-                    const tag = event.tag;
-                    const tagIndex = this.tags.toArray().indexOf(event.tag);
+        this.tagRemoveChanges.pipe(takeUntil(this.tagsSubscriptions$)).subscribe((event) => {
+            const tag = event.tag;
+            const tagIndex = this.tags.toArray().indexOf(event.tag);
 
-                    // In case the tag that will be removed is currently focused, we temporarily store
-                    // the index in order to be able to determine an appropriate sibling tag that will
-                    // receive focus.
-                    if (this.isValidIndex(tagIndex) && tag.hasFocus) {
-                        this.lastDestroyedTagIndex = tagIndex;
-                    }
-                })
-            )
-        ).subscribe();
+            // In case the tag that will be removed is currently focused, we temporarily store
+            // the index in order to be able to determine an appropriate sibling tag that will
+            // receive focus.
+            if (this.isValidIndex(tagIndex) && tag.hasFocus) {
+                this.lastDestroyedTagIndex = tagIndex;
+            }
+        });
+
+        // Set the pending flag so the subsequent `tags.changes` is treated as UI action.
+        this.tagBeforeRemoveChanges
+            .pipe(takeUntil(this.tagsSubscriptions$))
+            .subscribe(() => (this.pendingUIChange = true));
     }
 
     private listenToTagsEdit(): void {
-        this.tagEditSubscription = this.tagEditChanges
-            .pipe(filter(({ type }) => type === 'submit'))
+        this.tagEditChanges
+            .pipe(
+                filter(({ type }) => type === 'submit'),
+                takeUntil(this.tagsSubscriptions$)
+            )
             .subscribe(() => this.propagateTagsChanges());
     }
 

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -534,7 +534,7 @@ export class KbqTagList
     ngOnDestroy() {
         this.stateChanges.complete();
         this.focusMonitor.stopMonitoring(this.elementRef);
-        this.dropSubscriptions();
+        this.tagsSubscriptions$.next();
     }
 
     /** @docs-private */

--- a/packages/components/tags/tag-list.component.ts
+++ b/packages/components/tags/tag-list.component.ts
@@ -39,7 +39,7 @@ import {
 } from '@koobiq/components/core';
 import { KbqCleaner, KbqFormFieldControl } from '@koobiq/components/form-field';
 import { merge, Observable, Subject, Subscription } from 'rxjs';
-import { filter, startWith } from 'rxjs/operators';
+import { filter, startWith, tap } from 'rxjs/operators';
 import { KbqTagTextControl } from './tag-text-control';
 import {
     KbqTag,
@@ -162,6 +162,16 @@ export class KbqTagList
      */
     get tagRemoveChanges(): Observable<KbqTagEvent> {
         return merge(...this.tags.map((tag) => tag.destroyed));
+    }
+
+    /**
+     * `removed` fires only on user-initiated removal (click or keyboard).
+     * Set the pending flag so the subsequent `tags.changes` is treated as UI-initiated.
+     *
+     * @docs-private
+     */
+    protected get tagBeforeRemoveChanges(): Observable<KbqTagEvent> {
+        return merge(...this.tags.map((tag) => tag.removed));
     }
 
     /**
@@ -324,7 +334,8 @@ export class KbqTagList
 
     /**
      * Whether to emit change events when tags are added/removed.
-     * Set to `false` to prevent the form control from being marked as dirty during programmatic updates.
+     *
+     * @deprecated No longer needed. Will be removed in the next major release.
      */
     @Input({ transform: booleanAttribute }) emitOnTagChanges = true;
 
@@ -431,6 +442,9 @@ export class KbqTagList
     /** The tag input to add more tags */
     private tagInput: KbqTagTextControl;
 
+    /** True when the next `tags.changes` emission is triggered by a UI action, not programmatic update. */
+    private _pendingUIChange = false;
+
     /**
      * When a tag is destroyed, we store the index of the destroyed tag until the tags
      * query list notifies about the update. This is necessary because we cannot determine an
@@ -515,8 +529,8 @@ export class KbqTagList
                 Promise.resolve().then(() => {
                     this.stateChanges.next();
 
-                    // do not call on initial
-                    if (currentTags && this.emitOnTagChanges) {
+                    if (currentTags && this.emitOnTagChanges && this._pendingUIChange) {
+                        this._pendingUIChange = false;
                         this.propagateTagsChanges();
                     }
                 });
@@ -552,6 +566,11 @@ export class KbqTagList
 
     /** @docs-private */
     onChange: (value: any) => void = () => {};
+
+    /** Notifies that the next `tags.changes` emission is UI-initiated. */
+    notifyPendingTagChange(): void {
+        this._pendingUIChange = true;
+    }
 
     /**
      * Associates an HTML input element with this tag list.
@@ -865,17 +884,23 @@ export class KbqTagList
     }
 
     private listenToTagsRemoved(): void {
-        this.tagRemoveSubscription = this.tagRemoveChanges.subscribe((event) => {
-            const tag = event.tag;
-            const tagIndex = this.tags.toArray().indexOf(event.tag);
+        this.tagRemoveSubscription = merge(
+            this.tagBeforeRemoveChanges.pipe(tap(() => (this._pendingUIChange = true))),
+            // `destroyed` fires after the tag leaves the DOM.
+            this.tagRemoveChanges.pipe(
+                tap((event) => {
+                    const tag = event.tag;
+                    const tagIndex = this.tags.toArray().indexOf(event.tag);
 
-            // In case the tag that will be removed is currently focused, we temporarily store
-            // the index in order to be able to determine an appropriate sibling tag that will
-            // receive focus.
-            if (this.isValidIndex(tagIndex) && tag.hasFocus) {
-                this.lastDestroyedTagIndex = tagIndex;
-            }
-        });
+                    // In case the tag that will be removed is currently focused, we temporarily store
+                    // the index in order to be able to determine an appropriate sibling tag that will
+                    // receive focus.
+                    if (this.isValidIndex(tagIndex) && tag.hasFocus) {
+                        this.lastDestroyedTagIndex = tagIndex;
+                    }
+                })
+            )
+        ).subscribe();
     }
 
     private listenToTagsEdit(): void {
@@ -910,6 +935,8 @@ export class KbqTagList
         this.dropList.dropped
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe(({ currentIndex, previousIndex, event, item }) => {
+                this._pendingUIChange = true;
+
                 const { tag }: KbqTagDragData = item.data;
 
                 this.dropped.emit({ currentIndex, previousIndex, event, tag });

--- a/packages/components/tags/tag.component.ts
+++ b/packages/components/tags/tag.component.ts
@@ -303,10 +303,13 @@ export class KbqTag
     /** Emitted when the tag is selected or deselected. */
     @Output() readonly selectionChange: EventEmitter<KbqTagSelectionChange> = new EventEmitter<KbqTagSelectionChange>();
 
-    /** Emitted when the tag is destroyed. */
+    /** Emitted when the tag is destroyed and leaving the DOM. */
     @Output() readonly destroyed: EventEmitter<KbqTagEvent> = new EventEmitter<KbqTagEvent>();
 
-    /** Emitted when a tag is to be removed. */
+    /**
+     * Emitted when a tag is to be removed.
+     * Fires on programmatic and user-initiated removal (click or keyboard).
+     */
     @Output() readonly removed: EventEmitter<KbqTagEvent> = new EventEmitter<KbqTagEvent>();
 
     /** Whether the tag is selected. */

--- a/packages/components/tags/tag.component.ts
+++ b/packages/components/tags/tag.component.ts
@@ -308,7 +308,7 @@ export class KbqTag
 
     /**
      * Emitted when a tag is to be removed.
-     * Fires on programmatic and user-initiated removal (click or keyboard).
+     * Fires on programmatic and UI removal (click or keyboard).
      */
     @Output() readonly removed: EventEmitter<KbqTagEvent> = new EventEmitter<KbqTagEvent>();
 

--- a/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
+++ b/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
@@ -35,7 +35,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
             (ngSubmit)="onSubmitReactiveForm(reactiveForm)"
         >
             <kbq-form-field class="layout-margin-bottom-l">
-                <kbq-tag-list #inputTagList formControlName="reactiveTypeaheadValue" [emitOnTagChanges]="false">
+                <kbq-tag-list #inputTagList formControlName="reactiveTypeaheadValue">
                     @for (tag of reactiveForm.controls['reactiveTypeaheadValue'].value; track tag) {
                         <kbq-tag [value]="tag" (removed)="reactiveInputOnRemoveTag(tag)">
                             {{ tag }}

--- a/tools/public_api_guard/components/tags.api.md
+++ b/tools/public_api_guard/components/tags.api.md
@@ -253,6 +253,7 @@ export class KbqTagList implements KbqFormFieldControl<any>, ControlValueAccesso
     editable: boolean;
     // (undocumented)
     protected elementRef: ElementRef<HTMLElement>;
+    // @deprecated
     emitOnTagChanges: boolean;
     get empty(): boolean;
     errorState: boolean;
@@ -290,6 +291,7 @@ export class KbqTagList implements KbqFormFieldControl<any>, ControlValueAccesso
     ngDoCheck(): void;
     // (undocumented)
     ngOnDestroy(): void;
+    notifyPendingTagChange(): void;
     onChange: (value: any) => void;
     onContainerClick(): void;
     onTouched: () => void;
@@ -320,6 +322,7 @@ export class KbqTagList implements KbqFormFieldControl<any>, ControlValueAccesso
     readonly stateChanges: Subject<void>;
     get tabIndex(): number | null;
     set tabIndex(value: number);
+    protected get tagBeforeRemoveChanges(): Observable<KbqTagEvent>;
     get tagBlurChanges(): Observable<KbqTagEvent>;
     // @deprecated
     tagChanges: EventEmitter<any>;


### PR DESCRIPTION
## Summary

Added flag that marks UI changes and doesn't propagate onChange on them.

This changed how tag list behaves.

Before, assigning `formControl` connected to tag list a new value via `setTimeout`, would lead to mark tag list as dirty which shouldn't when using `kbqDisableLegacyValidationDirectiveProvider`. 




