### PR TITLE
chore(deps-dev): bump ip-address from 10.2.0 to 10.4.0 and hono from 4.12.33 to 4.13.0 (#DS-5215)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11753,9 +11753,9 @@ __metadata:
   linkType: hard
 
 "hono@npm:^4.11.4":
-  version: 4.12.33
-  resolution: "hono@npm:4.12.33"
-  checksum: 10c0/519d7e40acd8dcf9015f2012d536e56fd4896909602264a2cbc590a480ba5418dd56f68051dd5e624f3fd383abe766aaa95b5399261e9ab298dff2471271f3da
+  version: 4.13.0
+  resolution: "hono@npm:4.13.0"
+  checksum: 10c0/d7cfb4d1063be19bea1982ea2a6b3cfa1840e8403a03203e86d17278e76fed11e7483974738345257543e183a935ea73ffc6d4a1e6ad7f0008451f55cdf8be7b
   languageName: node
   linkType: hard
 
@@ -12241,9 +12241,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1, ip-address@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves four advisories, all reaching the tree through @angular/cli -> @modelcontextprotocol/sdk:

ip-address 10.2.0 -> 10.4.0 (via express-rate-limit and socks)
  GHSA-mwp4-54f8-5fhr / CVE-2026-69192 (high) - leading-zero octets decoded
  as decimal, SSRF and trust-boundary bypass
  GHSA-4xrf-jv44-h6hh / CVE-2026-69198 - a CIDR suffix suppresses
  special-use classification
  GHSA-22jq-vg5j-6vgg / CVE-2026-54272 - IPv4-mapped/NAT64 misclassification

hono 4.12.33 -> 4.13.0
  GHSA-8j4g-w8fx-2239 / CVE-2026-69207 - ReDoS in the CORS middleware via
  Access-Control-Request-Headers

Every parent range (^10.0.1, ^10.2.0, ^4.11.4) already admits the patched release, so this is a lockfile re-resolution via `yarn up -R` - no manifest change and no `resolutions` entry to carry forward.