### PR TITLE
chore(security): document that the CodeQL job name gates merges to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,10 @@ permissions:
 
 jobs:
   analyze:
+    # `Analyze` is a required status check on main, so the job name is part of the merge gate:
+    # renaming it renames the check run, and branch protection then waits forever for a context
+    # nothing reports. A `paths:` filter would deadlock the same way, because a filtered-out run
+    # creates no check run at all.
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
`Analyze` is now a required status check on `main`, so the job name in `codeql.yml` is part of the
merge gate rather than a cosmetic label. This adds a comment saying so, next to the name it protects.

### Why

The last open code scanning alert ([#26](https://github.com/koobiq/angular-components/security/code-scanning/26))
is OpenSSF Scorecard's SAST check, not a code vulnerability — it has no file attached:

```
score is 9: SAST tool detected but not run on all commits:
Warn: 23 commits out of 29 are checked with a SAST tool
```

Scorecard reads the last 30 commits of the default branch and, for each one that came from a merged
PR, looks for a successful check run from the `github-advanced-security` app on that PR's head SHA.
All six non-compliant commits are PRs whose heads predate `codeql.yml`, which landed on `main` on
2026-08-11 in 42439d0 (#1877): #1870, #1871, #1872, #1873, #1874 and #1878. Every one of the 23 PRs
merged since then passes, Dependabot's included, so the workflow itself needed no change and the
alert clears itself once those six commits fall out of the 30-commit window.

What did need fixing is that `main` had **no required status checks at all**, so nothing stopped a PR
from merging with CodeQL failed or skipped. That is not hypothetical: on 2026-08-17 the run on
`fix/DS-5407` failed with a transient GitHub-side error while uploading SARIF
(`No server is currently available to service your request`). Had that PR been merged on that head
SHA, it would have produced a permanently non-compliant commit and re-opened the alert.

`Analyze` has been added as a required check in branch protection (`strict: false`, so branches are
not forced to be up to date before merging). This comment records the consequence for whoever edits
the workflow next.

### Notes

- Renaming the job renames the check run, and branch protection would then wait forever for a
  context nothing reports.
- A `paths:` filter would deadlock the same way: a filtered-out workflow creates no check run at all.
