### PR TITLE
chore: group @eslint/* and @eslint-community/* with eslint in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,12 @@ updates:
       eslint:
         patterns:
           - 'eslint*'
+          # `eslint*` does not match scoped names, so the scopes are listed separately. @eslint/js
+          # provides `eslint.configs.recommended` and @eslint-community/* plugs into the same core:
+          # both have to move in the same pull request as eslint itself, or the group lands a major
+          # where the config and the linter come from different versions.
+          - '@eslint/*'
+          - '@eslint-community/*'
           - '@typescript-eslint/*'
           - '@angular-eslint/*'
           - '@stylistic/*'


### PR DESCRIPTION
The `eslint` group matched `eslint*`, which does not cover scoped names, so `@eslint/js` and `@eslint-community/eslint-plugin-eslint-comments` were updated by their own pull requests instead.

They cannot move independently: eslint.config.js pulls `configs.recommended` out of @eslint/js, and @eslint-community plugs into the same linter core. In #1834 that showed up as a group bump to eslint 10 that left @eslint/js on ^9.0.0 — ESLint 10 running the v9 `recommended` config.
