### PR TITLE
ci: retry the npm audit registry request on a transport failure

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -33,7 +33,7 @@ jobs:
           # on YN0001: an advisory is a real finding and must fail on the first attempt.
           attempts=3
 
-          for attempt in $(seq 1 $attempts); do
+          for ((attempt = 1; attempt <= attempts; attempt++)); do
             if output=$(yarn npm audit --all --recursive --no-deprecations --environment production --severity high 2>&1); then
               printf '%s\n' "$output"
               exit 0
@@ -42,7 +42,7 @@ jobs:
             printf '%s\n' "$output"
 
             case "$output" in
-              *YN0001*) ;;
+              *"YN0001:"*) ;;
               *) exit 1 ;;
             esac
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,4 +22,34 @@ jobs:
       #
       # Exceptions live in .yarnrc.yml (npmAuditExcludePackages / npmAuditIgnoreAdvisories),
       # each with the reasoning and the condition for removing it.
-      - run: yarn npm audit --all --recursive --no-deprecations --environment production --severity high
+      - name: Audit production dependencies
+        env:
+          FORCE_COLOR: '0'
+        run: |
+          # `yarn npm audit` POSTs to /-/npm/v1/security/advisories/bulk. Yarn hands got its
+          # `httpRetry` limit but never widens got's retry method allowlist, which is
+          # GET/PUT/HEAD/DELETE/OPTIONS/TRACE — a POST is never retried, so a single 60s
+          # `httpTimeout` against a slow registry fails the job. Retry here instead, and only
+          # on YN0001: an advisory is a real finding and must fail on the first attempt.
+          attempts=3
+
+          for attempt in $(seq 1 $attempts); do
+            if output=$(yarn npm audit --all --recursive --no-deprecations --environment production --severity high 2>&1); then
+              printf '%s\n' "$output"
+              exit 0
+            fi
+
+            printf '%s\n' "$output"
+
+            case "$output" in
+              *YN0001*) ;;
+              *) exit 1 ;;
+            esac
+
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::Registry request failed (attempt $attempt/$attempts); retrying."
+              sleep $((attempt * 15))
+            fi
+          done
+
+          exit 1


### PR DESCRIPTION
## Problem

`yarn npm audit` fails the `audit` job on a registry timeout, with no advisory involved:

```
➤ YN0001: RequestError: Timeout awaiting 'socket' for 60000ms
➤ Errors happened when preparing the environment required to run this command.
```

Since 04:11 UTC today this has red-walled `main` and every open PR — `review/select`,
`review/notification-center`, `fix/timepicker-signals`, `fix/textarea-signals`, `fix/tags-signals`,
`feat/DS-4259`, `fix/e2e-scrollbar-screenshot-flakes`. It is intermittent, not a hard outage: runs
alternate between success and failure, so a retry is enough to ride it out.

## Why yarn does not retry it on its own

`yarn npm audit` sends a **POST** to `/-/npm/v1/security/advisories/bulk`. Yarn builds the request as

```js
timeout: { socket: httpTimeout }, retry: httpRetry
```

but it never widens got's retry method allowlist, whose default is

```js
methods: ['GET', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE']
```

POST is not in it, so `httpRetry` never applies to the audit request no matter how high it is set —
one 60s `httpTimeout` fails the job. The failing steps run for exactly 61s, confirming a single
un-retried attempt. `yarn install --immutable` in the same job survives the same outage because its
requests are GETs and do get retried.

Raising `httpTimeout` in `.yarnrc.yml` would not help: the failure is a socket timeout, not a slow
but answering registry, and the setting would affect every local yarn command too.

## Change

Retry the audit in the workflow instead — and only on `YN0001`. A real advisory still fails the job
on the first attempt, so the gate is not weakened.

## Verification

The step's `run` block was extracted from the parsed YAML and exercised against a stubbed `yarn`:

| Stub behaviour                | exit | yarn calls | warnings |
| ----------------------------- | ---- | ---------- | -------- |
| clean audit                   | 0    | 1          | 0        |
| **advisory found**            | **1**| **1**      | **0**    |
| `YN0001` every time           | 1    | 3          | 2        |
| `YN0001` twice, then succeeds | 0    | 3          | 2        |

The second row is the one that matters: a genuine finding fails immediately, with no retries and no
delay. The fourth is the fix itself. `bash -n` and `prettier --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
