### PR TITLE
test(tree): reach the protected title getter through an index

### DIFF
--- a/packages/components/tree/tree-selection.component.spec.ts
+++ b/packages/components/tree/tree-selection.component.spec.ts
@@ -1663,7 +1663,7 @@ describe('KbqTreeSelection', () => {
             jest.spyOn(containerElement, 'scrollWidth', 'get').mockReturnValue(200);
             jest.spyOn(textElement, 'scrollWidth', 'get').mockReturnValue(400);
 
-            expect(titleDirective.isHorizontalOverflown).toBe(true);
+            expect(titleDirective['isHorizontalOverflown']).toBe(true);
         });
     });
 });


### PR DESCRIPTION
`isHorizontalOverflown` became protected in #1938 while this test sat in review, so the two merged cleanly and left main unable to compile. Index access is what #1938 used in the title spec itself.