### PR TITLE
test(e2e): run playwright at zero retries and keep a trace per failure

### DIFF
--- a/.github/workflows/e2e-approve-snapshots.yml
+++ b/.github/workflows/e2e-approve-snapshots.yml
@@ -48,6 +48,10 @@ jobs:
           # As in e2e.yml: the compose default is tuned for developer machines, the runner wants
           # its own core count.
           PLAYWRIGHT_WORKERS: 100%
+          # Unlike e2e.yml, this job regenerates baselines rather than measuring stability. A flake
+          # here reports nothing anyone acts on and costs a maintainer another /approve-snapshots
+          # plus another full image build, so buy the cushion back that the 0 default removes.
+          PLAYWRIGHT_RETRIES: 2
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         id: commit-and-push
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
   pull_request:
-  # Retries keep the runner green through a flake, which is the right default for a pull request and
-  # the wrong one for finding out what is unstable. This is how the suite gets run at zero retries
-  # without blocking anyone; see docs/guides/06-testing.md.
+  # Retries are 0 everywhere, so a flake fails the run and gets named rather than kept green. This
+  # input is the escape hatch: a dispatched run can put them back to nurse the suite through a known
+  # flake; see docs/guides/06-testing.md.
   workflow_dispatch:
     inputs:
       retries:
-        description: Playwright retries (0 reports flakiness instead of absorbing it)
+        description: Playwright retries (0, the default, reports flakiness instead of absorbing it)
         type: string
         default: '0'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,11 +136,11 @@ The committed baselines under `__screenshots__` are compared with `threshold: 0`
 platform suffix, so a native run outside Linux fails on font rasterization alone. `e2e:components`
 is still useful for the assertion-based specs; use `e2e:docker` whenever screenshots are involved,
 and never regenerate a baseline any other way. Without a local Docker, comment `/approve-snapshots`
-on the pull request. The container runs with `CI=true`, so `test.only` is rejected and failures are
-retried twice; set `PLAYWRIGHT_RETRIES=0` to see real flakiness and `PLAYWRIGHT_WORKERS=<n>` to change
-the worker cap. `@playwright/test` is pinned exactly because a patch release can change the bundled
-Chromium and invalidate every baseline — upgrade it on its own branch and refresh the baselines in
-the same PR.
+on the pull request. The container runs with `CI=true`, so `test.only` is rejected. Retries are 0
+everywhere, CI included, so a flaky test fails the run and is named; set `PLAYWRIGHT_RETRIES=<n>` to
+absorb a known flake and `PLAYWRIGHT_WORKERS=<n>` to change the worker cap. `@playwright/test` is
+pinned exactly because a patch release can change the bundled Chromium and invalidate every
+baseline — upgrade it on its own branch and refresh the baselines in the same PR.
 
 Jest setup (`jest.config.js`, `tools/jest/setup.ts`) that shapes how specs are written:
 

--- a/docs/e2e-flakiness.md
+++ b/docs/e2e-flakiness.md
@@ -225,22 +225,25 @@ any of the three states apart. **Verified:** 0 failures in 10 repeats.
 
 ## Retry policy
 
-`PLAYWRIGHT_RETRIES` now overrides the config; the default is unchanged at `isCI ? 2 : 0`. See
+The default is 0 everywhere, CI included: a flake fails the run and gets named rather than absorbed.
+`PLAYWRIGHT_RETRIES` overrides that for a run that has to be nursed through a known flake. See
 [06-testing.md](guides/06-testing.md).
 
-Keep CI at 2 until this has ridden a few weeks of real runs. Then run `PLAYWRIGHT_RETRIES=0` nightly,
-where it fails loudly without blocking anyone, and move the default to 0 once that has been green for
-a stretch.
+This audit recommended getting there in stages: hold CI at 2, run `PLAYWRIGHT_RETRIES=0` nightly
+where it fails loudly without blocking anyone, and flip the default once that had been green for a
+stretch. The default was flipped directly instead, on the strength of the ×5 run above — 2810
+results, 0 failures. The nightly soak never ran, so the first evidence from CI will be the pull
+requests themselves.
 
 ## Reproducing this
 
 ```bash
-PLAYWRIGHT_RETRIES=0 node tools/e2e/run.js \
-  yarn playwright test packages/components --repeat-each=5 --trace=retain-on-failure
+node tools/e2e/run.js yarn playwright test packages/components --repeat-each=5
 ```
 
