### PR TITLE
fix(autocomplete): handle click/input in shadow-dom parent (#DS-4801)

### DIFF
--- a/packages/components/autocomplete/autocomplete-trigger.directive.ts
+++ b/packages/components/autocomplete/autocomplete-trigger.directive.ts
@@ -9,7 +9,7 @@ import {
     PositionStrategy,
     ScrollStrategy
 } from '@angular/cdk/overlay';
-import { _getEventTarget } from '@angular/cdk/platform';
+import { _getEventTarget, _getFocusedElementPierceShadowDom } from '@angular/cdk/platform';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import { DOCUMENT } from '@angular/common';
@@ -387,7 +387,7 @@ export class KbqAutocompleteTrigger
             this.previousValue = value;
             this.onChange(value);
 
-            if (this.canOpen() && this.document.activeElement === event.target) {
+            if (this.canOpen() && _getFocusedElementPierceShadowDom() === target) {
                 this.openPanel();
             }
         }
@@ -403,7 +403,7 @@ export class KbqAutocompleteTrigger
     }
 
     handleClick($event: MouseEvent) {
-        if (!this.panelOpen && this.canOpen() && this.document.activeElement === $event.target) {
+        if (!this.panelOpen && this.canOpen() && _getFocusedElementPierceShadowDom() === $event.target) {
             this.openPanel();
         }
     }

--- a/packages/components/autocomplete/autocomplete.spec.ts
+++ b/packages/components/autocomplete/autocomplete.spec.ts
@@ -11,7 +11,8 @@ import {
     QueryList,
     Type,
     ViewChild,
-    ViewChildren
+    ViewChildren,
+    ViewEncapsulation
 } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, flush, inject, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
@@ -2108,6 +2109,40 @@ describe('KbqAutocomplete', () => {
             expect(fixture.componentInstance.trigger.panelOpen).toBe(true);
         });
     });
+
+    describe('with encapsulation: ViewEncapsulation.ShadowDom', () => {
+        it('should open the panel when the input is the shadow-DOM focused element', fakeAsync(() => {
+            const fixture = createComponent(TestShadowDomAutocomplete);
+
+            fixture.detectChanges();
+            const input: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+
+            // emulate native behavior
+            input.focus();
+            input.value = 'Alabama';
+            dispatchFakeEvent(input, 'input');
+            fixture.detectChanges();
+            flush();
+
+            expect(fixture.componentInstance.trigger.panelOpen).toBeTruthy();
+        }));
+
+        it('should open the panel when the clicked input is the shadow-DOM focused element', fakeAsync(() => {
+            const fixture = createComponent(TestShadowDomAutocomplete);
+
+            fixture.detectChanges();
+            const input: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+
+            expect(fixture.componentInstance.trigger.panelOpen).toBeFalsy();
+            // emulate native behavior
+            input.focus();
+            dispatchFakeEvent(input, 'click');
+            flush();
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.trigger.panelOpen).toBeTruthy();
+        }));
+    });
 });
 
 @Component({
@@ -2138,6 +2173,81 @@ describe('KbqAutocomplete', () => {
     `
 })
 class SimpleAutocomplete implements OnDestroy {
+    stateCtrl = new UntypedFormControl();
+    filteredStates: any[];
+    valueSub: Subscription;
+    width: number;
+    kbqOptionWidth: number;
+    autocompleteDisabled = false;
+    openedSpy = jest.fn();
+    closedSpy = jest.fn();
+
+    @ViewChild(KbqAutocompleteTrigger, { static: true }) trigger: KbqAutocompleteTrigger;
+    @ViewChild(KbqAutocomplete, { static: false }) panel: KbqAutocomplete;
+    @ViewChild(KbqFormField, { static: false }) formField: KbqFormField;
+    @ViewChildren(KbqOption) options: QueryList<KbqOption>;
+
+    states = [
+        { code: 'AL', name: 'Alabama' },
+        { code: 'CA', name: 'California' },
+        { code: 'FL', name: 'Florida' },
+        { code: 'KS', name: 'Kansas' },
+        { code: 'MA', name: 'Massachusetts' },
+        { code: 'NY', name: 'New York' },
+        { code: 'OR', name: 'Oregon' },
+        { code: 'PA', name: 'Pennsylvania' },
+        { code: 'TN', name: 'Tennessee' },
+        { code: 'VA', name: 'Virginia' },
+        { code: 'WY', name: 'Wyoming' }
+    ];
+
+    constructor() {
+        this.filteredStates = this.states;
+        this.valueSub = this.stateCtrl.valueChanges.subscribe((val) => {
+            this.filteredStates = val ? this.states.filter((s) => s.name.match(new RegExp(val, 'gi'))) : this.states;
+        });
+    }
+
+    displayFn(value: any): string {
+        return value ? value.name : value;
+    }
+
+    ngOnDestroy() {
+        this.valueSub.unsubscribe();
+    }
+}
+
+@Component({
+    template: `
+        <kbq-form-field [style.width.px]="width">
+            <input
+                kbqInput
+                placeholder="State"
+                [kbqAutocomplete]="auto"
+                [kbqAutocompleteDisabled]="autocompleteDisabled"
+                [formControl]="stateCtrl"
+            />
+        </kbq-form-field>
+
+        <kbq-autocomplete
+            #auto="kbqAutocomplete"
+            class="class-one class-two"
+            [displayWith]="displayFn"
+            (opened)="openedSpy()"
+            (closed)="closedSpy()"
+        >
+            @for (state of filteredStates; track state) {
+                <kbq-option [value]="state" [style.height.px]="kbqOptionWidth">
+                    <span>{{ state.code }}: {{ state.name }}</span>
+                </kbq-option>
+            }
+        </kbq-autocomplete>
+    `,
+    styles: ``,
+    encapsulation: ViewEncapsulation.ShadowDom,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+class TestShadowDomAutocomplete implements OnDestroy {
     stateCtrl = new UntypedFormControl();
     filteredStates: any[];
     valueSub: Subscription;
@@ -2302,7 +2412,6 @@ class AutocompleteWithNumbers {
 }
 
 @Component({
-    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `
         <kbq-form-field>
             <input type="text" kbqInput [kbqAutocomplete]="auto" />
@@ -2315,7 +2424,8 @@ class AutocompleteWithNumbers {
                 </kbq-option>
             }
         </kbq-autocomplete>
-    `
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 class AutocompleteWithOnPushDelay implements OnInit {
     @ViewChild(KbqAutocompleteTrigger, { static: false }) trigger: KbqAutocompleteTrigger;
@@ -2376,7 +2486,7 @@ class AutocompleteWithoutPanel {
         </kbq-form-field>
 
         <kbq-autocomplete #auto="kbqAutocomplete">
-            <kbq-option [value]="'California'">California</kbq-option>
+            <kbq-option value="California">California</kbq-option>
         </kbq-autocomplete>
     `
 })


### PR DESCRIPTION
Было выпущено в версию 19.x, ожидалось также в 18.x

