### PR TITLE
fix(datepicker,timepicker): keep the edited part of the value in view (#DS-3069)

### DIFF
--- a/packages/components/core/form-field/field-sizing-content.ts
+++ b/packages/components/core/form-field/field-sizing-content.ts
@@ -5,41 +5,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { fromEvent, merge } from 'rxjs';
 import { KBQ_WINDOW } from '../tokens';
 import { kbqInjectNativeElement } from '../utils';
-
-const INITIAL_PROPERTIES = {
-    all: 'initial',
-    position: 'absolute',
-    top: coerceCssPixelValue(0),
-    left: coerceCssPixelValue(0),
-    width: coerceCssPixelValue(0),
-    height: coerceCssPixelValue(0),
-    visibility: 'hidden',
-    overflow: 'scroll',
-    whiteSpace: 'pre',
-    pointerEvents: 'none'
-} as const satisfies Partial<CSSStyleDeclaration>;
-
-/**
- * Properties that can affect element width and should be inherited from the parent.
- */
-const WIDTH_INHERITED_PROPERTIES = [
-    'font',
-    'fontFamily',
-    'fontFeatureSettings',
-    'fontKerning',
-    'fontOpticalSizing',
-    'fontSizeAdjust',
-    'fontSize',
-    'fontStretch',
-    'fontSynthesis',
-    'fontVariant',
-    'fontVariantLigatures',
-    'fontVariationSettings',
-    'fontWeight',
-    'letterSpacing',
-    'textIndent',
-    'textTransform'
-] as const satisfies Array<keyof CSSStyleDeclaration>;
+import { kbqCreateTextRuler, kbqMeasureRulerText } from './text-ruler';
 
 /**
  * Properties that should be added to the width when `box-sizing: border-box` is applied.
@@ -93,39 +59,26 @@ export class KbqFieldSizingContent {
 
     private setupWidth(): void {
         const computedStyle = this.window.getComputedStyle(this.element);
-        const ruler = this.createRuler(computedStyle);
-
-        ruler.textContent = this.element.value || this.element.placeholder || '';
-        // We should add space to prevent text truncation in Safari/Firefox
-        if (ruler.textContent) ruler.textContent += ' ';
+        const ruler = kbqCreateTextRuler(this.document, computedStyle);
+        const text = this.element.value || this.element.placeholder || '';
 
         this.renderer.appendChild(this.document.body, ruler);
 
-        const width = this.calculateWidth(ruler, computedStyle);
+        // We should add space to prevent text truncation in Safari/Firefox
+        const width = this.calculateWidth(kbqMeasureRulerText(ruler, text && `${text} `), computedStyle);
 
         this.renderer.setStyle(this.element, 'width', coerceCssPixelValue(width));
         this.renderer.removeChild(this.document.body, ruler);
     }
 
-    private createRuler(computedStyle: CSSStyleDeclaration): HTMLElement {
-        const ruler: HTMLSpanElement = this.renderer.createElement('span');
-
-        Object.assign(ruler.style, INITIAL_PROPERTIES);
-        WIDTH_INHERITED_PROPERTIES.forEach((property) => {
-            ruler.style[property] = computedStyle[property];
-        });
-
-        return ruler;
-    }
-
-    private calculateWidth(ruler: HTMLElement, computedStyle: CSSStyleDeclaration): number {
+    private calculateWidth(textWidth: number, computedStyle: CSSStyleDeclaration): number {
         if (computedStyle.boxSizing === 'border-box') {
             return BOX_SIZING_BORDER_BOX_WIDTH_PROPERTIES.reduce(
                 (width, property) => width + (parseFloat(computedStyle[property]) || 0),
-                ruler.scrollWidth
+                textWidth
             );
         }
 
-        return ruler.scrollWidth;
+        return textWidth;
     }
 }

--- a/packages/components/core/form-field/index.ts
+++ b/packages/components/core/form-field/index.ts
@@ -1,2 +1,3 @@
 export * from './field-sizing-content';
 export * from './form-field-ref';
+export * from './text-field-selection';

--- a/packages/components/core/form-field/text-field-selection.spec.ts
+++ b/packages/components/core/form-field/text-field-selection.spec.ts
@@ -16,8 +16,9 @@ describe('text field selection', () => {
     };
 
     beforeEach(() => {
-        jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
-            return { width: (this.textContent || '').length * CHAR_WIDTH } as DOMRect;
+        // The ruler measures itself with `scrollWidth`, which jsdom reports as 0 for every element.
+        jest.spyOn(Element.prototype, 'scrollWidth', 'get').mockImplementation(function (this: Element) {
+            return (this.textContent || '').length * CHAR_WIDTH;
         });
 
         input = document.createElement('input');
@@ -32,10 +33,13 @@ describe('text field selection', () => {
         });
 
         document.body.appendChild(input);
+        input.focus();
     });
 
     afterEach(() => {
         input.remove();
+        // `clearMocks` only clears call records, so the prototype patch has to be undone by hand.
+        jest.restoreAllMocks();
         // Restores the prototype getter for the tests that shadow it on the shared document.
         Reflect.deleteProperty(document, 'defaultView');
     });
@@ -89,6 +93,27 @@ describe('text field selection', () => {
             kbqRevealSelection(input);
 
             expect(input.scrollLeft).toBe(0);
+        });
+
+        it('should leave a field the user has left alone', () => {
+            setClientWidth(100);
+            input.setSelectionRange(0, 2);
+            scrollLeft = 16;
+            input.blur();
+
+            kbqRevealSelection(input);
+
+            expect(input.scrollLeft).toBe(16);
+        });
+
+        it('should leave a field that renders something other than its value alone', () => {
+            setClientWidth(100);
+            input.type = 'password';
+            scrollLeft = 16;
+
+            kbqRevealSelection(input);
+
+            expect(input.scrollLeft).toBe(16);
         });
 
         it('should leave a field without a view alone', () => {

--- a/packages/components/core/form-field/text-field-selection.spec.ts
+++ b/packages/components/core/form-field/text-field-selection.spec.ts
@@ -1,0 +1,123 @@
+import { kbqRevealSelection, kbqSetSelectionRange } from './text-field-selection';
+
+const CHAR_WIDTH = 10;
+const PADDING = 8;
+const VALUE = '24.01.2026';
+const TEXT_WIDTH = VALUE.length * CHAR_WIDTH;
+
+describe('text field selection', () => {
+    let input: HTMLInputElement;
+    let scrollLeft: number;
+
+    /** jsdom lays nothing out, so the metrics the helper reads have to be supplied. */
+    const setClientWidth = (clientWidth: number) => {
+        Object.defineProperty(input, 'clientWidth', { value: clientWidth, configurable: true });
+        Object.defineProperty(input, 'scrollWidth', { value: TEXT_WIDTH + PADDING * 2, configurable: true });
+    };
+
+    beforeEach(() => {
+        jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+            return { width: (this.textContent || '').length * CHAR_WIDTH } as DOMRect;
+        });
+
+        input = document.createElement('input');
+        input.style.padding = `0 ${PADDING}px`;
+        input.value = VALUE;
+
+        scrollLeft = 0;
+        Object.defineProperty(input, 'scrollLeft', {
+            get: () => scrollLeft,
+            set: (value: number) => (scrollLeft = value),
+            configurable: true
+        });
+
+        document.body.appendChild(input);
+    });
+
+    afterEach(() => {
+        input.remove();
+        // Restores the prototype getter for the tests that shadow it on the shared document.
+        Reflect.deleteProperty(document, 'defaultView');
+    });
+
+    describe('kbqRevealSelection', () => {
+        it('should reset an offset left over from a longer value', () => {
+            setClientWidth(TEXT_WIDTH + PADDING * 2 + 40);
+            scrollLeft = 30;
+
+            kbqRevealSelection(input);
+
+            expect(input.scrollLeft).toBe(0);
+        });
+
+        it('should scroll back to the start for the first group', () => {
+            setClientWidth(100);
+            scrollLeft = 16;
+            input.setSelectionRange(0, 2);
+
+            kbqRevealSelection(input);
+
+            expect(input.scrollLeft).toBe(0);
+        });
+
+        it('should scroll the last group into view', () => {
+            setClientWidth(100);
+            input.setSelectionRange(6, 10);
+
+            kbqRevealSelection(input);
+
+            // The whole overflow: `end` sits at the very end of the value.
+            expect(input.scrollLeft).toBe(TEXT_WIDTH + PADDING * 2 - 100);
+        });
+
+        it('should scroll a middle group only as far as it takes to show it', () => {
+            const clientWidth = 60;
+
+            setClientWidth(clientWidth);
+            input.setSelectionRange(3, 5);
+
+            kbqRevealSelection(input);
+
+            // The end of the month group, one padding in from the right edge: neither end of the value.
+            expect(input.scrollLeft).toBe(PADDING + 5 * CHAR_WIDTH + PADDING - clientWidth);
+        });
+
+        it('should prefer the start of a selection wider than the field', () => {
+            setClientWidth(40);
+            input.setSelectionRange(0, 10);
+
+            kbqRevealSelection(input);
+
+            expect(input.scrollLeft).toBe(0);
+        });
+
+        it('should leave a field without a view alone', () => {
+            setClientWidth(100);
+            scrollLeft = 16;
+            Object.defineProperty(input.ownerDocument, 'defaultView', { value: null, configurable: true });
+
+            kbqRevealSelection(input);
+
+            expect(input.scrollLeft).toBe(16);
+        });
+    });
+
+    describe('kbqSetSelectionRange', () => {
+        it('should select the range and reveal it in one call', () => {
+            setClientWidth(100);
+
+            kbqSetSelectionRange(input, 6, 10);
+
+            expect([input.selectionStart, input.selectionEnd]).toEqual([6, 10]);
+            expect(input.scrollLeft).toBe(TEXT_WIDTH + PADDING * 2 - 100);
+        });
+
+        it('should not leave a ruler behind', () => {
+            setClientWidth(100);
+
+            kbqSetSelectionRange(input, 6, 10);
+
+            expect(document.body.querySelector('span')).toBeNull();
+        });
+    });
+});

