### PR TITLE
fix(scrollbar): theme corner, track and resizer of nested scrollbars (#DS-5152)

### DIFF
--- a/packages/components-dev/scrollbar/module.ts
+++ b/packages/components-dev/scrollbar/module.ts
@@ -6,6 +6,7 @@ import {
     KbqScrollbarModule,
     KbqScrollbarOptions
 } from '@koobiq/components/scrollbar';
+import { DevThemeToggle } from '../theme-toggle';
 
 @Component({
     selector: 'dev-scrollbar-with-options',
@@ -98,7 +99,8 @@ export class DevScrollbarScrollToTop {
         // components
         DevScrollbarWithOptions,
         DevScrollbarWithCustomConfig,
-        DevScrollbarScrollToTop
+        DevScrollbarScrollToTop,
+        DevThemeToggle
     ],
     templateUrl: './template.html',
     styleUrl: './styles.scss',

--- a/packages/components-dev/scrollbar/styles.scss
+++ b/packages/components-dev/scrollbar/styles.scss
@@ -16,3 +16,14 @@ textarea {
     white-space: nowrap;
     overflow: visible;
 }
+
+.dev-nested-scroll {
+    width: 200px;
+    height: 200px;
+    overflow: auto;
+    margin: 10px;
+}
+
+.dev-nested-scroll__content {
+    width: 800px;
+}

--- a/packages/components-dev/scrollbar/template.html
+++ b/packages/components-dev/scrollbar/template.html
@@ -1,3 +1,5 @@
+<dev-theme-toggle />
+
 <dev-scrollbar-with-options />
 <hr />
 
@@ -45,6 +47,18 @@
             <textarea style="height: 300px; width: 400px; overflow-y: auto" class="kbq-scrollbar dev-with-buttons">{{
                 longText
             }}</textarea>
+
+            <h3>Nested scroll — class on wrapper</h3>
+            <div class="kbq-scrollbar">
+                <div class="dev-nested-scroll">
+                    <div class="dev-nested-scroll__content">{{ longText }}</div>
+                </div>
+            </div>
+
+            <h3>Nested scroll — class on scroller (reference)</h3>
+            <div class="dev-nested-scroll kbq-scrollbar">
+                <div class="dev-nested-scroll__content">{{ longText }}</div>
+            </div>
         </div>
     </div>
 </div>

--- a/packages/components/core/styles/theming/_scrollbar-theme.scss
+++ b/packages/components/core/styles/theming/_scrollbar-theme.scss
@@ -73,7 +73,11 @@
 
         &::-webkit-scrollbar-track,
         &::-webkit-scrollbar-corner,
+        &::-webkit-resizer,
         &::-webkit-scrollbar,
+        ::-webkit-scrollbar-track,
+        ::-webkit-scrollbar-corner,
+        ::-webkit-resizer,
         ::-webkit-scrollbar {
             background-color: transparent;
         }


### PR DESCRIPTION
The `.kbq-scrollbar` theme reset ::-webkit-scrollbar-track and ::-webkit-scrollbar-corner
only via the `&` (self) selector. When `.kbq-scrollbar` sits on a wrapper and a descendant
element scrolls in both axes, that descendant's corner kept the native grey background.

Add the descendant (no-`&`) forms for track/corner and also reset ::-webkit-resizer,
matching the existing thumb/scrollbar coverage. Add a nested-scroll example to the
scrollbar dev app to demonstrate it.
