### PR TITLE
fix(tags): separator handling on empty input value (#DS-5009)

### DIFF
--- a/packages/components/tags/tag-input.spec.ts
+++ b/packages/components/tags/tag-input.spec.ts
@@ -587,17 +587,33 @@ describe('KbqTagInput', () => {
             expect(addSpyFn).toHaveBeenCalled();
         });
 
-        it('should not emit the tagEnd event if a separator is pressed with a modifier key', () => {
-            const ENTER_EVENT = createKeyboardEvent('keydown', ENTER, inputNativeElement, 'Enter');
+        it.each(['shiftKey', 'ctrlKey', 'altKey', 'metaKey'])(
+            'should not emit tagEnd when %s is pressed with separator',
+            (modifierKey) => {
+                const ENTER_EVENT = createKeyboardEvent('keydown', ENTER, inputNativeElement, 'Enter');
 
-            Object.defineProperty(ENTER_EVENT, 'shiftKey', { get: () => true });
-            const addSpyFn = jest.spyOn(testTagInput, 'add');
+                Object.defineProperty(ENTER_EVENT, modifierKey, { get: () => true });
+                const addSpyFn = jest.spyOn(testTagInput, 'add');
 
-            tagInputDirective.separatorKeyCodes = [ENTER];
+                tagInputDirective.separatorKeyCodes = [ENTER];
+                (inputNativeElement as HTMLInputElement).value = 'tag-value';
+                fixture.detectChanges();
+
+                tagInputDirective.onKeydown(ENTER_EVENT);
+                expect(addSpyFn).not.toHaveBeenCalled();
+            }
+        );
+
+        it('should prevent default when a separator key is pressed with empty input', () => {
+            const SPACE_EVENT = createKeyboardEvent('keydown', SPACE, inputNativeElement, ' ');
+            const preventDefaultSpy = jest.spyOn(SPACE_EVENT, 'preventDefault');
+
+            tagInputDirective.separatorKeyCodes = [SPACE];
+            (inputNativeElement as HTMLInputElement).value = '';
             fixture.detectChanges();
 
-            tagInputDirective.onKeydown(ENTER_EVENT);
-            expect(addSpyFn).not.toHaveBeenCalled();
+            tagInputDirective.onKeydown(SPACE_EVENT);
+            expect(preventDefaultSpy).toHaveBeenCalled();
         });
     });
 });

--- a/packages/components/tags/tag-input.ts
+++ b/packages/components/tags/tag-input.ts
@@ -12,7 +12,7 @@ import {
     Self
 } from '@angular/core';
 import { NgControl } from '@angular/forms';
-import { COMMA, ENTER, SEMICOLON, SPACE, TAB } from '@koobiq/cdk/keycodes';
+import { COMMA, ENTER, hasModifierKey, SEMICOLON, SPACE, TAB } from '@koobiq/cdk/keycodes';
 import { KbqAutocompleteTrigger } from '@koobiq/components/autocomplete';
 import { KbqFieldSizingContent } from '@koobiq/components/core';
 import { KbqTrim } from '@koobiq/components/form-field';
@@ -179,14 +179,20 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
 
     /** @docs-private */
     onKeydown(event: KeyboardEvent) {
+        const isSeparatorKey = this.isSeparatorKey(event);
+
         if (!this.inputElement.value) {
+            if (isSeparatorKey) {
+                event.preventDefault();
+            }
+
             this._tagList.keydown(event);
             event.stopPropagation();
 
             return;
         }
 
-        if (this.isSeparatorKey(event) && this.inputElement.value) {
+        if (isSeparatorKey) {
             this.emitTagEnd();
 
             event.preventDefault();
@@ -325,6 +331,6 @@ export class KbqTagInput implements KbqTagTextControl, OnChanges {
 
     /** Checks whether a keycode is one of the configured separators. */
     private isSeparatorKey(event: KeyboardEvent) {
-        return this.separators.some((separator) => separator.key === event.key && !event.shiftKey);
+        return this.separators.some((separator) => separator.key === event.key && !hasModifierKey(event));
     }
 }


### PR DESCRIPTION
## Summary

- Добавил фикс для ожидаемого поведения

- и добавил исправление isSeparatorKey в соответствие с ожиданием поведением из названия теста