### PR TITLE
fix(input): autofill bg overlap on focus border (#DS-4950)

### DIFF
--- a/packages/components/form-field/_form-field-theme.scss
+++ b/packages/components/form-field/_form-field-theme.scss
@@ -47,6 +47,7 @@
             &:-webkit-autofill,
             &:-webkit-autofill:hover,
             &:-webkit-autofill:focus {
+                // set as transparent to not override container background-color;
                 --kbq-form-field-states-autofill-background: var(--kbq-background-transparent);
                 -webkit-box-shadow: inset 0 0 0 40rem var(--kbq-form-field-states-autofill-background);
                 -webkit-text-fill-color: var(--kbq-form-field-states-autofill-text);

--- a/packages/components/form-field/_form-field-theme.scss
+++ b/packages/components/form-field/_form-field-theme.scss
@@ -46,13 +46,15 @@
             //https://css-tricks.com/almanac/selectors/a/autofill/
             &:-webkit-autofill,
             &:-webkit-autofill:hover,
-            &:-webkit-autofill:focus,
-            &:-internal-autofill-selected {
-                -webkit-box-shadow: inset 0 0 0 40rem var(--kbq-foreground-white);
+            &:-webkit-autofill:focus {
+                --kbq-form-field-states-autofill-background: var(--kbq-background-transparent);
+                -webkit-box-shadow: inset 0 0 0 40rem var(--kbq-form-field-states-autofill-background);
                 -webkit-text-fill-color: var(--kbq-form-field-states-autofill-text);
                 caret-color: var(--kbq-form-field-states-autofill-text);
-                position: relative;
-                z-index: -1;
+
+                /* hide browser default autofill background, no matter what background color set */
+                transition: background-color 5000s ease-in-out;
+                background-color: var(--kbq-background-transparent) !important;
             }
         }
 
@@ -75,7 +77,8 @@
                     @include _kbq-form-field-state(states-focused);
 
                     & .kbq-form-field__container {
-                        box-shadow: inset 0 0 0.1px 1px var(--kbq-form-field-states-focused-focus-outline);
+                        box-shadow: inset 0 0 0.1px var(--kbq-form-field-size-focus-outline-width)
+                            var(--kbq-form-field-states-focused-focus-outline);
                     }
                 }
 
@@ -86,7 +89,8 @@
                     @include _kbq-form-field-state(states-error);
 
                     &.cdk-focused .kbq-form-field__container {
-                        box-shadow: inset 0 0 0.1px 1px var(--kbq-form-field-states-error-focused-focus-outline);
+                        box-shadow: inset 0 0 0.1px var(--kbq-form-field-size-focus-outline-width)
+                            var(--kbq-form-field-states-error-focused-focus-outline);
                     }
 
                     & .kbq-icon.kbq-empty {

--- a/packages/components/form-field/_form-field-theme.scss
+++ b/packages/components/form-field/_form-field-theme.scss
@@ -46,10 +46,13 @@
             //https://css-tricks.com/almanac/selectors/a/autofill/
             &:-webkit-autofill,
             &:-webkit-autofill:hover,
-            &:-webkit-autofill:focus {
-                -webkit-box-shadow: inset 0 0 0 40rem var(--kbq-form-field-states-autofill-background);
+            &:-webkit-autofill:focus,
+            &:-internal-autofill-selected {
+                -webkit-box-shadow: inset 0 0 0 40rem var(--kbq-foreground-white);
                 -webkit-text-fill-color: var(--kbq-form-field-states-autofill-text);
                 caret-color: var(--kbq-form-field-states-autofill-text);
+                position: relative;
+                z-index: -1;
             }
         }
 

--- a/packages/components/form-field/form-field-tokens.scss
+++ b/packages/components/form-field/form-field-tokens.scss
@@ -3,6 +3,7 @@
 
     --kbq-form-field-size-border-width: var(--kbq-size-border-width);
     --kbq-form-field-size-border-radius: var(--kbq-size-border-radius);
+    --kbq-form-field-size-focus-outline-width: 1px;
 
     --kbq-form-field-size-icon-size: var(--kbq-size-l);
     --kbq-form-field-size-icon-margin-left: var(--kbq-size-s);

--- a/packages/components/form-field/form-field.scss
+++ b/packages/components/form-field/form-field.scss
@@ -95,6 +95,13 @@
         & .kbq-tag-input {
             padding-right: var(--kbq-form-field-size-infix-right-padding);
         }
+
+        .kbq-input {
+            min-height: calc(
+                var(--kbq-form-field-size-height) - var(--kbq-size-border-width) *
+                    2 - var(--kbq-form-field-size-focus-outline-width) * 2
+            );
+        }
     }
 
     &,
@@ -109,6 +116,18 @@
     &.cdk-focused,
     &.kbq-focused {
         z-index: 3;
+
+        .kbq-input {
+            &:-webkit-autofill,
+            &:-webkit-autofill:hover,
+            &:-webkit-autofill:focus {
+                --kbq-input-size-padding-vertical: calc(
+                    var(--kbq-size-xs) - var(--kbq-size-border-width) - var(--kbq-form-field-size-focus-outline-width)
+                );
+
+                margin: var(--kbq-size-border-width) 0;
+            }
+        }
     }
 
     &.kbq-form-field_without-borders .kbq-form-field__container,

--- a/packages/components/form-field/form-field.scss
+++ b/packages/components/form-field/form-field.scss
@@ -95,13 +95,6 @@
         & .kbq-tag-input {
             padding-right: var(--kbq-form-field-size-infix-right-padding);
         }
-
-        .kbq-input {
-            min-height: calc(
-                var(--kbq-form-field-size-height) - var(--kbq-size-border-width) *
-                    2 - var(--kbq-form-field-size-focus-outline-width) * 2
-            );
-        }
     }
 
     &,
@@ -121,11 +114,18 @@
             &:-webkit-autofill,
             &:-webkit-autofill:hover,
             &:-webkit-autofill:focus {
-                --kbq-input-size-padding-vertical: calc(
-                    var(--kbq-size-xs) - var(--kbq-size-border-width) - var(--kbq-form-field-size-focus-outline-width)
+                min-height: calc(
+                    var(--kbq-form-field-size-height) - var(--kbq-form-field-size-border-width) *
+                        2 - var(--kbq-form-field-size-focus-outline-width) * 2
                 );
 
-                margin: var(--kbq-size-border-width) 0;
+                --kbq-input-size-padding-vertical: calc(
+                    var(--kbq-size-xs) - var(--kbq-form-field-size-border-width) - var(
+                            --kbq-form-field-size-focus-outline-width
+                        )
+                );
+
+                margin: var(--kbq-form-field-size-border-width) 0;
             }
         }
     }


### PR DESCRIPTION
## Summary

The fix contains 2 changes
- Input height
- The color is autofilled

For the focused + autofilled state:
Before
`padding 5px; margin: 0px;`

After
`padding 4px 0; margin: 1px 0`

This way, the height remains the same, but the background of the input does not go beyond the boundaries.

No way to test since issue for autofill in playwrigh exist: https://github.com/microsoft/playwright/issues/26831

<details>
  <summary><strong>Press for description in ru-RU</strong></summary>

Фикс включает 2 изменения
- Высота инпута
- Цвет autofilled

Для состояния focused + autofilled: 
Было
`padding 5px; margin: 0px;`

Стало
`padding 4px 0; margin: 1px 0`

Таким образом, высота остается той же, но задний фон инпута не выходит за границы

</details>


