### PR TITLE
fix: add tag input autofill styles (#DS-4958)

### DIFF
--- a/packages/components/form-field/_form-field-theme.scss
+++ b/packages/components/form-field/_form-field-theme.scss
@@ -42,7 +42,8 @@
     .kbq-form-field {
         @include _kbq-form-field-state(default);
 
-        & .kbq-input {
+        & .kbq-input,
+        & .kbq-tag-input {
             //https://css-tricks.com/almanac/selectors/a/autofill/
             &:-webkit-autofill,
             &:-webkit-autofill:hover,
@@ -103,9 +104,9 @@
         }
 
         // todo quick fix for bug DS-4060. Technical debt DS-4096
-        & .kbq-form-field__container:has(.kbq-input:-webkit-autofill),
-        & .kbq-form-field__container:has(.kbq-input:-webkit-autofill:hover),
-        & .kbq-form-field__container:has(.kbq-input:-webkit-autofill:focus) {
+        & .kbq-form-field__container:has(:is(.kbq-input, .kbq-tag-input):-webkit-autofill),
+        & .kbq-form-field__container:has(:is(.kbq-input, .kbq-tag-input):-webkit-autofill:hover),
+        & .kbq-form-field__container:has(:is(.kbq-input, .kbq-tag-input):-webkit-autofill:focus) {
             background-color: var(--kbq-form-field-states-autofill-background) !important;
         }
 

--- a/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
+++ b/packages/docs-examples/components/validation/validation-tag-list/validation-tag-list-example.ts
@@ -43,6 +43,7 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
                         </kbq-tag>
                     }
                     <input
+                        autocomplete="off"
                         formControlName="tagInputFormControl"
                         placeholder="New tag..."
                         [kbqTagInputFor]="inputTagList"


### PR DESCRIPTION
Added missing tag input autofill styles


https://github.com/user-attachments/assets/40b8f19e-39e9-4693-b3fc-8c63dbf02013