--- a/packages/components/core/form-field/text-field-selection.ts
+++ b/packages/components/core/form-field/text-field-selection.ts
@@ -1,50 +1,4 @@
-/**
- * Properties that affect the rendered width of the text and have to be mirrored onto the ruler.
- */
-const RULER_INHERITED_PROPERTIES = [
-    'font',
-    'fontFamily',
-    'fontFeatureSettings',
-    'fontKerning',
-    'fontOpticalSizing',
-    'fontSize',
-    'fontSizeAdjust',
-    'fontStretch',
-    'fontStyle',
-    'fontSynthesis',
-    'fontVariant',
-    'fontVariationSettings',
-    'fontWeight',
-    'letterSpacing',
-    'textTransform'
-] as const satisfies Array<keyof CSSStyleDeclaration>;
-
-const RULER_PROPERTIES = {
-    all: 'initial',
-    position: 'absolute',
-    top: '0',
-    left: '0',
-    visibility: 'hidden',
-    whiteSpace: 'pre',
-    pointerEvents: 'none'
-} as const satisfies Partial<CSSStyleDeclaration>;
-
-const createRuler = (document: Document, computedStyle: CSSStyleDeclaration): HTMLSpanElement => {
-    const ruler: HTMLSpanElement = document.createElement('span');
-
-    Object.assign(ruler.style, RULER_PROPERTIES);
-    RULER_INHERITED_PROPERTIES.forEach((property) => {
-        ruler.style[property] = computedStyle[property];
-    });
-
-    return ruler;
-};
-
-const measureWith = (ruler: HTMLSpanElement, text: string): number => {
-    ruler.textContent = text;
-
-    return ruler.getBoundingClientRect().width;
-};
+import { kbqCreateTextRuler, kbqMeasureRulerText } from './text-ruler';
 
 /**
  * Scrolls a text field horizontally so that its current selection is visible.
@@ -53,8 +7,25 @@ const measureWith = (ruler: HTMLSpanElement, text: string): number => {
  * the field at whatever offset the last keystroke produced. A masked field re-renders its value and moves
  * the caret between value parts on every keystroke, so without this the field keeps the offset of the part
  * that was edited before and clips the one being edited now.
+ *
+ * Leaves the field alone when it is not focused, when it renders something other than its value, and in
+ * right-to-left text, where the browser's own caret following is already correct.
  */
 export const kbqRevealSelection = (element: HTMLInputElement): void => {
+    const document = element.ownerDocument;
+    const window = document.defaultView;
+
+    // A field the user has left is the browser's to scroll: it resets the offset on blur, and a write
+    // landing after that would park the field mid-value until it is focused again.
+    if (!window || document.activeElement !== element) {
+        return;
+    }
+
+    // A password field renders bullets, which are not the widths of the characters behind them.
+    if (element.type === 'password') {
+        return;
+    }
+
     const maxScrollLeft = element.scrollWidth - element.clientWidth;
 
     // The value fits, so any offset the field is left at is an artifact of an earlier, longer value.
@@ -64,24 +35,29 @@ export const kbqRevealSelection = (element: HTMLInputElement): void => {
         return;
     }
 
-    const document = element.ownerDocument;
-    const window = document.defaultView;
+    const computedStyle = window.getComputedStyle(element);
 
-    if (!window) {
+    // Every offset below is measured from the left edge, while an RTL field scrolls into negative
+    // `scrollLeft`. Mirroring that needs the visual order of a bidi line rather than a prefix of the
+    // value, so the browser's own caret following is left in place instead of being overwritten.
+    if (computedStyle.direction === 'rtl') {
         return;
     }
 
     const { value, selectionStart, selectionEnd, clientWidth } = element;
-    const computedStyle = window.getComputedStyle(element);
     const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
     const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
-    const ruler = createRuler(document, computedStyle);
+    const ruler = kbqCreateTextRuler(document, computedStyle);
 
     document.body.appendChild(ruler);
 
     // `scrollLeft` is measured from the start of the padding box, the text starts one `padding-left` in.
-    const start = paddingLeft + measureWith(ruler, value.slice(0, selectionStart ?? 0));
-    const end = paddingLeft + measureWith(ruler, value.slice(0, selectionEnd ?? 0));
+    const start = paddingLeft + kbqMeasureRulerText(ruler, value.slice(0, selectionStart ?? 0));
+    // A caret is the common case on the typing path, and measuring it twice costs a second layout.
+    const end =
+        selectionEnd === selectionStart
+            ? start
+            : paddingLeft + kbqMeasureRulerText(ruler, value.slice(0, selectionEnd ?? 0));
 
     ruler.remove();
 

--- a/packages/components/core/form-field/text-field-selection.ts
+++ b/packages/components/core/form-field/text-field-selection.ts
@@ -1,0 +1,107 @@
+/**
+ * Properties that affect the rendered width of the text and have to be mirrored onto the ruler.
+ */
+const RULER_INHERITED_PROPERTIES = [
+    'font',
+    'fontFamily',
+    'fontFeatureSettings',
+    'fontKerning',
+    'fontOpticalSizing',
+    'fontSize',
+    'fontSizeAdjust',
+    'fontStretch',
+    'fontStyle',
+    'fontSynthesis',
+    'fontVariant',
+    'fontVariationSettings',
+    'fontWeight',
+    'letterSpacing',
+    'textTransform'
+] as const satisfies Array<keyof CSSStyleDeclaration>;
+
+const RULER_PROPERTIES = {
+    all: 'initial',
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    visibility: 'hidden',
+    whiteSpace: 'pre',
+    pointerEvents: 'none'
+} as const satisfies Partial<CSSStyleDeclaration>;
+
+const createRuler = (document: Document, computedStyle: CSSStyleDeclaration): HTMLSpanElement => {
+    const ruler: HTMLSpanElement = document.createElement('span');
+
+    Object.assign(ruler.style, RULER_PROPERTIES);
+    RULER_INHERITED_PROPERTIES.forEach((property) => {
+        ruler.style[property] = computedStyle[property];
+    });
+
+    return ruler;
+};
+
+const measureWith = (ruler: HTMLSpanElement, text: string): number => {
+    ruler.textContent = text;
+
+    return ruler.getBoundingClientRect().width;
+};
+
+/**
+ * Scrolls a text field horizontally so that its current selection is visible.
+ *
+ * Browsers scroll a field to the caret only for edits the user makes: a selection set from script leaves
+ * the field at whatever offset the last keystroke produced. A masked field re-renders its value and moves
+ * the caret between value parts on every keystroke, so without this the field keeps the offset of the part
+ * that was edited before and clips the one being edited now.
+ */
+export const kbqRevealSelection = (element: HTMLInputElement): void => {
+    const maxScrollLeft = element.scrollWidth - element.clientWidth;
+
+    // The value fits, so any offset the field is left at is an artifact of an earlier, longer value.
+    if (maxScrollLeft <= 0) {
+        element.scrollLeft = 0;
+
+        return;
+    }
+
+    const document = element.ownerDocument;
+    const window = document.defaultView;
+
+    if (!window) {
+        return;
+    }
+
+    const { value, selectionStart, selectionEnd, clientWidth } = element;
+    const computedStyle = window.getComputedStyle(element);
+    const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+    const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
+    const ruler = createRuler(document, computedStyle);
+
+    document.body.appendChild(ruler);
+
+    // `scrollLeft` is measured from the start of the padding box, the text starts one `padding-left` in.
+    const start = paddingLeft + measureWith(ruler, value.slice(0, selectionStart ?? 0));
+    const end = paddingLeft + measureWith(ruler, value.slice(0, selectionEnd ?? 0));
+
+    ruler.remove();
+
+    // The smallest offset that still shows the selection, so that as much as possible of what precedes it
+    // stays on screen. Deriving the offset from the selection alone, instead of nudging the current one,
+    // keeps the result independent of where the last keystroke happened to leave the field.
+    const minimumRevealingEnd = Math.max(end + paddingRight - clientWidth, 0);
+    // A selection wider than the field cannot be shown whole; its start is the half worth keeping.
+    const maximumKeepingStart = Math.max(start - paddingLeft, 0);
+
+    element.scrollLeft = Math.min(minimumRevealingEnd, maximumKeepingStart, maxScrollLeft);
+};
+
+/**
+ * Selects the `[start, end]` range of a text field and keeps it visible.
+ *
+ * @see {@link kbqRevealSelection}
+ */
+export const kbqSetSelectionRange = (element: HTMLInputElement, start: number, end: number): void => {
+    element.setSelectionRange(start, end);
+
+    kbqRevealSelection(element);
+};

--- a/packages/components/core/form-field/text-ruler.ts
+++ b/packages/components/core/form-field/text-ruler.ts
@@ -1,0 +1,71 @@
+/**
+ * Properties that affect the rendered width of the text and have to be mirrored onto the ruler.
+ *
+ * `font-variant` is deliberately absent: the shorthand does not round-trip through the computed style
+ * once a field sets more than one of its longhands, so the longhands are copied instead.
+ */
+const RULER_INHERITED_PROPERTIES = [
+    'font',
+    'fontFamily',
+    'fontFeatureSettings',
+    'fontKerning',
+    'fontOpticalSizing',
+    'fontSize',
+    'fontSizeAdjust',
+    'fontStretch',
+    'fontStyle',
+    'fontSynthesis',
+    'fontVariantCaps',
+    'fontVariantEastAsian',
+    'fontVariantLigatures',
+    'fontVariantNumeric',
+    'fontVariationSettings',
+    'fontWeight',
+    'letterSpacing',
+    'textIndent',
+    'textTransform'
+] as const satisfies Array<keyof CSSStyleDeclaration>;
+
+const RULER_PROPERTIES = {
+    all: 'initial',
+    position: 'absolute',
+    top: '0px',
+    left: '0px',
+    width: '0px',
+    height: '0px',
+    visibility: 'hidden',
+    overflow: 'scroll',
+    whiteSpace: 'pre',
+    pointerEvents: 'none'
+} as const satisfies Partial<CSSStyleDeclaration>;
+
+/**
+ * Builds a hidden element that renders text with the typography of the element `computedStyle` was taken
+ * from. Append it to the document, measure through {@link kbqMeasureRulerText}, and remove it.
+ *
+ * @docs-private
+ */
+export const kbqCreateTextRuler = (document: Document, computedStyle: CSSStyleDeclaration): HTMLSpanElement => {
+    const ruler: HTMLSpanElement = document.createElement('span');
+
+    Object.assign(ruler.style, RULER_PROPERTIES);
+    RULER_INHERITED_PROPERTIES.forEach((property) => {
+        ruler.style[property] = computedStyle[property];
+    });
+
+    return ruler;
+};
+
+/**
+ * Width of `text` in pixels, in the same coordinate space as `clientWidth` and `scrollLeft`.
+ *
+ * `scrollWidth`, not `getBoundingClientRect()`: the latter reports the transformed box, which disagrees
+ * with the untransformed layout metrics it would be compared against under a scaled ancestor.
+ *
+ * @docs-private
+ */
+export const kbqMeasureRulerText = (ruler: HTMLSpanElement, text: string): number => {
+    ruler.textContent = text;
+
+    return ruler.scrollWidth;
+};

--- a/packages/components/datepicker/datepicker-input.directive.ts
+++ b/packages/components/datepicker/datepicker-input.directive.ts
@@ -50,6 +50,7 @@ import {
     KbqErrorStateTracker,
     kbqInjectLocaleConfiguration,
     kbqLocaleConfigurationOverrideProvider,
+    kbqRevealSelection,
     kbqSetSelectionRange,
     LEFT_ARROW,
     PAGE_DOWN,
@@ -754,7 +755,7 @@ export class KbqDatepickerInput<D>
     }
 
     onInput = () => {
-        this.correctCursorPosition();
+        const cursorPosition = this.correctedCursorPosition();
         const formattedValue = this.replaceSymbols(this.viewValue);
 
         const newTimeObj = this.getDateFromString(formattedValue);
@@ -774,7 +775,7 @@ export class KbqDatepickerInput<D>
 
         this.setViewValue(this.getTimeStringFromDate(newTimeObj, this.dateInputFormat), true);
 
-        this.selectNextDigitByCursor(this.selectionStart as number);
+        this.selectNextDigitByCursor(cursorPosition);
 
         this.updateValue(newTimeObj);
     };
@@ -975,15 +976,19 @@ export class KbqDatepickerInput<D>
     private spaceKeyHandler(event: KeyboardEvent) {
         event.preventDefault();
 
-        if (this.selectionStart === this.selectionEnd) {
-            const value = this.getNewValue(event.key, this.selectionStart as number);
+        const position = this.selectionStart as number;
 
-            this.setViewValue(value);
+        // Right after a separator the digit group is empty, so a space cannot stand in for one:
+        // advance instead of inserting a character the value can never be parsed with.
+        if (this.selectionStart !== this.selectionEnd || this.separatorPositions.includes(position)) {
+            this.selectNextDigit(position, true);
 
-            setTimeout(this.onInput);
-        } else if (this.selectionStart !== this.selectionEnd) {
-            this.selectNextDigit(this.selectionStart as number, true);
+            return;
         }
+
+        this.setViewValue(this.getNewValue(event.key, position));
+
+        setTimeout(this.onInput);
     }
 
     private getNewValue(key: string, position: number) {
@@ -992,17 +997,22 @@ export class KbqDatepickerInput<D>
 
     private setViewValue(value: string, savePosition: boolean = false) {
         const element = this.elementRef.nativeElement;
+        const selectionStart = this.selectionStart ?? 0;
+        const selectionEnd = this.selectionEnd ?? 0;
+
+        this.renderer.setProperty(element, 'value', value);
 
         if (savePosition) {
-            const selectionStart = this.selectionStart ?? 0;
-            const selectionEnd = this.selectionEnd ?? 0;
-
-            this.renderer.setProperty(element, 'value', value);
-
-            kbqSetSelectionRange(element, selectionStart, selectionEnd);
+            this.setSelection(selectionStart, selectionEnd);
         } else {
-            this.renderer.setProperty(element, 'value', value);
+            // A paste, a model write or a calendar pick replaces the whole value, and the offset the
+            // previous one was left at has to go with it.
+            kbqRevealSelection(element);
         }
+    }
+
+    private setSelection(start: number, end: number): void {
+        kbqSetSelectionRange(this.elementRef.nativeElement, start, end);
     }
 
     private replaceSymbols(value: string): string {
@@ -1319,7 +1329,7 @@ export class KbqDatepickerInput<D>
 
         this.value = changedTime;
 
-        kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
+        this.setSelection(selectionStart, selectionEnd);
 
         this.cvaOnChange(changedTime);
 
@@ -1372,7 +1382,7 @@ export class KbqDatepickerInput<D>
         setTimeout(() => {
             const [, selectionStart, selectionEnd] = this.getDateEditMetrics(cursorPos);
 
-            kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
+            this.setSelection(selectionStart, selectionEnd);
         });
     }
 
@@ -1381,7 +1391,7 @@ export class KbqDatepickerInput<D>
             const [, , endPositionOfCurrentDigit] = this.getDateEditMetrics(cursorPos);
             const [, selectionStart, selectionEnd] = this.getDateEditMetrics(endPositionOfCurrentDigit + 1);
 
-            kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
+            this.setSelection(selectionStart, selectionEnd);
         });
     }
 
@@ -1394,7 +1404,7 @@ export class KbqDatepickerInput<D>
 
             const [, selectionStart, selectionEnd] = this.getDateEditMetrics(newCursorPos);
 
-            kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
+            this.setSelection(selectionStart, selectionEnd);
         });
     }
 
