### PR TITLE
chore: update checkout action versions and add permissions (#DS-3557)

### DIFF
--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: .nvmrc
         cache: 'yarn'

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -6,11 +6,14 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/setup-node
       - uses: ./.github/workflows/actions/build-packages
       - run: yarn run check-api

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/setup-node
-      - run: echo "$PR_TITLE" | yarn commitlint --verbose
+      - run: printf '%s\n' "$PR_TITLE" | yarn commitlint --verbose
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,10 +2,15 @@ name: Commitlint
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/setup-node
-      - run: echo "${{ github.event.pull_request.title }}" | yarn commitlint --verbose
+      - run: echo "$PR_TITLE" | yarn commitlint --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/docs-next.yml
+++ b/.github/workflows/docs-next.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.repository_owner == 'koobiq' }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
         uses: ./.github/workflows/actions/setup-node

--- a/.github/workflows/docs-next.yml
+++ b/.github/workflows/docs-next.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ./.github/workflows/actions/build-docs
 
       - name: Deploy
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOOBIQ }}'

--- a/.github/workflows/docs-stable.yml
+++ b/.github/workflows/docs-stable.yml
@@ -7,6 +7,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   build:
     name: Build
@@ -25,7 +29,7 @@ jobs:
       - uses: ./.github/workflows/actions/build-docs
 
       - name: Deploy
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOOBIQ }}'
@@ -35,7 +39,7 @@ jobs:
           channelId: live
 
       - name: Run Algolia DocSearch Crawler
-        uses: algolia/algoliasearch-crawler-github-actions@v1.1.13
+        uses: algolia/algoliasearch-crawler-github-actions@3ae4def15d82c60aa02b0e528b50167593cbaaf6 # v1.1.13
         id: algolia_docsearch_crawler
         with:
           crawler-user-id: ${{ secrets.ALGOLIA_DOCSEARCH_CRAWLER_USER_ID }}

--- a/.github/workflows/docs-stable.yml
+++ b/.github/workflows/docs-stable.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.repository_owner == 'koobiq' }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
         uses: ./.github/workflows/actions/setup-node

--- a/.github/workflows/e2e-approve-snapshots.yml
+++ b/.github/workflows/e2e-approve-snapshots.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: xt0rted/pull-request-comment-branch@v3
+      - uses: xt0rted/pull-request-comment-branch@e8b8daa837e8ea7331c0003c9c316a64c6d8b0b1 # v3.0.0
         id: comment-branch
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-      - uses: thollander/actions-comment-pull-request@v3
+      - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: 🔄 [Updating](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) snapshots.
       - uses: ./.github/workflows/actions/setup-node
@@ -27,20 +27,20 @@ jobs:
       - id: update-snapshots
         run: |
           yarn run e2e:components --update-snapshots
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         id: commit-and-push
         with:
           commit_message: 'test: updated e2e snapshots'
           file_pattern: '**/*.png'
-      - uses: thollander/actions-comment-pull-request@v3
+      - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ steps.commit-and-push.outputs.changes_detected == 'true' }}
         with:
           message: ✅ Snapshots [updated](https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}/commits/${{ steps.commit-and-push.outputs.commit_hash }})!
-      - uses: thollander/actions-comment-pull-request@v3
+      - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ steps.commit-and-push.outputs.changes_detected != 'true' }}
         with:
           message: ⚠️ No snapshot changes detected.
-      - uses: thollander/actions-comment-pull-request@v3
+      - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ failure() && steps.update-snapshots.outcome == 'failure' }}
         with:
           message: 🚨 Failed to [update](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) snapshots.

--- a/.github/workflows/e2e-approve-snapshots.yml
+++ b/.github/workflows/e2e-approve-snapshots.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: xt0rted/pull-request-comment-branch@v3
         id: comment-branch
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
       - uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/setup-node
       - run: yarn run e2e:setup
       - id: run-e2e-tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,14 +21,14 @@ jobs:
       - id: run-e2e-tests
         run: |
           yarn run e2e:components
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
         id: upload-report
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 5
-      - uses: thollander/actions-comment-pull-request@v3
+      - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ failure() && steps.run-e2e-tests.outcome == 'failure' }}
         with:
           message: |

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -6,10 +6,13 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   license_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/setup-node
       - run: yarn run validate:license

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,11 +6,14 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/setup-node
       - run: |
           yarn run cspell --no-progress

--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Deploy Documentation
         if: github.actor != 'dependabot[bot]'
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOOBIQ }}'

--- a/.github/workflows/pr-docs-preview.yml
+++ b/.github/workflows/pr-docs-preview.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -5,6 +5,8 @@ on:
     types:
       - opened
 
+permissions: {}
+
 jobs:
   notify:
     name: Pull Request Notification
@@ -12,7 +14,7 @@ jobs:
     steps:
       - name: Notification
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: mattermost/action-mattermost-notify@v2.1.0
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         env:
           PR_URL: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}
         with:
@@ -23,7 +25,7 @@ jobs:
             [${{ github.repository }}] | [${{ github.event.pull_request.title }} #${{ github.event.number }}](${{ env.PR_URL }}) was created by ${{ github.actor }}
 
       - name: Notification to BotChannel
-        uses: mattermost/action-mattermost-notify@v2.1.0
+        uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         env:
           PR_URL: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'koobiq' }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
         uses: ./.github/workflows/actions/setup-node

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -6,11 +6,14 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/setup-node
       # Build styles which are required for unit tests
       - run: yarn run styles:build-all


### PR DESCRIPTION

## Summary

  Security hardening for GitHub Actions workflows

  Two categories of changes across 12 workflow files:

  1. Explicit permissions blocks — all workflows previously relied on the repository's default token permissions. Now each workflow declares only what it needs:
  - contents: read added to api, commitlint, license, linters, units
  - contents: read + checks: write added to docs-stable (Firebase deploy posts check runs)
  - permissions: {} added to pr-notify — it uses pull_request_target (elevated trigger) but makes no GitHub API calls, so it needs no token access at all

  2. Action pins to commit SHAs — all actions/checkout references were on floating version tags (@v6.0.2). All are now pinned with the version in a comment. Additionally three third-party actions were unpinned:
  - FirebaseExtended/action-hosting-deploy@v0 → pinned to (# v0.10.0)
  - algolia/algoliasearch-crawler-github-actions@v1.1.13 → pinned
  - mattermost/action-mattermost-notify@v2.1.0 → pinned 

  Also includes a minor fix in commitlint.yml: the PR title is now passed via an environment variable instead of being interpolated directly into the shell command, which prevents potential shell injection.