### PR TITLE
docs: update docs feedback callout text (#DS-5304)

### DIFF
--- a/apps/docs/src/app/components/component-viewer/component-overview.template.html
+++ b/apps/docs/src/app/components/component-viewer/component-overview.template.html
@@ -9,20 +9,18 @@
 
     <div class="kbq-callout kbq-callout_contrast">
         <div class="kbq-callout__header">
-            {{ isRuLocale() ? 'Вопросы и предложения по документации' : 'Docs Feedback' }}
+            {{ isRuLocale() ? 'Предложения по улучшению' : 'Suggestions for improvement' }}
         </div>
 
         <div class="kbq-callout__content kbq-docs-element-last-child-margin-bottom-0">
             @if (isRuLocale()) {
-                Если у вас есть вопросы или вы хотите внести свой вклад в написание документации, пожалуйста,
-                <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>создайте issue</a>
-                в нашем репозитории на GitHub.
+                Если вы нашли ошибку или хотите доработать статью,
+                <!-- prettier-ignore -->
+                <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>создайте запрос на&nbsp;GitHub</a>.</span>
             } @else {
-                If you have any questions or would like to contribute to writing the documentation, please
-                <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>
-                    create an issue
-                </a>
-                in our GitHub repository.
+                If you found a mistake or want to improve the article,
+                <!-- prettier-ignore -->
+                <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>create an issue on GitHub</a>.</span>
             }
         </div>
     </div>

--- a/apps/docs/src/app/components/component-viewer/component-overview.template.html
+++ b/apps/docs/src/app/components/component-viewer/component-overview.template.html
@@ -12,15 +12,14 @@
             {{ isRuLocale() ? 'Предложения по улучшению' : 'Suggestions for improvement' }}
         </div>
 
+        <!-- prettier-ignore -->
         <div class="kbq-callout__content kbq-docs-element-last-child-margin-bottom-0">
             @if (isRuLocale()) {
                 Если вы нашли ошибку или хотите доработать статью,
-                <!-- prettier-ignore -->
-                <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>создайте запрос на&nbsp;GitHub</a>.</span>
+                <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>создайте запрос на&nbsp;GitHub</a>.
             } @else {
                 If you found a mistake or want to improve the article,
-                <!-- prettier-ignore -->
-                <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>create an issue on GitHub</a>.</span>
+                <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>create an issue on GitHub</a>.
             }
         </div>
     </div>

--- a/apps/docs/src/app/components/component-viewer/component-viewer-wrapper.ts
+++ b/apps/docs/src/app/components/component-viewer/component-viewer-wrapper.ts
@@ -22,15 +22,14 @@ import { DocsOverviewComponentBase } from './component-viewer.component';
                     {{ isRuLocale() ? 'Предложения по улучшению' : 'Suggestions for improvement' }}
                 </div>
 
+                <!-- prettier-ignore -->
                 <div class="kbq-callout__content kbq-docs-element-last-child-margin-bottom-0">
                     @if (isRuLocale()) {
                         Если вы нашли ошибку или хотите доработать статью,
-                        <!-- prettier-ignore -->
-                        <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>создайте запрос на&nbsp;GitHub</a>.</span>
+                        <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>создайте запрос на&nbsp;GitHub</a>.
                     } @else {
                         If you found a mistake or want to improve the article,
-                        <!-- prettier-ignore -->
-                        <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>create an issue on GitHub</a>.</span>
+                        <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>create an issue on GitHub</a>.
                     }
                 </div>
             </div>

--- a/apps/docs/src/app/components/component-viewer/component-viewer-wrapper.ts
+++ b/apps/docs/src/app/components/component-viewer/component-viewer-wrapper.ts
@@ -19,22 +19,18 @@ import { DocsOverviewComponentBase } from './component-viewer.component';
 
             <div class="kbq-callout kbq-callout_contrast">
                 <div class="kbq-callout__header">
-                    {{ isRuLocale() ? 'Вопросы и предложения по документации' : 'Docs Feedback' }}
+                    {{ isRuLocale() ? 'Предложения по улучшению' : 'Suggestions for improvement' }}
                 </div>
 
                 <div class="kbq-callout__content kbq-docs-element-last-child-margin-bottom-0">
                     @if (isRuLocale()) {
-                        Если у вас есть вопросы или вы хотите внести свой вклад в написание документации, пожалуйста,
-                        <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>
-                            создайте issue
-                        </a>
-                        в нашем репозитории на GitHub.
+                        Если вы нашли ошибку или хотите доработать статью,
+                        <!-- prettier-ignore -->
+                        <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>создайте запрос на&nbsp;GitHub</a>.</span>
                     } @else {
-                        If you have any questions or would like to contribute to writing the documentation, please
-                        <a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>
-                            create an issue
-                        </a>
-                        in our GitHub repository.
+                        If you found a mistake or want to improve the article,
+                        <!-- prettier-ignore -->
+                        <span><a big href="https://github.com/koobiq/angular-components/issues/new/choose" kbq-link>create an issue on GitHub</a>.</span>
                     }
                 </div>
             </div>


### PR DESCRIPTION
## Summary

По итогам вычитки обновлён текст коллаута внизу статей документации.

## List of notable changes:

- **updated** русский текст коллаута: заголовок «Предложения по улучшению», текст «Если вы нашли ошибку или хотите доработать статью, создайте запрос на GitHub.» — ссылка охватывает всю фразу, после «на» неразрывный пробел;
- **updated** английский текст: «Suggestions for improvement» / «If you found a mistake or want to improve the article, create an issue on GitHub.»

## What should reviewers focus on?

Фраза со ссылкой обёрнута в `<span>` с `<!-- prettier-ignore -->`, чтобы prettier не отрывал точку от ссылки.