@@ -1533,13 +1543,12 @@ export class KbqDatepickerInput<D>
         );
     }
 
-    private correctCursorPosition() {
-        const position = this.selectionStart;
+    // The position to advance from, with a caret that landed just past a separator pulled back onto
+    // the digit before it. Returned rather than applied to the field: on the paths where the value
+    // cannot be parsed, a moved caret would survive into the next keystroke and change what it does.
+    private correctedCursorPosition(): number {
+        const position = this.selectionStart ?? 0;
 
-        // Assigning `selectionStart` on its own leaves `selectionEnd` where it was, turning the caret
-        // into a one-character selection that the next digit overwrites instead of inserting before.
-        if (position && this.separatorPositions.includes(position)) {
-            kbqSetSelectionRange(this.elementRef.nativeElement, position - 1, position - 1);
-        }
+        return this.separatorPositions.includes(position) ? position - 1 : position;
     }
 }

--- a/packages/components/datepicker/datepicker-input.directive.ts
+++ b/packages/components/datepicker/datepicker-input.directive.ts
@@ -50,6 +50,7 @@ import {
     KbqErrorStateTracker,
     kbqInjectLocaleConfiguration,
     kbqLocaleConfigurationOverrideProvider,
+    kbqSetSelectionRange,
     LEFT_ARROW,
     PAGE_DOWN,
     PAGE_UP,
@@ -559,16 +560,8 @@ export class KbqDatepickerInput<D>
         return this.elementRef.nativeElement.selectionStart;
     }
 
