### PR TITLE
fix: corrected billion formatter key for ru-RU (#DS-5286)

### DIFF
--- a/packages/components/core/locales/formatters.ts
+++ b/packages/components/core/locales/formatters.ts
@@ -125,6 +125,7 @@ export const ruRUFormattersData = {
                 groupSeparator: ',',
                 thousand: 'К',
                 million: 'М',
+                // Latin `B` (U+0042) according to UX Guidelines.
                 billion: 'B',
                 trillion: 'Т'
             },

--- a/packages/components/core/locales/formatters.ts
+++ b/packages/components/core/locales/formatters.ts
@@ -125,7 +125,7 @@ export const ruRUFormattersData = {
                 groupSeparator: ',',
                 thousand: 'К',
                 million: 'М',
-                billion: 'М',
+                billion: 'B',
                 trillion: 'Т'
             },
             decimal: {


### PR DESCRIPTION
## Summary

Fixed typo - used `B` (unicode 66), instead of `M` for billions, according to spec