### PR TITLE
fix(filter-bar): stale open request reopens a pipe after the filter is recreated (#DS-5517)

### DIFF
--- a/packages/components/filter-bar/filter-bar.ts
+++ b/packages/components/filter-bar/filter-bar.ts
@@ -128,7 +128,7 @@ export class KbqFilterBar implements KbqFilterBarHost {
     readonly internalFilterChanges = new BehaviorSubject<KbqFilter | null>(null);
     /** internal changes in templates */
     readonly internalTemplatesChanges = new BehaviorSubject<KbqPipeTemplate[] | null>(null);
-    /** this subject need for opens pipe after adding
+    /** Requests that an already-added pipe open its pop-up. See {@link KbqFilterBarHost.openPipe}.
      * @docs-private */
     readonly openPipe = new BehaviorSubject<string | number | null>(null);
 

--- a/packages/components/filter-bar/filter-bar.types.ts
+++ b/packages/components/filter-bar/filter-bar.types.ts
@@ -87,7 +87,11 @@ export interface KbqFilterBarHost {
     readonly internalFilterChanges: BehaviorSubject<KbqFilter | null>;
     /** Internal pipe-template changes. */
     readonly internalTemplatesChanges: BehaviorSubject<KbqPipeTemplate[] | null>;
-    /** Requests opening a pipe after it is added. */
+    /**
+     * Requests that an already-added pipe open its pop-up. A one-shot command handled synchronously by the
+     * pipes that exist when it is dispatched, not retained state — clear it back to `null` after `next`. A
+     * pipe that has not been rendered yet is opened with `openOnAdd` on the pipe itself, not through this.
+     */
     readonly openPipe: BehaviorSubject<string | number | null>;
     /** Emits when the filter is reset. */
     readonly onResetFilter: BehaviorSubject<boolean>;

--- a/packages/components/filter-bar/pipe-add.spec.ts
+++ b/packages/components/filter-bar/pipe-add.spec.ts
@@ -439,6 +439,7 @@ describe('KbqPipeAdd', () => {
             fixture.detectChanges();
 
             expect(openPipeSpy).toHaveBeenCalledWith(PIPE_TEMPLATE_ID_1);
+            expect(filterBar.openPipe.value).toBeNull();
         }));
 
         it('should NOT add a duplicate pipe when option is already selected', fakeAsync(() => {

--- a/packages/components/filter-bar/pipe-add.ts
+++ b/packages/components/filter-bar/pipe-add.ts
@@ -101,7 +101,10 @@ export class KbqPipeAdd {
 
     addPipeFromTemplate(option: KbqOption) {
         if (option.selected) {
+            // Clear the request once dispatched: subscribers are notified synchronously, and a value left
+            // behind would be replayed to anyone reading the subject directly.
             this.filterBar.openPipe.next(getId(option.value));
+            this.filterBar.openPipe.next(null);
         } else {
             option.select();
 

--- a/packages/components/filter-bar/pipes/base-pipe.ts
+++ b/packages/components/filter-bar/pipes/base-pipe.ts
@@ -15,7 +15,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { isMac, KbqPanelMaxHeight } from '@koobiq/components/core';
 import { Subject } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, skip } from 'rxjs/operators';
 import {
     KBQ_FILTER_BAR_DEFAULT_CONFIGURATION,
     KBQ_FILTER_BAR_HOST,
@@ -148,11 +148,20 @@ export abstract class KbqBasePipe<V> implements AfterViewInit {
             this.open();
         }
 
-        this.filterBar?.openPipe.pipe(filter(Boolean), takeUntilDestroyed(this.destroyRef)).subscribe((id) => {
-            if (getId(this.data) === id) {
-                this.open();
-            }
-        });
+        // `skip(1)` drops the replayed value: a request is addressed to the pipes alive when it is dispatched
+        // (a pipe added later opens through `openOnAdd` above). It has to precede the null check, or that
+        // check swallows the replayed value and `skip` eats the first real request instead.
+        this.filterBar?.openPipe
+            .pipe(
+                skip(1),
+                filter((id): id is string | number => id !== null),
+                takeUntilDestroyed(this.destroyRef)
+            )
+            .subscribe((id) => {
+                if (getId(this.data) === id) {
+                    this.open();
+                }
+            });
 
         if (this.data.openOnReset) {
             this.filterBar?.onResetFilter.pipe(filter(Boolean), takeUntilDestroyed(this.destroyRef)).subscribe(() => {

--- a/packages/components/filter-bar/pipes/pipe-input.spec.ts
+++ b/packages/components/filter-bar/pipes/pipe-input.spec.ts
@@ -549,5 +549,40 @@ describe('KbqPipeInputComponent', () => {
 
             expect(document.activeElement).toBe(getInputElement());
         }));
+
+        it('should focus the input when the requested id is falsy', fakeAsync(() => {
+            fixture.componentInstance.activeFilter = createFilter([createPipe({ value: null, id: 0 })]);
+            fixture.detectChanges();
+
+            getFilterBar().openPipe.next(0);
+            flush();
+
+            expect(document.activeElement).toBe(getInputElement());
+        }));
+
+        it('should not open a recreated pipe from an already-dispatched request', fakeAsync(() => {
+            fixture.componentInstance.activeFilter = createFilter([createPipe({ value: null })]);
+            fixture.detectChanges();
+
+            getFilterBar().openPipe.next(PIPE_TEMPLATE_ID);
+            flush();
+
+            const dispatchedTo = getPipeComponent();
+
+            // Fresh pipe objects rebuild every view, the way `KbqFilters.selectFilter` does, so the new pipe
+            // subscribes after the request was already handled.
+            fixture.componentInstance.activeFilter = createFilter([createPipe({ value: null })]);
+            fixture.detectChanges();
+            flush();
+
+            expect(getPipeComponent()).not.toBe(dispatchedTo);
+            expect(document.activeElement).not.toBe(getInputElement());
+
+            // The recreated pipe is not deafened — it still answers a request issued after it subscribed.
+            getFilterBar().openPipe.next(PIPE_TEMPLATE_ID);
+            flush();
+
+            expect(document.activeElement).toBe(getInputElement());
+        }));
     });
 });


### PR DESCRIPTION
## Summary

`KbqFilterBar.openPipe` is a `BehaviorSubject` that was never cleared, so the last requested pipe id stayed retained and was replayed to every pipe created afterwards. Pipes subscribe in `ngAfterViewInit`, so recreating the filter — picking a saved filter, restoring state, or reassigning it from the consumer — made the matching pipe open its pop-up on its own, with no user action.

Reported repro: add a pipe, pick it again in the `add` menu (it opens), close it with `Esc`, then recreate the filter — the pop-up opens again by itself.

`Esc` turned out to be a red herring: it closes the panel correctly (`cdkConnectedOverlay` detaches and `(detach)="close()"` resets `panelOpen`). What survived the close was the *request*, not the open state.

## List of notable changes:

- **changed** `KbqPipeAdd.addPipeFromTemplate` to clear `openPipe` right after dispatch — subscribers are notified synchronously, so the retained value buys nothing and only leaks to consumers that read the subject directly
- **changed** `KbqBasePipe` to `skip(1)` the `BehaviorSubject`'s replayed value, so a pipe created after a request is never opened by it, whoever dispatched it (`skip(1)` is already the idiom for this in the repo — six other production sites)
- **fixed** the guard discarding a legitimate falsy pipe id: `getId` returns `id ?? name`, so `0` is a valid id that `filter(Boolean)` silently dropped
- **updated** JSDoc on both `openPipe` declarations to state the one-shot contract and point at `openOnAdd` for the not-yet-rendered case
- **added** three unit tests: a recreated pipe is not opened by a spent request, a recreated pipe still answers a fresh one, and a falsy id opens its pipe

## What should reviewers focus on?

**1. Is dropping the replay a behaviour change we want on 20.x?** `openPipe` is guarded public API on `KbqFilterBarHost`. Before this, a consumer could assign a filter and call `openPipe.next(id)` in the same tick, and the not-yet-rendered pipe would open from the replay. That path is gone; `openOnAdd` on the pipe object is the supported replacement, now named in the JSDoc. No golden-file change — signatures are untouched, only doc text — so `check-api` stays green.

**2. `onResetFilter` has the same defect and is deliberately left alone.** It is also never pushed back to `false`, so after one Reset click every later-created `openOnReset` pipe opens itself. Fixing it symmetrically would *break* the feature: `KbqFilterReset` emits its `output()` before `next(true)`, so consumers like `filter-bar-required-example` have already swapped in fresh pipe objects and the pipes that should open do not exist yet — `openOnReset` currently works only because of the replay. It needs a per-pipe flag along the lines of `openOnAdd`, which is worth its own ticket rather than a rider here.

**3. Operator order in `base-pipe.ts`.** `skip(1)` has to precede the null check — the other order lets the check swallow the replayed value and makes `skip` eat the first real request instead.

## Verification

- `npx jest --roots "<rootDir>/packages/components/filter-bar"` — 12 suites, 523 tests, green.
- Both fixes are mutation-verified: reverting the null check to `filter(Boolean)` fails the falsy-id test, and removing `skip(1)` fails the recreation test.
- `eslint --max-warnings=0` and `prettier --check` clean over the package.
- Manual: `yarn run dev:filter-bar`, add a pipe, reopen `+` and pick it (opens), `Esc`, then pick the same saved filter or hit Reset — it stays closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