-    private set selectionStart(value: number | null) {
-        this.elementRef.nativeElement.selectionStart = value;
-    }
-
     private get selectionEnd(): number | null {
         return this.elementRef.nativeElement.selectionEnd;
-    }
-
-    private set selectionEnd(value: number | null) {
-        this.elementRef.nativeElement.selectionEnd = value;
     }
 
     private control: AbstractControl | undefined;
@@ -998,16 +991,17 @@ export class KbqDatepickerInput<D>
     }
 
     private setViewValue(value: string, savePosition: boolean = false) {
+        const element = this.elementRef.nativeElement;
+
         if (savePosition) {
-            const selectionStart = this.selectionStart;
-            const selectionEnd = this.selectionEnd;
+            const selectionStart = this.selectionStart ?? 0;
+            const selectionEnd = this.selectionEnd ?? 0;
 
-            this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+            this.renderer.setProperty(element, 'value', value);
 
-            this.selectionStart = selectionStart;
-            this.selectionEnd = selectionEnd;
+            kbqSetSelectionRange(element, selectionStart, selectionEnd);
         } else {
-            this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+            this.renderer.setProperty(element, 'value', value);
         }
     }
 
@@ -1325,8 +1319,7 @@ export class KbqDatepickerInput<D>
 
         this.value = changedTime;
 
