### PR TITLE
fix(select,tree-select): stop propagation on Esc when panel opened (#DS-3739)

### DIFF
--- a/packages/components/select/select.component.spec.ts
+++ b/packages/components/select/select.component.spec.ts
@@ -2683,6 +2683,24 @@ describe('KbqSelect', () => {
                 expect(fixture.componentInstance.select().panelOpen).toBe(false);
             }));
 
+            it('should stop ESCAPE propagation when the panel is open so ancestor overlays are not closed', fakeAsync(() => {
+                trigger.click();
+                fixture.detectChanges();
+                flush();
+
+                expect(fixture.componentInstance.select().panelOpen).toBe(true);
+
+                const event = createKeyboardEvent('keydown', ESCAPE);
+                const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+
+                dispatchEvent(trigger, event);
+                fixture.detectChanges();
+                flush();
+
+                expect(fixture.componentInstance.select().panelOpen).toBe(false);
+                expect(stopPropagationSpy).toHaveBeenCalled();
+            }));
+
             it('should focus the first option when pressing HOME', fakeAsync(() => {
                 fixture.componentInstance.control.setValue('pizza-1');
                 fixture.detectChanges();

--- a/packages/components/select/select.component.ts
+++ b/packages/components/select/select.component.ts
@@ -1594,6 +1594,12 @@ export class KbqSelect
         if ((isArrowKey && event.altKey) || keyCode === ESCAPE || keyCode === TAB) {
             // Close the select on ALT + arrow key to match the native <select>
             event.preventDefault();
+
+            // Prevent ESCAPE from bubbling to ancestor (when inside overlay)
+            if (keyCode === ESCAPE) {
+                event.stopPropagation();
+            }
+
             this.close();
             this.focus();
         } else if (keyCode === HOME) {

--- a/packages/components/tree-select/tree-select.component.spec.ts
+++ b/packages/components/tree-select/tree-select.component.spec.ts
@@ -2283,6 +2283,24 @@ describe('KbqTreeSelect', () => {
                 expect(fixture.componentInstance.select().panelOpen).toBe(false);
             }));
 
+            it('should stop ESCAPE propagation when the panel is open so ancestor overlays are not closed', fakeAsync(() => {
+                trigger.click();
+                fixture.detectChanges();
+                flush();
+
+                expect(fixture.componentInstance.select().panelOpen).toBe(true);
+
+                const event = createKeyboardEvent('keydown', ESCAPE);
+                const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+
+                dispatchEvent(trigger, event);
+                fixture.detectChanges();
+                flush();
+
+                expect(fixture.componentInstance.select().panelOpen).toBe(false);
+                expect(stopPropagationSpy).toHaveBeenCalled();
+            }));
+
             it('should focus the first option when pressing HOME', fakeAsync(() => {
                 fixture.componentInstance.control.setValue('Applications');
                 fixture.detectChanges();

--- a/packages/components/tree-select/tree-select.component.ts
+++ b/packages/components/tree-select/tree-select.component.ts
@@ -1244,6 +1244,12 @@ export class KbqTreeSelect
         if ((isArrowKey && event.altKey) || keyCode === ESCAPE || keyCode === TAB) {
             // Close the select on ALT + arrow key to match the native <select>
             event.preventDefault();
+
+            // Prevent ESCAPE from bubbling to ancestor (when inside overlay)
+            if (keyCode === ESCAPE) {
+                event.stopPropagation();
+            }
+
             this.close();
             this.focus();
         } else if (keyCode === LEFT_ARROW || keyCode === RIGHT_ARROW) {


### PR DESCRIPTION
## Summary

Prevent keydown Escape event bubbling for select and tree-select because it may affect other components (e.g. modals)

