### PR TITLE
fix(tree): prevent tooltip for non-truncated option text (#DS-4931)

### DIFF
--- a/packages/components/tree/tree-option.component.ts
+++ b/packages/components/tree/tree-option.component.ts
@@ -108,8 +108,12 @@ export class KbqTreeOption extends KbqTreeNode<KbqTreeOption> implements AfterCo
     preventBlur: boolean = false;
 
     @ViewChild('kbqTitleContainer') parentTextElement: ElementRef;
-    /** Same element as `parentTextElement` — `.kbq-option-text` clips the text, so it is measured against itself. */
-    @ViewChild('kbqTitleContainer') textElement: ElementRef;
+
+    // Same element as `parentTextElement` — `.kbq-option-text` clips the text, so it is measured against itself.
+    get textElement(): ElementRef {
+        return this.parentTextElement;
+    }
+
     readonly toggleElementDirective = contentChild(KbqTreeNodeToggleDirective);
     readonly toggleElementComponent = contentChild(KbqTreeNodeToggleComponent);
     readonly pseudoCheckbox = contentChild(KbqPseudoCheckbox);

--- a/packages/components/tree/tree-option.component.ts
+++ b/packages/components/tree/tree-option.component.ts
@@ -108,6 +108,8 @@ export class KbqTreeOption extends KbqTreeNode<KbqTreeOption> implements AfterCo
     preventBlur: boolean = false;
 
     @ViewChild('kbqTitleContainer') parentTextElement: ElementRef;
+    /** Same element as `parentTextElement` — `.kbq-option-text` clips the text, so it is measured against itself. */
+    @ViewChild('kbqTitleContainer') textElement: ElementRef;
     readonly toggleElementDirective = contentChild(KbqTreeNodeToggleDirective);
     readonly toggleElementComponent = contentChild(KbqTreeNodeToggleComponent);
     readonly pseudoCheckbox = contentChild(KbqPseudoCheckbox);

--- a/packages/components/tree/tree-selection.component.spec.ts
+++ b/packages/components/tree/tree-selection.component.spec.ts
@@ -1582,14 +1582,14 @@ describe('KbqTreeSelection', () => {
     });
 
     describe('kbq-title', () => {
-        let fixture: ComponentFixture<KbqTreeAppWithTitle>;
+        let fixture: ComponentFixture<TreeAppWithTitle>;
         let titleDirective: KbqTitleDirective;
         let optionElement: HTMLElement;
         let containerElement: HTMLElement;
 
         beforeEach(() => {
             configureKbqTreeTestingModule();
-            fixture = TestBed.createComponent(KbqTreeAppWithTitle);
+            fixture = TestBed.createComponent(TreeAppWithTitle);
             fixture.detectChanges();
 
             const optionDebugElement = fixture.debugElement.query(By.directive(KbqTitleDirective));
@@ -1619,6 +1619,46 @@ describe('KbqTreeSelection', () => {
             jest.spyOn(containerElement, 'scrollHeight', 'get').mockReturnValue(20);
 
             expect(titleDirective.isOverflown).toBe(true);
+        });
+
+        it('should report overflow when the container is clipped vertically', () => {
+            // Two-line options (`.kbq-option-caption`) clamp vertically, so the height check must stay a
+            // real signal and not just mirror the width one.
+            jest.spyOn(containerElement, 'offsetWidth', 'get').mockReturnValue(232);
+            jest.spyOn(containerElement, 'scrollWidth', 'get').mockReturnValue(232);
+            jest.spyOn(containerElement, 'offsetHeight', 'get').mockReturnValue(20);
+            jest.spyOn(containerElement, 'scrollHeight', 'get').mockReturnValue(40);
+
+            expect(titleDirective.isOverflown).toBe(true);
+        });
+    });
+
+    describe('kbq-title with projected #kbqTitleText', () => {
+        let fixture: ComponentFixture<TreeAppWithTitleText>;
+        let titleDirective: KbqTitleDirective;
+        let containerElement: HTMLElement;
+        let textElement: HTMLElement;
+
+        beforeEach(() => {
+            configureKbqTreeTestingModule();
+            fixture = TestBed.createComponent(TreeAppWithTitleText);
+            fixture.detectChanges();
+
+            const optionDebugElement = fixture.debugElement.query(By.directive(KbqTitleDirective));
+
+            titleDirective = optionDebugElement.injector.get(KbqTitleDirective);
+            containerElement = optionDebugElement.nativeElement.querySelector('.kbq-option-text')!;
+            textElement = optionDebugElement.nativeElement.querySelector('.projected-text')!;
+        });
+
+        it('should measure the projected text element, not the option container', () => {
+            // Projected `#kbqTitleText` wins over the `KbqTitleTextRef` fallback, so the container stays the
+            // measured parent while the child is the projected span. Consumers relying on this must keep working.
+            jest.spyOn(containerElement, 'offsetWidth', 'get').mockReturnValue(200);
+            jest.spyOn(containerElement, 'scrollWidth', 'get').mockReturnValue(200);
+            jest.spyOn(textElement, 'scrollWidth', 'get').mockReturnValue(400);
+
+            expect(titleDirective.isHorizontalOverflown).toBe(true);
         });
     });
 });
@@ -1850,7 +1890,22 @@ abstract class TreeParams {
         </kbq-tree-selection>
     `
 })
-class KbqTreeAppWithTitle extends TreeParams {}
+class TreeAppWithTitle extends TreeParams {}
+
+@Component({
+    imports: [
+        KbqTreeModule,
+        KbqTitleModule
+    ],
+    template: `
+        <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbq-title kbqTreeNodePadding>
+                <span #kbqTitleText class="projected-text">{{ node.name }}</span>
+            </kbq-tree-option>
+        </kbq-tree-selection>
+    `
+})
+class TreeAppWithTitleText extends TreeParams {}
 
 @Component({
     imports: [KbqTreeModule, FormsModule],

--- a/packages/components/tree/tree-selection.component.spec.ts
+++ b/packages/components/tree/tree-selection.component.spec.ts
@@ -20,6 +20,7 @@ import {
     TAB
 } from '@koobiq/components/core';
 import { KbqDropdownModule } from '@koobiq/components/dropdown';
+import { KbqTitleDirective, KbqTitleModule } from '@koobiq/components/title';
 import { AsyncScheduler } from 'rxjs/internal/scheduler/AsyncScheduler';
 import { TestScheduler } from 'rxjs/testing';
 import {
@@ -1579,6 +1580,47 @@ describe('KbqTreeSelection', () => {
             });
         });
     });
+
+    describe('kbq-title', () => {
+        let fixture: ComponentFixture<KbqTreeAppWithTitle>;
+        let titleDirective: KbqTitleDirective;
+        let optionElement: HTMLElement;
+        let containerElement: HTMLElement;
+
+        beforeEach(() => {
+            configureKbqTreeTestingModule();
+            fixture = TestBed.createComponent(KbqTreeAppWithTitle);
+            fixture.detectChanges();
+
+            const optionDebugElement = fixture.debugElement.query(By.directive(KbqTitleDirective));
+
+            titleDirective = optionDebugElement.injector.get(KbqTitleDirective);
+            optionElement = optionDebugElement.nativeElement;
+            containerElement = optionElement.querySelector('.kbq-option-text')!;
+        });
+
+        it('should measure the clipping container, not the option host', () => {
+            // The host is always wider and taller than the container it wraps (padding, border, checkbox),
+            // so measuring the container against the host reported every option as truncated.
+            jest.spyOn(optionElement, 'scrollWidth', 'get').mockReturnValue(296);
+            jest.spyOn(optionElement, 'scrollHeight', 'get').mockReturnValue(28);
+            jest.spyOn(containerElement, 'offsetWidth', 'get').mockReturnValue(232);
+            jest.spyOn(containerElement, 'scrollWidth', 'get').mockReturnValue(232);
+            jest.spyOn(containerElement, 'offsetHeight', 'get').mockReturnValue(20);
+            jest.spyOn(containerElement, 'scrollHeight', 'get').mockReturnValue(20);
+
+            expect(titleDirective.isOverflown).toBe(false);
+        });
+
+        it('should report overflow when the container is clipped', () => {
+            jest.spyOn(containerElement, 'offsetWidth', 'get').mockReturnValue(28);
+            jest.spyOn(containerElement, 'scrollWidth', 'get').mockReturnValue(70);
+            jest.spyOn(containerElement, 'offsetHeight', 'get').mockReturnValue(20);
+            jest.spyOn(containerElement, 'scrollHeight', 'get').mockReturnValue(20);
+
+            expect(titleDirective.isOverflown).toBe(true);
+        });
+    });
 });
 
 export const DATA_OBJECT = {
@@ -1796,6 +1838,19 @@ abstract class TreeParams {
         return flatNode;
     };
 }
+
+@Component({
+    imports: [
+        KbqTreeModule,
+        KbqTitleModule
+    ],
+    template: `
+        <kbq-tree-selection [dataSource]="dataSource" [treeControl]="treeControl">
+            <kbq-tree-option *kbqTreeNodeDef="let node" kbq-title kbqTreeNodePadding>{{ node.name }}</kbq-tree-option>
+        </kbq-tree-selection>
+    `
+})
+class KbqTreeAppWithTitle extends TreeParams {}
 
 @Component({
     imports: [KbqTreeModule, FormsModule],

--- a/tools/public_api_guard/components/tree.api.md
+++ b/tools/public_api_guard/components/tree.api.md
@@ -482,7 +482,8 @@ export class KbqTreeOption extends KbqTreeNode<KbqTreeOption> implements AfterCo
     // (undocumented)
     get showCheckbox(): any;
     set showCheckbox(value: any);
-    textElement: ElementRef;
+    // (undocumented)
+    get textElement(): ElementRef;
     // (undocumented)
     toggle(): void;
     // (undocumented)

--- a/tools/public_api_guard/components/tree.api.md
+++ b/tools/public_api_guard/components/tree.api.md
@@ -482,6 +482,7 @@ export class KbqTreeOption extends KbqTreeNode<KbqTreeOption> implements AfterCo
     // (undocumented)
     get showCheckbox(): any;
     set showCheckbox(value: any);
+    textElement: ElementRef;
     // (undocumented)
     toggle(): void;
     // (undocumented)


### PR DESCRIPTION
## Summary

Tree options showed a tooltip even when the text was not truncated. `KbqTreeOption` exposed only
`parentTextElement`, so `KbqTitleDirective` measured the `.kbq-option-text` container against the
option host — which is always bigger, so every option looked overflown.

Reported on `kbq-username`, but it is unchanged and correct: plain-text options were affected too.

## List of notable changes:

- **fixed** tooltip without truncation, by exposing `textElement` so the clipping box is measured against itself
- **added** two unit tests: no tooltip when the text fits, tooltip when it is clipped

## What should reviewers focus on?

Content marking its own `#kbqTitleText` keeps priority, so tree-select and filter-bar should be unaffected.

Trade-off: with `parent === child` a sub-pixel clip is no longer reported for tree options that do not
mark their own `#kbqTitleText`. Previously that case reported truncation unconditionally, so it goes
from always shown to never shown. Content marking its own text keeps both the sub-pixel branch and the
`hasEllipsis` check intact.