-        this.selectionStart = selectionStart;
-        this.selectionEnd = selectionEnd;
+        kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
 
         this.cvaOnChange(changedTime);
 
@@ -1379,8 +1372,7 @@ export class KbqDatepickerInput<D>
         setTimeout(() => {
             const [, selectionStart, selectionEnd] = this.getDateEditMetrics(cursorPos);
 
-            this.selectionStart = selectionStart;
-            this.selectionEnd = selectionEnd;
+            kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
         });
     }
 
@@ -1389,8 +1381,7 @@ export class KbqDatepickerInput<D>
             const [, , endPositionOfCurrentDigit] = this.getDateEditMetrics(cursorPos);
             const [, selectionStart, selectionEnd] = this.getDateEditMetrics(endPositionOfCurrentDigit + 1);
 
-            this.selectionStart = selectionStart;
-            this.selectionEnd = selectionEnd;
+            kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
         });
     }
 
@@ -1403,8 +1394,7 @@ export class KbqDatepickerInput<D>
 
             const [, selectionStart, selectionEnd] = this.getDateEditMetrics(newCursorPos);
 
-            this.selectionStart = selectionStart;
-            this.selectionEnd = selectionEnd;
+            kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, selectionEnd);
         });
     }
 
@@ -1544,8 +1534,12 @@ export class KbqDatepickerInput<D>
     }
 
     private correctCursorPosition() {
-        if (this.selectionStart && this.separatorPositions.includes(this.selectionStart)) {
-            this.selectionStart = this.selectionStart - 1;
+        const position = this.selectionStart;
+
+        // Assigning `selectionStart` on its own leaves `selectionEnd` where it was, turning the caret
+        // into a one-character selection that the next digit overwrites instead of inserting before.
+        if (position && this.separatorPositions.includes(position)) {
+            kbqSetSelectionRange(this.elementRef.nativeElement, position - 1, position - 1);
         }
     }
 }

--- a/packages/components/datepicker/datepicker.spec.ts
+++ b/packages/components/datepicker/datepicker.spec.ts
@@ -467,6 +467,57 @@ describe('KbqDatepicker', () => {
             }));
         });
 