-Traces have to be asked for explicitly: the config captures them `on-first-retry`, which never happens
-when there are none. Failures leave `-actual.png`, `-expected.png`, `-diff.png` under `test-results/`.
+Retries and traces no longer need passing: the config runs at 0 retries and records
+`retain-on-failure`. Failures leave the trace plus `-actual.png`, `-expected.png`, `-diff.png` under
+`test-results/`.
 
 Two things did most of the diagnostic work. The **pixel count** in `error-context.md` separates one
 mechanism from another — a count that is identical across runs means a binary state rather than

--- a/docs/guides/06-testing.md
+++ b/docs/guides/06-testing.md
@@ -77,9 +77,10 @@ yarn run e2e:docker yarn playwright test packages/components/button
 ```
 
 The container always runs with `CI=true`, so that Playwright behaves the way it does on the runner.
-Two consequences matter when debugging inside it: `test.only` is rejected outright rather than
-honoured (`forbidOnly`), and a failing test is retried twice before being reported — see Retries
-below for how to turn that off. Narrow a run with a path and `-g` instead of `test.only`:
+The consequence that matters when debugging inside it is that `test.only` is rejected outright
+rather than honoured (`forbidOnly`). Retries are not one of the differences — they are 0 in the
+container, on the runner and locally alike, see Retries below. Narrow a run with a path and `-g`
+instead of `test.only`:
 
 ```bash
 yarn run e2e:docker yarn playwright test packages/components/select -g "single select"
@@ -97,31 +98,41 @@ surfaces later, when the actual `docker compose run` fails.
 
 ### Retries
 
-A test that passes on a retry is reported as flaky and does not fail the run. That is what the
-runner does, and it is the right default — but it also means a suite can be reliably green and
-still be unreliable.
+A test that passes on a retry is reported as flaky and does not fail the run, which means a suite
+can be reliably green and still be unreliable. Retries are therefore 0 everywhere — locally, in the
+container and on the runner: an unstable test fails the run and gets named instead of absorbed.
 
-Set `PLAYWRIGHT_RETRIES` to take retries out of the picture and see which tests are actually
-unstable:
+Set `PLAYWRIGHT_RETRIES` when a run has to be nursed through a known flake:
 
 ```bash
-PLAYWRIGHT_RETRIES=0 yarn run e2e:docker
+PLAYWRIGHT_RETRIES=2 yarn run e2e:docker
 ```
 
 Repeating each test is what turns a single red run into evidence, since one failure on its own does
-not distinguish a flake from a regression. Traces have to be asked for explicitly here: the config
-captures them `on-first-retry`, which never happens when there are none.
+not distinguish a flake from a regression. Traces come with the failure — the config records them
+`retain-on-failure` — so there is nothing extra to pass:
 
 ```bash
-PLAYWRIGHT_RETRIES=0 node tools/e2e/run.js yarn playwright test packages/components --repeat-each=5 --trace=retain-on-failure
+node tools/e2e/run.js yarn playwright test packages/components --repeat-each=5
 ```
 
-On PowerShell the assignment is separate: `$env:PLAYWRIGHT_RETRIES = '0'; yarn run e2e:docker`.
+A failure leaves its trace at `test-results/<test-dir>/trace.zip` — through the bind mount, so a
+Docker run reaches it too — and the report embeds a copy. Open either:
 
-The `E2E tests` workflow also takes a `retries` input through `workflow_dispatch`, which is how the
-suite gets run at zero retries on the runner without turning pull requests red.
+```bash
+npx playwright show-trace test-results/<test-dir>/trace.zip
+npx playwright show-report                                    # the same traces, per failed test
+```
 
