### PR TITLE
fix(ci): deploy preview to v19 target

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,4 +25,4 @@ jobs:
           expires: 3d
           channelId: prs-${{ github.event.number }}
           projectId: koobiq
-          target: next
+          target: v19

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -38,7 +38,7 @@ jobs:
           expires: 3d
           channelId: prs-${{ github.event.issue.number }}
           projectId: koobiq
-          target: next
+          target: v19
       - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
## What
Fixes failing GitHub Actions job `deploy` in v19 branch by aligning Firebase Hosting target with v19 config.

## Root cause
Backported workflows from main used `target: next`, but this branch config defines only `v19` target in `.firebaserc`/`firebase.json`.

## Changes
- `.github/workflows/deploy-preview.yml`: `target` changed from `next` to `v19`
- `.github/workflows/redeploy-preview.yml`: `target` changed from `next` to `v19`

## Validation
- Failure log for job 89146998155 reported: `Hosting site or target next not detected in firebase.json`.
- Updated workflows now point to existing `v19` target.