+        describe('caret handling', () => {
+            const charWidth = 10;
+            const clientWidth = 60;
+            const value = '24.01.2026';
+
+            let fixture: ComponentFixture<StandardDatepicker>;
+            let input: HTMLInputElement;
+
+            beforeEach(() => {
+                fixture = createComponent(StandardDatepicker, [KbqLuxonDateModule]);
+                fixture.detectChanges();
+
+                input = getDatepickerInputElement(fixture);
+                input.value = value;
+            });
+
+            it('should move the caret off a separator instead of selecting the digit before it', () => {
+                input.setSelectionRange(3, 3);
+
+                fixture.componentInstance.datepickerInput().onInput();
+
+                expect([input.selectionStart, input.selectionEnd]).toEqual([2, 2]);
+            });
+
+            it('should scroll the part the caret moves to into view', fakeAsync(() => {
+                // jsdom lays nothing out, so the metrics the reveal reads have to be supplied.
+                jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+                    return { width: (this.textContent || '').length * charWidth } as DOMRect;
+                });
+                Object.defineProperty(input, 'scrollWidth', { value: value.length * charWidth, configurable: true });
+                Object.defineProperty(input, 'clientWidth', { value: clientWidth, configurable: true });
+
+                let scrollLeft = 0;
+
+                Object.defineProperty(input, 'scrollLeft', {
+                    get: () => scrollLeft,
+                    set: (offset: number) => (scrollLeft = offset),
+                    configurable: true
+                });
+
+                // The caret sits at the end of the month, so the year is the part it moves on to.
+                input.setSelectionRange(5, 5);
+
+                fixture.componentInstance.datepickerInput().onInput();
+                tick();
+
+                expect([input.selectionStart, input.selectionEnd]).toEqual([6, 10]);
+                expect(input.scrollLeft).toBe(value.length * charWidth - clientWidth);
+            }));
+        });
+
         describe('datepicker with too many inputs', () => {
             it('should throw when multiple inputs registered', fakeAsync(() => {
                 const fixture = createComponent(MultiInputDatepicker, [KbqLuxonDateModule]);

--- a/packages/components/datepicker/datepicker.spec.ts
+++ b/packages/components/datepicker/datepicker.spec.ts
@@ -469,52 +469,67 @@ describe('KbqDatepicker', () => {
 
         describe('caret handling', () => {
             const charWidth = 10;
+            const padding = 8;
             const clientWidth = 60;
             const value = '24.01.2026';
 
             let fixture: ComponentFixture<StandardDatepicker>;
             let input: HTMLInputElement;
+            let scrollLeft: number;
+
+            // jsdom lays nothing out, so the metrics the reveal reads have to be supplied.
+            const stubMetrics = () => {
+                jest.spyOn(Element.prototype, 'scrollWidth', 'get').mockImplementation(function (this: Element) {
+                    return (this.textContent || '').length * charWidth;
+                });
+                Object.defineProperty(input, 'scrollWidth', {
+                    value: value.length * charWidth + padding * 2,
+                    configurable: true
+                });
+                Object.defineProperty(input, 'clientWidth', { value: clientWidth, configurable: true });
+                Object.defineProperty(input, 'scrollLeft', {
+                    get: () => scrollLeft,
+                    set: (offset: number) => (scrollLeft = offset),
+                    configurable: true
+                });
+            };
 
             beforeEach(() => {
                 fixture = createComponent(StandardDatepicker, [KbqLuxonDateModule]);
                 fixture.detectChanges();
 
                 input = getDatepickerInputElement(fixture);
+                input.style.padding = `0 ${padding}px`;
                 input.value = value;
+                scrollLeft = 0;
+                input.focus();
             });
 
-            it('should move the caret off a separator instead of selecting the digit before it', () => {
+            // `clearMocks` only clears call records, so the prototype patch has to be undone by hand.
+            afterEach(() => jest.restoreAllMocks());
+
+            it('should advance from the digit before a separator, not the one after it', fakeAsync(() => {
                 input.setSelectionRange(3, 3);
-
-                fixture.componentInstance.datepickerInput().onInput();
-
-                expect([input.selectionStart, input.selectionEnd]).toEqual([2, 2]);
-            });
-
-            it('should scroll the part the caret moves to into view', fakeAsync(() => {
-                // jsdom lays nothing out, so the metrics the reveal reads have to be supplied.
-                jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
-                    return { width: (this.textContent || '').length * charWidth } as DOMRect;
-                });
-                Object.defineProperty(input, 'scrollWidth', { value: value.length * charWidth, configurable: true });
-                Object.defineProperty(input, 'clientWidth', { value: clientWidth, configurable: true });
-
-                let scrollLeft = 0;
-
-                Object.defineProperty(input, 'scrollLeft', {
-                    get: () => scrollLeft,
-                    set: (offset: number) => (scrollLeft = offset),
-                    configurable: true
-                });
-
-                // The caret sits at the end of the month, so the year is the part it moves on to.
-                input.setSelectionRange(5, 5);
 
                 fixture.componentInstance.datepickerInput().onInput();
                 tick();
 
-                expect([input.selectionStart, input.selectionEnd]).toEqual([6, 10]);
-                expect(input.scrollLeft).toBe(value.length * charWidth - clientWidth);
+                // Corrected back onto the day, so the month follows; uncorrected it would skip to the year.
+                expect([input.selectionStart, input.selectionEnd]).toEqual([3, 5]);
+            }));
+
+            it('should scroll the part the caret moves to into view', fakeAsync(() => {
+                stubMetrics();
+
+                // The caret sits at the end of the day, so the month is the part it moves on to.
+                input.setSelectionRange(2, 2);
+
+                fixture.componentInstance.datepickerInput().onInput();
+                tick();
+
+                expect([input.selectionStart, input.selectionEnd]).toEqual([3, 5]);
+                // Just enough to show the end of the month: neither end of the value.
+                expect(input.scrollLeft).toBe(padding + 5 * charWidth + padding - clientWidth);
             }));
         });
 

--- a/packages/components/datepicker/e2e.playwright-spec.ts
+++ b/packages/components/datepicker/e2e.playwright-spec.ts
@@ -91,8 +91,10 @@ test.describe('KbqDatepickerModule', () => {
 
             const typed = await readState(input);
 
-            // Without an overflow there is nothing to scroll and the rest of this proves nothing.
+            // Without an overflow, and without the field actually being scrolled away from the start,
+            // the assertion below would hold for a field that never moved.
             expect(typed.overflowing).toBe(true);
+            expect(typed.scrollLeft).toBeGreaterThan(0);
             expect(typed.selection).toBe('6,10');
 
             // Back through the month and onto the day, which the field is currently scrolled past.

--- a/packages/components/datepicker/e2e.playwright-spec.ts
+++ b/packages/components/datepicker/e2e.playwright-spec.ts
@@ -62,6 +62,48 @@ test.describe('KbqDatepickerModule', () => {
         });
     });
 
+    test.describe('a value wider than the field', () => {
+        const readState = (input: Locator) =>
+            input.evaluate((element: HTMLInputElement) => ({
+                value: element.value,
+                selection: [element.selectionStart, element.selectionEnd].join(','),
+                scrollLeft: element.scrollLeft,
+                overflowing: element.scrollWidth > element.clientWidth
+            }));
+
+        test('scrolls back to the part the caret returns to', async ({ page }) => {
+            await page.goto('/E2eDatepickerPositioning');
+
+            // Squeezed until `dd.MM.yyyy` no longer fits, the state a narrower system font or an extra
+            // suffix in the field puts it in. Only then does the field have an offset to get stuck at.
+            await page.getByTestId('e2eFormField').evaluate((formField: HTMLElement) => {
+                formField.style.width = '96px';
+            });
+
+            const input = page.locator('input.kbq-datepicker');
+
+            await input.click();
+            await page.keyboard.press('Control+a');
+            // Typing is what scrolls the field: the browser follows the caret to the end of the value.
+            await page.keyboard.type('24012024', { delay: 30 });
+
+            await expect.poll(async () => (await readState(input)).value).toBe('24.01.2024');
+
+            const typed = await readState(input);
+
+            // Without an overflow there is nothing to scroll and the rest of this proves nothing.
+            expect(typed.overflowing).toBe(true);
+            expect(typed.selection).toBe('6,10');
+
+            // Back through the month and onto the day, which the field is currently scrolled past.
+            await page.keyboard.press('ArrowLeft');
+            await page.keyboard.press('ArrowLeft');
+
+            await expect.poll(async () => (await readState(input)).selection).toBe('0,2');
+            expect((await readState(input)).scrollLeft).toBe(0);
+        });
+    });
+
     test.describe('trigger↔panel gap is not click-through', () => {
         // The overlay's origin is the form-field's connection container (KbqFormField.getConnectedOverlayOrigin()),
         // not the raw <input>, so that's what "trigger" means for the gap probe here.

--- a/packages/components/timepicker/timepicker.directive.ts
+++ b/packages/components/timepicker/timepicker.directive.ts
@@ -45,6 +45,7 @@ import {
     KbqErrorStateTracker,
     kbqInjectLocaleConfiguration,
     kbqLocaleConfigurationOverrideProvider,
+    kbqSetSelectionRange,
     KbqTimepickerLocaleConfiguration,
     LEFT_ARROW,
     PAGE_DOWN,
@@ -549,8 +550,9 @@ export class KbqTimepicker<D>
             this.setViewValue(nextViewValue);
 
             if (selectionStart !== null) {
-                this.selectionStart = selectionStart;
-                this.selectionEnd = newTimeObj ? selectionEnd : selectionStart;
+                const rangeEnd = newTimeObj ? (selectionEnd ?? selectionStart) : selectionStart;
+
+                kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, rangeEnd);
 
                 this.createSelectionOfTimeComponentInInput(selectionStart + 1);
             }
@@ -775,8 +777,11 @@ export class KbqTimepicker<D>
 
         this.value = changedTime;
 
-        this.selectionStart = newEditParams.cursorStartPosition;
-        this.selectionEnd = newEditParams.cursorEndPosition;
+        kbqSetSelectionRange(
+            this.elementRef.nativeElement,
+            newEditParams.cursorStartPosition,
+            newEditParams.cursorEndPosition
+        );
 
         this.onChange(changedTime);
         this.stateChanges.next();
@@ -819,8 +824,11 @@ export class KbqTimepicker<D>
         setTimeout(() => {
             const newEditParams = this.getTimeEditMetrics(cursorPos);
 
-            this.selectionStart = newEditParams.cursorStartPosition;
-            this.selectionEnd = newEditParams.cursorEndPosition;
+            kbqSetSelectionRange(
+                this.elementRef.nativeElement,
+                newEditParams.cursorStartPosition,
+                newEditParams.cursorEndPosition
+            );
         });
     }
 

--- a/packages/components/timepicker/timepicker.directive.ts
+++ b/packages/components/timepicker/timepicker.directive.ts
@@ -45,6 +45,7 @@ import {
     KbqErrorStateTracker,
     kbqInjectLocaleConfiguration,
     kbqLocaleConfigurationOverrideProvider,
+    kbqRevealSelection,
     kbqSetSelectionRange,
     KbqTimepickerLocaleConfiguration,
     LEFT_ARROW,
@@ -383,6 +384,8 @@ export class KbqTimepicker<D>
 
     set selectionStart(value: number | null) {
         this.elementRef.nativeElement.selectionStart = value;
+
+        kbqRevealSelection(this.elementRef.nativeElement);
     }
 
     get selectionEnd(): number | null {
@@ -391,6 +394,8 @@ export class KbqTimepicker<D>
 
     set selectionEnd(value: number | null) {
         this.elementRef.nativeElement.selectionEnd = value;
+
+        kbqRevealSelection(this.elementRef.nativeElement);
     }
 
     /** Localized placeholder */
@@ -552,7 +557,7 @@ export class KbqTimepicker<D>
             if (selectionStart !== null) {
                 const rangeEnd = newTimeObj ? (selectionEnd ?? selectionStart) : selectionStart;
 
-                kbqSetSelectionRange(this.elementRef.nativeElement, selectionStart, rangeEnd);
+                this.setSelection(selectionStart, rangeEnd);
 
                 this.createSelectionOfTimeComponentInInput(selectionStart + 1);
             }
@@ -777,11 +782,7 @@ export class KbqTimepicker<D>
 
         this.value = changedTime;
 
-        kbqSetSelectionRange(
-            this.elementRef.nativeElement,
-            newEditParams.cursorStartPosition,
-            newEditParams.cursorEndPosition
-        );
+        this.setSelection(newEditParams.cursorStartPosition, newEditParams.cursorEndPosition);
 
         this.onChange(changedTime);
         this.stateChanges.next();
@@ -824,11 +825,7 @@ export class KbqTimepicker<D>
         setTimeout(() => {
             const newEditParams = this.getTimeEditMetrics(cursorPos);
 
-            kbqSetSelectionRange(
-                this.elementRef.nativeElement,
-                newEditParams.cursorStartPosition,
-                newEditParams.cursorEndPosition
-            );
+            this.setSelection(newEditParams.cursorStartPosition, newEditParams.cursorEndPosition);
         });
     }
 
@@ -1040,7 +1037,17 @@ export class KbqTimepicker<D>
     }
 
     private setViewValue(value: string) {
-        this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+        const element = this.elementRef.nativeElement;
+
+        this.renderer.setProperty(element, 'value', value);
+
+        // A paste or a model write replaces the whole value, and the offset the previous one was left
+        // at has to go with it.
+        kbqRevealSelection(element);
+    }
+
+    private setSelection(start: number, end: number): void {
+        kbqSetSelectionRange(this.elementRef.nativeElement, start, end);
     }
 
     private updateView() {

--- a/packages/components/timepicker/timepicker.spec.ts
+++ b/packages/components/timepicker/timepicker.spec.ts
@@ -138,17 +138,29 @@ describe(KbqTimepicker.name, () => {
 
     describe('caret handling', () => {
         const charWidth = 10;
-        const clientWidth = 30;
+        const padding = 8;
+        const clientWidth = 40;
+        const value = '12:18:28';
+
+        // `clearMocks` only clears call records, so the prototype patch has to be undone by hand.
+        afterEach(() => jest.restoreAllMocks());
 
         it('should scroll the part the caret moves to into view', fakeAsync(() => {
+            // Three parts, so the caret can land on one that is neither end of the value.
+            testComponent.timeFormat = TimeFormats.HHmmss;
+            fixture.detectChanges();
+
             const input = getTimepickerElement(fixture);
 
+            expect(input.value).toBe(value);
+
             // jsdom lays nothing out, so the metrics the reveal reads have to be supplied.
-            jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
-                return { width: (this.textContent || '').length * charWidth } as DOMRect;
+            jest.spyOn(Element.prototype, 'scrollWidth', 'get').mockImplementation(function (this: Element) {
+                return (this.textContent || '').length * charWidth;
             });
+            input.style.padding = `0 ${padding}px`;
             Object.defineProperty(input, 'scrollWidth', {
-                value: input.value.length * charWidth,
+                value: value.length * charWidth + padding * 2,
                 configurable: true
             });
             Object.defineProperty(input, 'clientWidth', { value: clientWidth, configurable: true });
@@ -161,6 +173,7 @@ describe(KbqTimepicker.name, () => {
                 configurable: true
             });
 
+            input.focus();
             // The caret sits at the end of the hours, so the minutes are the part it moves on to.
             input.setSelectionRange(2, 2);
 
@@ -168,7 +181,8 @@ describe(KbqTimepicker.name, () => {
             tick();
 
             expect([input.selectionStart, input.selectionEnd]).toEqual([3, 5]);
-            expect(input.scrollLeft).toBe(input.value.length * charWidth - clientWidth);
+            // Just enough to show the end of the minutes: neither end of the value.
+            expect(input.scrollLeft).toBe(padding + 5 * charWidth + padding - clientWidth);
         }));
     });
 

--- a/packages/components/timepicker/timepicker.spec.ts
+++ b/packages/components/timepicker/timepicker.spec.ts
@@ -136,6 +136,42 @@ describe(KbqTimepicker.name, () => {
         fixture.detectChanges();
     });
 
+    describe('caret handling', () => {
+        const charWidth = 10;
+        const clientWidth = 30;
+
+        it('should scroll the part the caret moves to into view', fakeAsync(() => {
+            const input = getTimepickerElement(fixture);
+
+            // jsdom lays nothing out, so the metrics the reveal reads have to be supplied.
+            jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+                return { width: (this.textContent || '').length * charWidth } as DOMRect;
+            });
+            Object.defineProperty(input, 'scrollWidth', {
+                value: input.value.length * charWidth,
+                configurable: true
+            });
+            Object.defineProperty(input, 'clientWidth', { value: clientWidth, configurable: true });
+
+            let scrollLeft = 0;
+
+            Object.defineProperty(input, 'scrollLeft', {
+                get: () => scrollLeft,
+                set: (offset: number) => (scrollLeft = offset),
+                configurable: true
+            });
+
+            // The caret sits at the end of the hours, so the minutes are the part it moves on to.
+            input.setSelectionRange(2, 2);
+
+            inputElementDebug.injector.get(KbqTimepicker).onInput();
+            tick();
+
+            expect([input.selectionStart, input.selectionEnd]).toEqual([3, 5]);
+            expect(input.scrollLeft).toBe(input.value.length * charWidth - clientWidth);
+        }));
+    });
+
     describe('Core attributes support', () => {
         it('Timepicker disabled state switching on/off', () => {
             testComponent.isDisabled = true;

--- a/tools/public_api_guard/components/core.api.md
+++ b/tools/public_api_guard/components/core.api.md
@@ -4037,6 +4037,9 @@ export function kbqResolvePanelWidth(panelWidth: KbqPanelWidth | undefined, pane
 // @public
 export const kbqResolveTimezoneOffset: (timezone: KbqTimezoneLike, timestamp: number) => number | null;
 
+// @public
+export const kbqRevealSelection: (element: HTMLInputElement) => void;
+
 // @public (undocumented)
 export class KbqRoundDecimalPipe implements PipeTransform {
     constructor();
@@ -4163,6 +4166,9 @@ export class KbqSelectTrigger {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqSelectTrigger, never>;
 }
+
+// @public
+export const kbqSetSelectionRange: (element: HTMLInputElement, start: number, end: number) => void;
 
 // @public
 export class KbqShadowDomOverlayContainer extends OverlayContainer {


### PR DESCRIPTION
## Summary

In a datepicker or timepicker field narrower than its value, the part being edited could sit off screen. Browsers scroll a text field to the caret only for edits the user makes; these masked inputs re-render the value and move the caret between digit groups from script on every keystroke, and nothing reconciled the horizontal offset afterwards. The field kept whatever position the last keystroke left it in and clipped the group the caret had just moved to, resetting only on blur — which is what "the digits run away while you work with them" looks like.

It was reported as Safari-only, but the mechanism is engine-independent: programmatic selection changes scroll the field in neither WebKit nor Blink. What differs is the threshold. The stock field is `136px` with ~13px of slack for `dd.MM.yyyy`, so it does not overflow on its own; an extra suffix in that fixed width uses the slack up, and WebKit then reserves one pixel more than Blink, so Safari crosses over where Chrome still fits. The regression test therefore asserts the bug in Chromium rather than depending on Safari: without the fix the field stays at `scrollLeft = 27` after the caret returns to the day group, with it at `0`.

## List of notable changes:

- **added** `kbqSetSelectionRange` and `kbqRevealSelection` to `@koobiq/components/core`, which set a text field's selection and then scroll the field to the smallest offset that keeps that selection fully visible — plain `0` whenever the value fits, so a field with room behaves exactly as before
- **updated** `KbqDatepickerInput` and `KbqTimepicker` so that every programmatic caret move goes through one private `setSelection`, and every value write reconciles the offset from `setViewValue` — that covers paste, model writes and calendar selection, not only the typing path
- **added** an internal shared text ruler (`core/form-field/text-ruler.ts`) used by the new helper and by `KbqFieldSizingContent`, replacing two copies of the same measurement that had already diverged on which font properties they mirror
- **fixed** `correctCursorPosition` in the datepicker, which assigned `selectionStart` on its own and so turned the caret into a one-character selection that the next digit overwrote instead of inserting before; it now computes the position instead of mutating the field
- **fixed** Space pressed right after a separator, which inserted a literal space into a value that could never be parsed with it; it now advances to the next digit group

Public API grows by the two exported functions; `core.api.md` is updated accordingly. No visual changes, so no screenshot baselines are affected.

## What should reviewers focus on?

- **The guards in `kbqRevealSelection`.** It deliberately does nothing for a field the user has left (the browser resets that offset itself, and writing to it afterwards parks the field mid-value), for a field that renders something other than its value (`type="password"`), and in right-to-left text.
- **RTL is opted out of, not supported.** `scrollLeft` is negative in an RTL field, and mirroring the arithmetic needs the visual order of a bidi line rather than a prefix of the value. Bailing out leaves the browser's own caret following in place, which measured correct; computing the offset would have assigned the sign-inverted value. The original caret-reveal defect therefore remains unfixed in RTL.
- **Residual clipping.** When a field genuinely cannot fit its value, something is always clipped; this change decides *what* — the group being edited stays visible and the hidden part is minimised. Making nothing clip is a width question, and `.kbq-form-field-type-datepicker { width: 136px }` was left alone here on purpose to keep screenshot baselines untouched.
- **Measurement cost.** The reveal reads layout and measures with a ruler, so it runs at most twice per keystroke and returns early — one `scrollWidth` read — whenever the value fits, which is the default field. The ruler is still built per call rather than cached.