-[e2e-flakiness.md](../e2e-flakiness.md) records what this found the first time it was used: the
+The trace carries the DOM snapshots, the network log and the action log, which is what separates
+"the wait resolved a frame early" from "the pixels really changed". The screencast is turned off
+in the config — the pixels are already attached as `-actual.png`, `-expected.png` and `-diff.png`.
+
+On PowerShell the assignment is separate: `$env:PLAYWRIGHT_RETRIES = '2'; yarn run e2e:docker`.
+
+The `E2E tests` workflow takes the same value as a `retries` input through `workflow_dispatch`.
+
+[e2e-flakiness.md](../e2e-flakiness.md) records what the first run at zero retries found: the
 mechanisms behind each flake the suite had, and which ones remain unexplained.
 
 ### Worker count

--- a/packages/components/tabs/e2e.playwright-spec.ts
+++ b/packages/components/tabs/e2e.playwright-spec.ts
@@ -1,73 +1,5 @@
-import { expect, Locator, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { e2eEnableDarkTheme } from 'packages/e2e/utils';
-
-/**
- * Waits until every tab header inside `component` has finished scroll-correcting to its selected tab.
- *
- * A header whose selected tab starts out of view scrolls to it with `behavior: 'smooth'`
- * (`scrollCorrection` in paginated-tab-header.ts), and `animations: 'disabled'` does not reach that:
- * it fast-forwards CSS animations and transitions, not a scroll the browser animates itself. A shot
- * taken without this lands on whichever frame of that scroll the machine happened to be on.
- *
- * Both halves are load-bearing. "The offset stopped changing" is equally true of a header the
- * correction has not started on yet, and "the selected label is in view" becomes true a few frames
- * before the scroll lands, because the target it eases to carries an overscroll margin.
- */
-const e2eWaitForSettledTabHeaders = (component: Locator): Promise<void> =>
-    component.evaluate(
-        (root) =>
-            new Promise<void>((resolve) => {
-                const stableFramesNeeded = 3;
-                const containers = Array.from(root.querySelectorAll<HTMLElement>('.kbq-tab-header__scroll-container'));
-                const offsets = () =>
-                    containers.map(({ scrollLeft, scrollTop }) => `${scrollLeft}:${scrollTop}`).join();
-
-                const selectedLabelsInView = () =>
-                    containers.every((container) => {
-                        const label = container.querySelector('.kbq-tab-label.kbq-selected');
-
-                        // A group whose active tab is not among the rendered ones has no selected
-                        // label, and nothing scrolls it — there is no in-view state to wait for.
-                        if (!label) {
-                            return true;
-                        }
-
-                        const labelBox = label.getBoundingClientRect();
-                        const containerBox = container.getBoundingClientRect();
-
-                        // A pixel of tolerance: both boxes come back fractional, and a label flush
-                        // against the edge of its scrollport is in view for the purpose of a shot.
-                        return (
-                            labelBox.left >= containerBox.left - 1 &&
-                            labelBox.right <= containerBox.right + 1 &&
-                            labelBox.top >= containerBox.top - 1 &&
-                            labelBox.bottom <= containerBox.bottom + 1
-                        );
-                    });
-
-                let previous = offsets();
-                let stableFrames = 0;
-
-                const check = () => {
-                    const current = offsets();
-
-                    stableFrames = current === previous && selectedLabelsInView() ? stableFrames + 1 : 0;
-                    previous = current;
-
-                    if (stableFrames >= stableFramesNeeded) {
-                        resolve();
-
-                        return;
-                    }
-
-                    // No frame cap: Playwright's own timeout reports a header that never settles far
-                    // more clearly than a mid-flight offset that silently satisfies the wait.
-                    requestAnimationFrame(check);
-                };
-
-                requestAnimationFrame(check);
-            })
-    );
 
 test.describe('KbqTabsModule', () => {
     test.describe('E2eTabsStates', () => {
@@ -82,13 +14,8 @@ test.describe('KbqTabsModule', () => {
             // Flaky test workaround: click to underlined tab to ensure proper bottom outline rendering
             await getTabsUnderlined(page).locator('.kbq-tab-label_underlined').nth(0).click();
 
-            // TODO: 01-light.png was committed with the two `[activeTab]="tabs[5]"` groups caught
-            // mid-scroll, so it holds a frame this wait deliberately no longer returns. Regenerate it
-            // with /approve-snapshots on this pull request and delete this note.
-            await e2eWaitForSettledTabHeaders(component);
             await expect(component).toHaveScreenshot('01-light.png');
             await e2eEnableDarkTheme(page);
-            await e2eWaitForSettledTabHeaders(component);
             await expect(component).toHaveScreenshot('01-dark.png');
         });
     });

--- a/packages/components/tabs/e2e.playwright-spec.ts
+++ b/packages/components/tabs/e2e.playwright-spec.ts
@@ -1,5 +1,73 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, Locator, Page, test } from '@playwright/test';
 import { e2eEnableDarkTheme } from 'packages/e2e/utils';
+
+/**
+ * Waits until every tab header inside `component` has finished scroll-correcting to its selected tab.
+ *
+ * A header whose selected tab starts out of view scrolls to it with `behavior: 'smooth'`
+ * (`scrollCorrection` in paginated-tab-header.ts), and `animations: 'disabled'` does not reach that:
+ * it fast-forwards CSS animations and transitions, not a scroll the browser animates itself. A shot
+ * taken without this lands on whichever frame of that scroll the machine happened to be on.
+ *
+ * Both halves are load-bearing. "The offset stopped changing" is equally true of a header the
+ * correction has not started on yet, and "the selected label is in view" becomes true a few frames
+ * before the scroll lands, because the target it eases to carries an overscroll margin.
+ */
+const e2eWaitForSettledTabHeaders = (component: Locator): Promise<void> =>
+    component.evaluate(
+        (root) =>
+            new Promise<void>((resolve) => {
+                const stableFramesNeeded = 3;
+                const containers = Array.from(root.querySelectorAll<HTMLElement>('.kbq-tab-header__scroll-container'));
+                const offsets = () =>
+                    containers.map(({ scrollLeft, scrollTop }) => `${scrollLeft}:${scrollTop}`).join();
+
+                const selectedLabelsInView = () =>
+                    containers.every((container) => {
+                        const label = container.querySelector('.kbq-tab-label.kbq-selected');
+
+                        // A group whose active tab is not among the rendered ones has no selected
+                        // label, and nothing scrolls it — there is no in-view state to wait for.
+                        if (!label) {
+                            return true;
+                        }
+
+                        const labelBox = label.getBoundingClientRect();
+                        const containerBox = container.getBoundingClientRect();
+
+                        // A pixel of tolerance: both boxes come back fractional, and a label flush
+                        // against the edge of its scrollport is in view for the purpose of a shot.
+                        return (
+                            labelBox.left >= containerBox.left - 1 &&
+                            labelBox.right <= containerBox.right + 1 &&
+                            labelBox.top >= containerBox.top - 1 &&
+                            labelBox.bottom <= containerBox.bottom + 1
+                        );
+                    });
+
+                let previous = offsets();
+                let stableFrames = 0;
+
+                const check = () => {
+                    const current = offsets();
+
+                    stableFrames = current === previous && selectedLabelsInView() ? stableFrames + 1 : 0;
+                    previous = current;
+
+                    if (stableFrames >= stableFramesNeeded) {
+                        resolve();
+
+                        return;
+                    }
+
+                    // No frame cap: Playwright's own timeout reports a header that never settles far
+                    // more clearly than a mid-flight offset that silently satisfies the wait.
+                    requestAnimationFrame(check);
+                };
+
+                requestAnimationFrame(check);
+            })
+    );
 
 test.describe('KbqTabsModule', () => {
     test.describe('E2eTabsStates', () => {
@@ -14,8 +82,13 @@ test.describe('KbqTabsModule', () => {
             // Flaky test workaround: click to underlined tab to ensure proper bottom outline rendering
             await getTabsUnderlined(page).locator('.kbq-tab-label_underlined').nth(0).click();
 
+            // TODO: 01-light.png was committed with the two `[activeTab]="tabs[5]"` groups caught
+            // mid-scroll, so it holds a frame this wait deliberately no longer returns. Regenerate it
+            // with /approve-snapshots on this pull request and delete this note.
+            await e2eWaitForSettledTabHeaders(component);
             await expect(component).toHaveScreenshot('01-light.png');
             await e2eEnableDarkTheme(page);
+            await e2eWaitForSettledTabHeaders(component);
             await expect(component).toHaveScreenshot('01-dark.png');
         });
     });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,10 +53,10 @@ const resolveWorkers = () => {
 
 /**
  * Retries hide flakiness rather than remove it: a test that fails and then passes is reported as
- * flaky and does not fail the run, so a suite can be reliably green and still be unreliable. This
- * override is what makes a run answer "which tests are unstable" — PLAYWRIGHT_RETRIES=0 in the
- * container, where Dockerfile's CI=true would otherwise force 2. With the variable unset this
- * behaves exactly as it did before.
+ * flaky and does not fail the run, so a suite can be reliably green and still be unreliable. The
+ * default is therefore 0 everywhere, CI included — an unstable test fails the run and is named
+ * rather than absorbed. PLAYWRIGHT_RETRIES is the escape hatch for a run that has to be nursed
+ * through a known flake.
  *
  * Validated for the same reason as resolveWorkers above: Playwright's own guard rejects a negative
  * number but not NaN, so `PLAYWRIGHT_RETRIES=none` would reach the runner and be treated as no
@@ -67,7 +67,7 @@ const resolveRetries = () => {
     const override = process.env.PLAYWRIGHT_RETRIES?.trim();
 
     if (!override) {
-        return isCI ? 2 : 0;
+        return 0;
     }
 
     const retries = Number(override);
@@ -123,7 +123,20 @@ export default defineConfig({
     },
     use: {
         baseURL: baseURL,
-        trace: 'on-first-retry',
+        // `on-first-retry` was the cheap choice while retries existed: the trace came free on the
+        // retry a failing test was going to get anyway. With retries at 0 that never fires, and a
+        // failure would leave only the screenshot diff — the wrong artifact for the flakes here,
+        // since a wait that resolved a frame early tells you nothing in a still image.
+        //
+        // `screenshots: false` drops the trace's screencast, which is the expensive half twice
+        // over. It takes CPU from every test, including the ones that pass and discard the trace,
+        // and the flakes this suite has are the ones that only appear under load (see
+        // docs/e2e-flakiness.md), so the recorder would manufacture the failures it exists to
+        // explain. It also dominates trace size, which decides how large the uploaded report gets
+        // on the run where a Chromium bump invalidates every baseline at once. What is kept — DOM
+        // snapshots, network, the action log — is what explains a screenshot flake; the pixels are
+        // already attached as -actual.png, -expected.png and -diff.png.
+        trace: { mode: 'retain-on-failure', screenshots: false },
         contextOptions: {
             deviceScaleFactor: 2,
             reducedMotion: 'reduce',

--- a/tools/e2e/Dockerfile
+++ b/tools/e2e/Dockerfile
@@ -22,10 +22,11 @@ FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble@sha256:dcc5531e97
 
 WORKDIR /app
 
-# CI=true selects the same Playwright behavior as the runner: retries: 2 (unless PLAYWRIGHT_RETRIES
-# overrides it — see docs/guides/06-testing.md), forbidOnly, and
-# reuseExistingServer: false. It would also mean workers: '100%', which is wrong in a container —
-# see the PLAYWRIGHT_WORKERS note in tools/e2e/docker-compose.yml.
+# CI=true selects the same Playwright behavior as the runner: forbidOnly and
+# reuseExistingServer: false. Retries are 0 here and on the runner alike, so a flake fails the run
+# instead of being absorbed — see the PLAYWRIGHT_RETRIES note in playwright.config.ts. CI=true would
+# also mean workers: '100%', which is wrong in a container — see the PLAYWRIGHT_WORKERS note in
+# tools/e2e/docker-compose.yml.
 #
 # forbidOnly is the one that surprises people: `test.only` is rejected here rather than honoured, so
 # a run is narrowed with a path and `-g`. Parity is worth more than the convenience — the whole

--- a/tools/e2e/docker-compose.yml
+++ b/tools/e2e/docker-compose.yml
@@ -44,8 +44,9 @@ services:
       # 8 rather than a higher guess because it is the value that was actually measured clean; the
       # ceiling is the single dev server, not the core count, so raising it buys little.
       PLAYWRIGHT_WORKERS: ${PLAYWRIGHT_WORKERS:-8}
-      # Unset by default, so the image keeps the CI behaviour its ENV selects. Set it to 0 to make
-      # a run report flakiness instead of absorbing it; see docs/guides/06-testing.md.
+      # Unset by default, which playwright.config.ts reads as 0: a flake fails the run rather than
+      # being absorbed by a retry. Set it to a positive number to nurse a run through a known
+      # flake; see docs/guides/06-testing.md.
       PLAYWRIGHT_RETRIES: ${PLAYWRIGHT_RETRIES:-}
     # Outputs only — the source tree comes from the image, deliberately, so a plain run cannot write
     # anywhere near the working tree. Mounting the sources as well costs about 5 seconds per run


### PR DESCRIPTION
## Summary

Playwright retried a failing test twice on CI, so a test that failed and then passed was reported as flaky and did not fail the run — the suite could be reliably green while being measurably unstable. The default is now **0 retries everywhere**, CI included: an unstable test fails the run and gets named. `PLAYWRIGHT_RETRIES` stays as the escape hatch for a run that has to be nursed through a known flake.

That change alone would have made failures harder to diagnose, since `trace: 'on-first-retry'` never fires without a retry. Traces are therefore retained on failure — minus the screencast, which is the expensive half twice over: it takes CPU from every test (and this suite's known flakes are the ones that only appear under load, per [`docs/e2e-flakiness.md`](docs/e2e-flakiness.md)), and it dominates the size of the uploaded report on the run where a Chromium bump invalidates every baseline at once. What is kept — DOM snapshots, network, the action log — is what actually explains a screenshot flake; the pixels are already attached as `-actual.png`, `-expected.png` and `-diff.png`.

The staged rollout this repo's own audit recommended (hold CI at 2, soak at 0 nightly, then flip) was skipped in favour of flipping directly, on the strength of its ×5 verification run: 2810 results, 0 failures. That deviation is now recorded in `docs/e2e-flakiness.md` rather than left implicit.

## List of notable changes:

- **updated** `playwright.config.ts` — `retries` defaults to 0 regardless of `CI`; `trace` is `{ mode: 'retain-on-failure', screenshots: false }`
- **updated** `.github/workflows/e2e-approve-snapshots.yml` — asks for `PLAYWRIGHT_RETRIES: 2` explicitly, because that job regenerates baselines rather than measuring stability: a flake there reports nothing anyone acts on and costs a maintainer another `/approve-snapshots` plus another full image build
- **updated** `.github/workflows/e2e.yml`, `tools/e2e/Dockerfile`, `tools/e2e/docker-compose.yml` — comments that claimed `CI=true` means two retries, and that `PLAYWRIGHT_RETRIES=0` is the way to see flakiness, are now the opposite of the truth
- **updated** documentation — `docs/guides/06-testing.md` (Retries section rewritten, plus the stale "retried twice" claim in the Docker section and where to find a trace), `docs/e2e-flakiness.md`, `AGENTS.md`

## What should reviewers focus on?

1. **Whether the docs smoke should follow.** `playwright.docs.config.ts` spreads `...baseConfig`, so `e2e:docs` inherits 0 retries too — but it was never part of the flakiness audit, which measured only `packages/components`. Hydration and SSR smoke specs are the classic shape of a timing flake, so this is the job most likely to start turning PRs red. Dialling it back is one line (`PLAYWRIGHT_RETRIES: 2` in that job's `env`) if we would rather not find out the hard way.
2. **Whether `screenshots: false` gives up too much.** The trace viewer loses its filmstrip; the DOM snapshots and the separate diff PNGs are the argument that nothing important goes with it.
3. **The retry cushion put back on `/approve-snapshots`** — deliberate asymmetry with `e2e.yml`, worth agreeing on.

Not verified locally: the suite was not run for this change (no local Docker run in this session), so the real cost of per-test trace recording on a 4-vCPU runner will first show up in this PR's own E2E job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)