### PR TITLE
chore: use proper @koobiq/design-tokens peerDeps version (#DS-5142)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
         "@koobiq/angular-luxon-adapter": "{{VERSION}}",
         "@koobiq/date-formatter": "^3.2.3",
         "@koobiq/icons": "^11.1.3",
-        "@koobiq/design-tokens": "3.14.0"
+        "@koobiq/design-tokens": "^3.14.0"
     },
     "dependencies": {
         "tslib": "^2.6.2"


### PR DESCRIPTION
## Summary

Updated @koobiq/design-tokens as peerDependency of @koobiq/components, so actual versions with new palette are available.

When creating custom themes using style dictionary, simply replace paths in build config.

```diff
-'@koobiq/design-tokens/web/properties/**/*.json5',
+'@koobiq/design-tokens/web/properties/**/!(*v2|plt|semantic).json5',
```