### PR TITLE
fix(docs): anchor nesting in the table of contents (#DS-5468)

### DIFF
--- a/apps/docs/src/app/components/anchors/anchors.component.scss
+++ b/apps/docs/src/app/components/anchors/anchors.component.scss
@@ -20,15 +20,17 @@
 
 .docs-anchors__element {
     list-style-type: none;
-    padding: 6px 16px;
+    padding: var(--kbq-size-xs) var(--kbq-size-l);
 }
 
-.docs-anchors__element_1 {
-    padding-left: 32px;
-}
-
-.docs-anchors__element_2 {
-    padding-left: 48px;
+// One indent step per nesting level. Level 0 needs no rule of its own: the base padding above is
+// already one step. Keep the bound at the deepest level the markdown renderer emits (`#####` ->
+// `kbq-markdown__h5` -> 3). A level with no rule here falls back to the base padding and renders
+// shallower than its own parent.
+@for $level from 1 through 3 {
+    .docs-anchors__element_#{$level} {
+        padding-left: calc(var(--kbq-size-l) * #{$level + 1});
+    }
 }
 
 .docs-anchors {
@@ -48,7 +50,12 @@
 
 .docs-anchors__element {
     &:first-child {
-        padding: 0 0 0 var(--kbq-size-l);
+        // Longhands only: the `padding` shorthand would also set `padding-left`, and this selector
+        // (0,2,0) outweighs the level rule (0,1,0), so a shorthand here flattens the first anchor
+        // to the base indent whatever its nesting level.
+        padding-top: 0;
+        padding-right: 0;
+        padding-bottom: 0;
         margin: 0;
 
         & .docs-anchors__link {


### PR DESCRIPTION
## Summary

The table of contents rendered its first entry at the root indent regardless of nesting level. On the `select` overview, where every heading is `###`, that made "Валидация" look like the parent of its 15 siblings. A second, independent defect indented `#####` headings *less* than their own parent, visible on the English `select` page.

Both are stylesheet bugs. The level computation in `anchors.component.ts` is correct and is not touched.

## List of notable changes:

- **fixed** the `:first-child` rule in `anchors.component.scss` to declare `padding-top`/`right`/`bottom` instead of the `padding` shorthand, because the shorthand also set `padding-left` and its specificity (0,2,0) outweighs the level rule (0,1,0), flattening the first anchor to the base indent whatever its level
- **replaced** the hand-written `_1`/`_2` indent rules with a `@for` loop covering every level the markdown renderer can emit, because level 3 (`kbq-markdown__h5`) had no rule at all and fell back to the base padding
- **updated** the base row padding to `var(--kbq-size-xs) var(--kbq-size-l)`, the tokens the adjacent `.docs-anchors__link` rule already uses; computed values are unchanged (6px/16px)

## What should reviewers focus on?

**The cascade.** After the change the `:first-child` rule and the level rule share no property at all, so the outcome no longer depends on source order. Levels 1 and 2 keep their previous values byte for byte (32px, 48px); level 3 is new (64px).

**Verified in the browser** rather than only by reading the CSS:

| page | before | after |
|---|---|---|
| `/ru/components/select` | first anchor 16px, its 15 `###` siblings 32px | all `###` 32px, `####` 48px |
| `/en/components/select` | five `#####` at 16px, above their own parent | `###`/`####`/`#####` at 32/48/64px |
| API tab, design tokens, `theming` guide | 32/48px | unchanged |

The active-state rail stays flush with the list's left edge at every level (indentation is padding, the `box-shadow` sits on the border box), and the first row keeps its 32px height.

**Deliberately out of scope:** making the level *relative* to the page's shallowest heading. 183 of 234 documentation markdown files start at `###`, so level 0 is effectively unreachable and every list sits one step deeper than it needs to. That is a uniform shift which does not break hierarchy, and changing it would move levels on every docs page, the API tab and the design-token pages — worth its own ticket.

No unit test guards this: the change is pure CSS, and jsdom neither computes layout nor loads the component stylesheet.
