### PR TITLE
chore(tooltip,ellipsis-center,title): load styles with directive and synced disabled (#DS-5271)

### DIFF
--- a/packages/components/ellipsis-center/e2e.playwright-spec.ts
+++ b/packages/components/ellipsis-center/e2e.playwright-spec.ts
@@ -1,0 +1,74 @@
+import { expect, Page, test } from '@playwright/test';
+
+const tooltip = (page: Page) => page.locator('.kbq-tooltip');
+
+const startHalf = (page: Page, testId: string) =>
+    page.getByTestId(testId).locator('.kbq-ellipsis-center_data-text-start');
+
+const endHalf = (page: Page, testId: string) => page.getByTestId(testId).locator('.kbq-ellipsis-center_data-text-end');
+
+test.describe('KbqEllipsisCenterDirective', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/E2eEllipsisCenterOverflow');
+    });
+
+    test('should load its own layout contract on a host that supplies no styles', async ({ page }) => {
+        const host = page.getByTestId('ellipsisTruncated');
+
+        // Asserted on the host that carries no styles of its own, so this fails on a build where
+        // `_CdkPrivateStyleLoader` never ran — the case no other e2e fixture can reach.
+        await expect(host).toHaveCSS('display', 'flex');
+        await expect(host).toHaveCSS('overflow', 'hidden');
+        await expect(host).toHaveCSS('min-width', '0px');
+
+        await expect(startHalf(page, 'ellipsisTruncated')).toHaveCSS('text-overflow', 'ellipsis');
+        await expect(endHalf(page, 'ellipsisTruncated')).toHaveCSS('white-space', 'pre');
+    });
+
+    test('should split the text and keep the extension visible', async ({ page }) => {
+        // The tail is what the split exists for: end-truncation would take the extension with it.
+        await expect(endHalf(page, 'ellipsisTruncated')).toContainText('.pdf');
+        await expect(startHalf(page, 'ellipsisTruncated')).toContainText('annual-report');
+    });
+
+    test('should stay on one line instead of wrapping inside the cell', async ({ page }) => {
+        const host = page.getByTestId('ellipsisTruncated');
+
+        // Wrapping is precisely how a missing contract hides itself: the text fits once it wraps, the
+        // directive measures no overflow, and every other assertion about a "short" name would still pass.
+        const { height } = (await host.boundingBox())!;
+
+        expect(height).toBeLessThan(24);
+    });
+
+    test('should show the tooltip with the full text on hover', async ({ page }) => {
+        await page.getByTestId('ellipsisTruncated').hover();
+
+        await expect(tooltip(page)).toBeVisible();
+        await expect(tooltip(page)).toContainText('annual-report-for-the-fiscal-year-2024-final-approved.pdf');
+    });
+
+    test('should not show the tooltip when the text fits', async ({ page }) => {
+        await page.getByTestId('ellipsisFits').hover();
+
+        // Longer than the tooltip enterDelay (400ms), so a tooltip that should not open has had time to
+        // appear. Without the wait the assertion resolves on its first poll, while it is still absent anyway.
+        await page.waitForTimeout(800);
+        await expect(tooltip(page)).toBeHidden();
+    });
+
+    test('should leave text below minVisibleLength unsplit but still hinted', async ({ page }) => {
+        // Asserted before the shape, and deliberately: an empty tail also describes a name that simply fits,
+        // so without proof of overflow this test would pass on a fixture that never reached the split at all.
+        await page.getByTestId('ellipsisBelowMinVisibleLength').hover();
+
+        await expect(tooltip(page)).toBeVisible();
+        await expect(tooltip(page)).toContainText('quarterly-summary-report-2024-final.pdf');
+
+        // Nothing moves to the tail, so the host's own `text-overflow` cuts the name off at the end instead.
+        await expect(endHalf(page, 'ellipsisBelowMinVisibleLength')).toBeEmpty();
+        await expect(startHalf(page, 'ellipsisBelowMinVisibleLength')).toHaveText(
+            'quarterly-summary-report-2024-final.pdf'
+        );
+    });
+});

--- a/packages/components/ellipsis-center/e2e.ts
+++ b/packages/components/ellipsis-center/e2e.ts
@@ -1,0 +1,72 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { KbqEllipsisCenterDirective } from './ellipsis-center.directive';
+
+/**
+ * Bare hosts — no file upload, no breadcrumbs, no host-supplied styles. The directive now ships its own
+ * layout contract through `_CdkPrivateStyleLoader`, and nothing else in the e2e suite can tell whether that
+ * loader fired: the file upload fixtures render inside a `.kbq-file-upload` wrapper, so they would pass on a
+ * build where the styles never load.
+ *
+ * The split itself is the assertion. Without `white-space: pre` on the start span the text wraps inside the
+ * cell instead of overflowing it, `scrollWidth` collapses onto `clientWidth`, and the directive concludes
+ * everything fits — leaving the text unsplit and the tooltip disabled. Every case below is therefore a
+ * behavioural check on the contract, not a screenshot of it.
+ */
+@Component({
+    selector: 'e2e-ellipsis-center-overflow',
+    imports: [KbqEllipsisCenterDirective],
+    template: `
+        <div class="cell">
+            <span data-testid="ellipsisTruncated" [kbqEllipsisCenter]="longName"></span>
+        </div>
+
+        <div class="wide">
+            <span data-testid="ellipsisFits" [kbqEllipsisCenter]="shortName"></span>
+        </div>
+
+        <div class="cell">
+            <span
+                data-testid="ellipsisBelowMinVisibleLength"
+                [kbqEllipsisCenter]="shortEnoughToOverflow"
+                [minVisibleLength]="80"
+            ></span>
+        </div>
+    `,
+    styles: `
+        :host {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 16px;
+            padding: 16px;
+            font-family: Arial, sans-serif;
+            font-size: 14px;
+        }
+
+        /* Narrow enough that the name cannot fit, and a flex container so the host is a flex item — the
+           arrangement the contract's min-width and max-width exist for. */
+        .cell {
+            display: flex;
+            width: 200px;
+        }
+
+        .wide {
+            display: flex;
+            width: 600px;
+        }
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'data-testid': 'e2eEllipsisCenterOverflow'
+    }
+})
+export class E2eEllipsisCenterOverflow {
+    readonly longName = 'annual-report-for-the-fiscal-year-2024-final-approved.pdf';
+    readonly shortName = 'report.pdf';
+
+    /**
+     * Overflows the cell — long enough that the two halves would be measurably different from the whole —
+     * while staying under the `minVisibleLength` above, so it must still not be split.
+     */
+    readonly shortEnoughToOverflow = 'quarterly-summary-report-2024-final.pdf';
+}

--- a/packages/components/ellipsis-center/ellipsis-center.directive.spec.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.spec.ts
@@ -23,7 +23,12 @@ const getEllipsisDirectiveDebugElement = (debugElement: DebugElement): DebugElem
         KbqToolTipModule
     ],
     template: `
-        <div [kbqEllipsisCenter]="text" [charWidth]="charWidth" [minVisibleLength]="minLength"></div>
+        <div
+            [kbqEllipsisCenter]="text"
+            [charWidth]="charWidth"
+            [minVisibleLength]="minLength"
+            [kbqTooltipDisabled]="tooltipDisabled"
+        ></div>
     `
 })
 class SimpleTestComponent {
@@ -32,6 +37,7 @@ class SimpleTestComponent {
     text = 'This is a long sample string used to test ellipsis center logic.';
     charWidth = 7;
     minLength = 50;
+    tooltipDisabled = false;
 }
 
 /**
@@ -173,5 +179,47 @@ describe(KbqEllipsisCenterDirective.name, () => {
 
         // 150px of host at the measured 7px per glyph leaves the tail at most half of ~21 characters.
         expect(end.length).toBeLessThanOrEqual(11);
+    }));
+
+    it('should show the hint only for text that does not fit', fakeAsync(() => {
+        const fixture = createComponent(SimpleTestComponent);
+        const directive = fixture.componentInstance.ellipsisCenterDirective();
+
+        refreshAt(fixture, 150, 420);
+
+        expect(directive.disabled).toBe(false);
+
+        jest.restoreAllMocks();
+        refreshAt(fixture, 420, 420);
+
+        expect(directive.disabled).toBe(true);
+    }));
+
+    it('should keep an explicit kbqTooltipDisabled across a refresh that finds the text truncated', fakeAsync(() => {
+        const fixture = createComponent(SimpleTestComponent);
+
+        fixture.componentInstance.tooltipDisabled = true;
+        fixture.detectChanges();
+
+        refreshAt(fixture, 150, 420);
+
+        expect(fixture.componentInstance.ellipsisCenterDirective().disabled).toBe(true);
+    }));
+
+    it('should leave text that fits without a hint after kbqTooltipDisabled is toggled off again', fakeAsync(() => {
+        const fixture = createComponent(SimpleTestComponent);
+        const { componentInstance } = fixture;
+
+        refreshAt(fixture, 420, 420);
+
+        expect(componentInstance.ellipsisCenterDirective().disabled).toBe(true);
+
+        componentInstance.tooltipDisabled = true;
+        fixture.detectChanges();
+        componentInstance.tooltipDisabled = false;
+        fixture.detectChanges();
+
+        // The consumer releasing the input must not resurrect a hint for text that is fully visible.
+        expect(componentInstance.ellipsisCenterDirective().disabled).toBe(true);
     }));
 });

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -1,7 +1,9 @@
 import { SharedResizeObserver } from '@angular/cdk/observers/private';
+import { _CdkPrivateStyleLoader } from '@angular/cdk/private';
 import {
     AfterViewInit,
     ChangeDetectorRef,
+    Component,
     Directive,
     inject,
     Input,
@@ -9,7 +11,8 @@ import {
     NgModule,
     numberAttribute,
     OnDestroy,
-    OnInit
+    OnInit,
+    ViewEncapsulation
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
@@ -17,12 +20,20 @@ import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
 /**
+ * Component used to load the `.kbq-ellipsis-center` styles.
+ */
+@Component({
+    selector: 'ellipsis-center-style-loader',
+    template: '',
+    styleUrl: 'ellipsis-center.scss',
+    encapsulation: ViewEncapsulation.None
+})
+class EllipsisCenterStyleLoader {}
+
+/**
  * Renders text as two spans and moves the ellipsis into the middle, so the tail — a file extension, the
  * digits that tell two reports apart — stays readable when the host is too narrow for the whole string. A
  * tooltip spells out the full text, and is enabled only while something is actually hidden.
- *
- * The host needs the layout contract the consuming component ships (see `.kbq-ellipsis-center` in
- * `file-upload.scss`): the two spans have no styles of their own.
  */
 @Directive({
     selector: '[kbqEllipsisCenter]',
@@ -40,6 +51,9 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
      * none of which resize the window, all of which change where the text has to be split.
      */
     private readonly resizeObserver = inject(SharedResizeObserver);
+
+    /** The two spans this directive renders have no styles of their own until this is loaded. */
+    private readonly styleLoader = inject(_CdkPrivateStyleLoader);
 
     // TODO: Skipped for migration because:
     //  Accessor inputs cannot be migrated as they are too complex.
@@ -94,6 +108,12 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
     private lastMeasuredWidth: number | undefined;
 
     private refreshTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    constructor() {
+        super();
+
+        this.styleLoader.load(EllipsisCenterStyleLoader);
+    }
 
     override ngOnInit(): void {
         super.ngOnInit();

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -35,8 +35,9 @@ class EllipsisCenterStyleLoader {}
  * digits that tell two reports apart — stays readable when the host is too narrow for the whole string. A
  * tooltip spells out the full text, and is enabled only while something is actually hidden.
  *
- * The tooltip's `forDisabledComponent` has no meaning here: the hint always repeats the text this directive
- * shortened, never an explanation of why a wrapped control is unavailable. Overflow is the only state the
+ * The tooltip's `forDisabledComponent` is not for this host and should not be bound on it: the hint always
+ * repeats the text this directive shortened, never an explanation of why a wrapped control is unavailable,
+ * and the two derive the same state, so they would overwrite each other. Overflow is the only state the
  * directive derives, and `kbqTooltipDisabled` is how a consumer suppresses the hint.
  */
 @Directive({

--- a/packages/components/ellipsis-center/ellipsis-center.directive.ts
+++ b/packages/components/ellipsis-center/ellipsis-center.directive.ts
@@ -34,6 +34,10 @@ class EllipsisCenterStyleLoader {}
  * Renders text as two spans and moves the ellipsis into the middle, so the tail — a file extension, the
  * digits that tell two reports apart — stays readable when the host is too narrow for the whole string. A
  * tooltip spells out the full text, and is enabled only while something is actually hidden.
+ *
+ * The tooltip's `forDisabledComponent` has no meaning here: the hint always repeats the text this directive
+ * shortened, never an explanation of why a wrapped control is unavailable. Overflow is the only state the
+ * directive derives, and `kbqTooltipDisabled` is how a consumer suppresses the hint.
  */
 @Directive({
     selector: '[kbqEllipsisCenter]',
@@ -141,6 +145,14 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
     }
 
     /**
+     * The hint spells out what the split hid, so `kbqTooltipDisabled="false"` cannot conjure one for a name
+     * that fits — unlike the base, where an explicit value wins outright.
+     * @docs-private */
+    protected override foldDisabled(): boolean {
+        return this.explicitlyDisabled === true || (this.derivedDisabled ?? false);
+    }
+
+    /**
      * Updates the displayed text with center ellipsis truncation based on container width.
      * Recreates start/end span elements, measures available space, and adjusts text accordingly.
      * @docs-private
@@ -215,7 +227,7 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
             dataTextStart.innerText = start;
             dataTextEnd.innerText = end;
 
-            this.disabled = !truncated;
+            this.setDerivedDisabled(!truncated);
             this.cdr.markForCheck();
         });
 

--- a/packages/components/ellipsis-center/ellipsis-center.scss
+++ b/packages/components/ellipsis-center/ellipsis-center.scss
@@ -1,0 +1,31 @@
+// Layout contract for the two spans `KbqEllipsisCenterDirective` renders. Loaded once by the directive
+// itself through `_CdkPrivateStyleLoader`, so a host no longer copies these declarations — every copy was a
+// chance for the directive to behave differently depending on where it was used.
+.kbq-ellipsis-center {
+    position: relative;
+    display: flex;
+
+    // The split point is measured against the host's own `clientWidth`, so the host must not grow to fit the
+    // text it is about to shorten — a shrink-to-fit host measures the full width, concludes everything fits,
+    // and leaves the text unsplit and overflowing. `min-width: 0` opts out of the `auto` minimum a flex item
+    // would otherwise inherit from the non-shrinkable end span.
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+
+    .kbq-ellipsis-center_data-text-start {
+        // The only half that shrinks, and the only one carrying `text-overflow` — unsplit text lands here.
+        flex: 0 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: pre;
+    }
+
+    .kbq-ellipsis-center_data-text-end {
+        // Holds the tail the split exists to keep visible (the file extension, the trailing digits), so it
+        // must not shrink; the directive sizes it from the width the text actually rendered at.
+        flex: 1 0 auto;
+        overflow: hidden;
+        white-space: pre;
+    }
+}

--- a/packages/components/file-upload/file-upload.scss
+++ b/packages/components/file-upload/file-upload.scss
@@ -17,35 +17,6 @@
         align-items: baseline;
         gap: var(--dropzone-gap, var(--kbq-file-upload-size-dropzone-content-gap-horizontal));
     }
-
-    .kbq-ellipsis-center {
-        position: relative;
-        display: flex;
-
-        // The split point is measured against the host's own `clientWidth`, so the host must not grow to fit
-        // the text it is about to shorten — a shrink-to-fit host measures the full width, concludes
-        // everything fits, and leaves the text unsplit and overflowing. `min-width: 0` opts out of the `auto`
-        // minimum a flex item would otherwise inherit from the non-shrinkable end span.
-        max-width: 100%;
-        min-width: 0;
-        overflow: hidden;
-
-        .kbq-ellipsis-center_data-text-start {
-            // The only half that shrinks, and the only one carrying `text-overflow` — unsplit text lands here.
-            flex: 0 1 auto;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: pre;
-        }
-
-        .kbq-ellipsis-center_data-text-end {
-            // Holds the tail the split exists to keep visible (the file extension, the trailing digits), so
-            // it must not shrink; the directive sizes it from the width the text actually rendered at.
-            flex: 1 0 auto;
-            overflow: hidden;
-            white-space: pre;
-        }
-    }
 }
 
 .kbq-file-upload__hint {

--- a/packages/components/file-upload/file-upload.spec.ts
+++ b/packages/components/file-upload/file-upload.spec.ts
@@ -392,6 +392,38 @@ describe(KbqMultipleFileUploadComponent.name, () => {
         });
     });
 
+    describe('with ellipsis in the center', () => {
+        afterEach(() => jest.restoreAllMocks());
+
+        it('should keep the hint for a long file name while the upload is disabled', fakeAsync(() => {
+            // Reading a name the host had to shorten is not an interaction with the control, so blocking the
+            // control must not take it away. The single variant never suppressed it; this pins the multiple
+            // variant to the same behaviour, which it only diverged from once `kbqTooltipDisabled` started
+            // being honoured on a `kbqEllipsisCenter` host.
+            jest.spyOn(Element.prototype, 'clientWidth', 'get').mockReturnValue(100);
+            jest.spyOn(Element.prototype, 'scrollWidth', 'get').mockReturnValue(400);
+
+            const fakeFile = new File(['test'], 'very very very very very very very very very long file name.txt');
+
+            dispatchEvent(component.fileUpload().input!.nativeElement, getMockedChangeEvent(fakeFile));
+            fixture.detectChanges();
+            flush();
+
+            component.disabled = true;
+            fixture.detectChanges();
+            flush();
+
+            dispatchMouseEvent(
+                fixture.debugElement.query(By.css(`.${fileItemTextCssClass}`)).nativeElement,
+                'mouseenter'
+            );
+            fixture.detectChanges();
+            flush();
+
+            expect(document.querySelector('.kbq-tooltip')).toBeTruthy();
+        }));
+    });
+
     describe('with ControlValueAccessor', () => {
         let fixture: ComponentFixture<ControlValueAccessorMultipleFileUpload>;
         let component: ControlValueAccessorMultipleFileUpload;

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -51,7 +51,6 @@
                                 <span
                                     class="kbq-file-item__text"
                                     [minVisibleLength]="10"
-                                    [kbqTooltipDisabled]="disabled"
                                     [kbqEllipsisCenter]="file.file.name"
                                 ></span>
                             </div>

--- a/packages/components/title/title.directive.spec.ts
+++ b/packages/components/title/title.directive.spec.ts
@@ -460,6 +460,42 @@ describe('KbqTitleDirective', () => {
         });
     });
 
+    describe('explicit kbqTooltipDisabled', () => {
+        it('should survive a hover that finds the text overflown', () => {
+            const fixture = createComponent(ExplicitlyDisabledTitleComponent);
+            const directive = getTitleDirective(fixture.debugElement);
+            const el = fixture.debugElement.query(By.directive(KbqTitleDirective)).nativeElement;
+
+            fixture.componentInstance.tooltipDisabled = true;
+            fixture.detectChanges();
+
+            jest.spyOn(el, 'offsetWidth', 'get').mockReturnValue(100);
+            jest.spyOn(el, 'scrollWidth', 'get').mockReturnValue(200);
+            directive['handleElementEnter']();
+
+            // The hover used to write its own verdict through the same setter and take the suppression with it.
+            expect(directive.disabled).toBe(true);
+        });
+
+        it('should not conjure a hint for text that fits once it is toggled off again', () => {
+            const fixture = createComponent(ExplicitlyDisabledTitleComponent);
+            const directive = getTitleDirective(fixture.debugElement);
+
+            // JSDOM defaults: all sizing = 0 → nothing is overflown.
+            directive['handleElementEnter']();
+
+            expect(directive.disabled).toBe(true);
+
+            fixture.componentInstance.tooltipDisabled = true;
+            fixture.detectChanges();
+            fixture.componentInstance.tooltipDisabled = false;
+            fixture.detectChanges();
+
+            // Releasing the input asks for the derived state back, and the derived state is "nothing to show".
+            expect(directive.disabled).toBe(true);
+        });
+    });
+
     describe('hideTooltip()', () => {
         it('should always set disabled=true', () => {
             const { debugElement } = createComponent(SimpleTitleComponent);
@@ -1089,6 +1125,17 @@ class SimpleTitleComponent {}
     `
 })
 class EmptyTitleComponent {}
+
+@Component({
+    imports: [KbqTitleDirective],
+    standalone: true,
+    template: `
+        <div kbq-title [kbqTooltipDisabled]="tooltipDisabled">Hello World</div>
+    `
+})
+class ExplicitlyDisabledTitleComponent {
+    tooltipDisabled = false;
+}
 
 @Component({
     imports: [KbqTitleDirective],

--- a/packages/components/title/title.directive.ts
+++ b/packages/components/title/title.directive.ts
@@ -204,7 +204,7 @@ export class KbqTitleDirective extends KbqTooltipTrigger implements AfterViewIni
             .pipe(skip(1), takeUntilDestroyed())
             .subscribe(() => {
                 this.content = this.resolvedContent;
-                this.disabled = !this.isOverflown;
+                this.setDerivedDisabled(!this.isOverflown);
             });
     }
 
@@ -231,13 +231,13 @@ export class KbqTitleDirective extends KbqTooltipTrigger implements AfterViewIni
         this.resizeObserver
             .observe(this.parent)
             .pipe(debounceTime(this.debounceInterval), takeUntilDestroyed(this.destroyRef))
-            .subscribe(() => (this.disabled = !this.isOverflown));
+            .subscribe(() => this.setDerivedDisabled(!this.isOverflown));
 
         this.contentObserver
             .observe(this.parent)
             .pipe(throttleTime(this.debounceInterval), takeUntilDestroyed(this.destroyRef))
             .subscribe(() => {
-                this.disabled = !this.isOverflown;
+                this.setDerivedDisabled(!this.isOverflown);
                 this.content = this.resolvedContent;
             });
 
@@ -264,7 +264,7 @@ export class KbqTitleDirective extends KbqTooltipTrigger implements AfterViewIni
                     this.triggerName = 'blur';
                 }
 
-                // `disabled = true` hides an open tooltip through the base setter.
+                // Disabling hides an open tooltip on the way through `setDerivedDisabled`.
                 this.hideTooltip();
             });
     }
@@ -273,13 +273,22 @@ export class KbqTitleDirective extends KbqTooltipTrigger implements AfterViewIni
      * @docs-private */
     protected handleElementEnter() {
         this.content = this.resolvedContent;
-        this.disabled = !this.isOverflown;
+        this.setDerivedDisabled(!this.isOverflown);
     }
 
     /** Always disables (hides) the tooltip. Bound to `mouseleave` and non-keyboard focus changes.
      * @docs-private */
     protected hideTooltip() {
-        this.disabled = true;
+        this.setDerivedDisabled(true);
+    }
+
+    /**
+     * The tooltip repeats text the host had to clip, so `kbqTooltipDisabled="false"` cannot conjure one for a
+     * title that is fully visible — unlike the base, where an explicit value wins outright. A consumer's
+     * `kbqTooltipDisabled="true"`, in turn, is no longer overwritten by the next hover.
+     * @docs-private */
+    protected override foldDisabled(): boolean {
+        return this.explicitlyDisabled === true || (this.derivedDisabled ?? false);
     }
 
     /**

--- a/packages/components/tooltip/tooltip.component.ts
+++ b/packages/components/tooltip/tooltip.component.ts
@@ -393,7 +393,12 @@ export class KbqTooltipTrigger
         this.updateData();
     }
 
-    /** Input (`kbqTooltipDisabled`) controlling whether the tooltip is disabled; setting it to `true` hides it. */
+    /**
+     * Input (`kbqTooltipDisabled`) controlling whether the tooltip is disabled; setting it to `true` hides it.
+     *
+     * Reads back the *effective* state, which for subclasses that derive one of their own (see
+     * `foldDisabled`) is not necessarily the value that was written.
+     */
     // TODO: Skipped for migration because:
     //  Accessor inputs cannot be migrated as they are too complex.
     @Input('kbqTooltipDisabled')
@@ -403,19 +408,23 @@ export class KbqTooltipTrigger
 
     set disabled(value) {
         this.explicitlyDisabled = coerceBooleanProperty(value);
-        this._disabled = this.explicitlyDisabled;
 
-        if (this._disabled) {
-            this.hide();
-        }
+        this.applyDisabled();
     }
 
     /**
      * Value the consumer assigned to `kbqTooltipDisabled`, or `undefined` while the input was never set. It
      * makes the input win over the state `forDisabledComponent` derives, instead of the two fighting over
      * `_disabled` in whichever order they happen to run.
-     */
-    private explicitlyDisabled: boolean | undefined;
+     * @docs-private */
+    protected explicitlyDisabled: boolean | undefined;
+
+    /**
+     * State a subclass derived from what it renders — the wrapped control being disabled here, text overflow
+     * in `KbqTitleDirective` and `KbqEllipsisCenterDirective`. Kept apart from `explicitlyDisabled` so both
+     * survive, whichever order they are written in.
+     * @docs-private */
+    protected derivedDisabled: boolean | undefined;
 
     /** Input (`kbqEnterDelay`) — delay in milliseconds before the tooltip is shown. Defaults to `400`. */
     // TODO: Skipped for migration because:
@@ -685,11 +694,9 @@ export class KbqTooltipTrigger
                 this.renderer.removeClass(nativeElement, 'kbq-tooltip-trigger_for-disabled');
             }
 
-            // An explicit `kbqTooltipDisabled` binding wins: the wrapper only derives the state when the
-            // consumer left the input alone.
-            if (this.explicitlyDisabled === undefined) {
-                this._disabled = !disabled;
-            }
+            // Derived, not assigned: an explicit `kbqTooltipDisabled` binding still wins, whichever of the
+            // two runs first.
+            this.setDerivedDisabled(!disabled);
         });
     }
 
@@ -703,6 +710,37 @@ export class KbqTooltipTrigger
         this.focusMonitor.stopMonitoring(this.elementRef.nativeElement);
 
         super.ngOnDestroy();
+    }
+
+    /**
+     * Records the state the subclass derived from its own content and re-folds it with the consumer's
+     * `kbqTooltipDisabled`. Subclasses call this instead of writing `disabled`, which would be read back as
+     * the consumer's own value and lose whichever of the two was written first.
+     * @docs-private */
+    protected setDerivedDisabled(value: boolean): void {
+        this.derivedDisabled = value;
+
+        this.applyDisabled();
+    }
+
+    /**
+     * Effective `disabled`: the consumer's `kbqTooltipDisabled` wins over the derived state in both
+     * directions, so `false` on a wrapped control that is not disabled still asks for a tooltip.
+     *
+     * Subclasses whose derived state means *there is nothing to show* override this — a hint that repeats
+     * text the host had to clip cannot be conjured for text that was never clipped.
+     * @docs-private */
+    protected foldDisabled(): boolean {
+        return this.explicitlyDisabled ?? this.derivedDisabled ?? false;
+    }
+
+    /** Recomputes the effective `disabled` and closes an open tooltip that just lost its reason to be open. */
+    private applyDisabled(): void {
+        this._disabled = this.foldDisabled();
+
+        if (this._disabled) {
+            this.hide();
+        }
     }
 
     /**

--- a/packages/components/tooltip/tooltip.component.ts
+++ b/packages/components/tooltip/tooltip.component.ts
@@ -413,9 +413,13 @@ export class KbqTooltipTrigger
     }
 
     /**
-     * Value the consumer assigned to `kbqTooltipDisabled`, or `undefined` while the input was never set. It
-     * makes the input win over the state `forDisabledComponent` derives, instead of the two fighting over
-     * `_disabled` in whichever order they happen to run.
+     * Value the consumer assigned to `kbqTooltipDisabled`, or `undefined` while the input was never set.
+     * Kept apart from `derivedDisabled` so the consumer's binding and the state a subclass computes cannot
+     * overwrite each other in whichever order they happen to run.
+     *
+     * How the two combine is `foldDisabled()`, not this field: the base lets the input win in both
+     * directions, while a subclass whose derived state means *there is nothing to show* overrides that, so
+     * an explicit `false` there cannot conjure a hint for text that was never clipped.
      * @docs-private */
     protected explicitlyDisabled: boolean | undefined;
 
@@ -736,7 +740,16 @@ export class KbqTooltipTrigger
 
     /** Recomputes the effective `disabled` and closes an open tooltip that just lost its reason to be open. */
     private applyDisabled(): void {
-        this._disabled = this.foldDisabled();
+        const next = this.foldDisabled();
+
+        // Both producers re-state their verdict on every resize, content mutation and pointer sweep, and
+        // most of those repeat the previous answer. Without this the repeats still reach `hide()`, which
+        // re-enters the Angular zone from a `ResizeObserver` callback CDK deliberately runs outside it and
+        // schedules a tick — once per visible host, on a directive that sits on every dropdown item, list
+        // option and tree option.
+        if (next === this._disabled) return;
+
+        this._disabled = next;
 
         if (this._disabled) {
             this.hide();

--- a/packages/components/tooltip/tooltip.spec.ts
+++ b/packages/components/tooltip/tooltip.spec.ts
@@ -1611,6 +1611,34 @@ describe('KbqTooltip', () => {
             expect(host.hasAttribute('role')).toBe(false);
             expect(host.style.outlineColor).toBe('');
         });
+
+        it('should let an explicit false ask for a hint the wrapped control state would not have produced', () => {
+            // The base fold lets the input win in both directions. Only `true` is pinned above, and `true`
+            // agrees with the derived state here — this is the row where the two genuinely disagree.
+            expect(component.enabledTooltip().disabled).toBe(false);
+        });
+
+        it('should hide an open tooltip once the wrapped control stops being disabled', fakeAsync(() => {
+            component.controlDisabled = true;
+            fixture.detectChanges();
+
+            component.derivedTooltip().show();
+            fixture.detectChanges();
+            tick(tooltipDefaultEnterDelayWithDefer);
+            fixture.detectChanges();
+
+            expect(overlayContainerElement.textContent).toContain('DERIVED');
+
+            // The hint exists only to explain a control the user cannot reach, so re-enabling the control
+            // takes its reason away. Closing it has to happen there and then, not whenever a pointer next
+            // leaves — the pane may be sitting over the control that just became clickable.
+            component.controlDisabled = false;
+            fixture.detectChanges();
+            tick(tooltipDefaultEnterDelayWithDefer);
+            fixture.detectChanges();
+
+            expect(overlayContainerElement.textContent).not.toContain('DERIVED');
+        }));
     });
 });
 
@@ -2030,11 +2058,21 @@ class TooltipPointerEvents {
         <div #derivedTooltip="kbqTooltip" kbqTooltip="DERIVED" [forDisabledComponent]="derivedButton">
             <button #derivedButton kbq-button [disabled]="controlDisabled">Derived</button>
         </div>
+
+        <div
+            #enabledTooltip="kbqTooltip"
+            kbqTooltip="ENABLED"
+            [forDisabledComponent]="enabledButton"
+            [kbqTooltipDisabled]="false"
+        >
+            <button #enabledButton kbq-button [disabled]="controlDisabled">Enabled</button>
+        </div>
     `
 })
 class TooltipForDisabledWithExplicitState {
     readonly explicitTooltip = viewChild.required<KbqTooltipTrigger>('explicitTooltip');
     readonly derivedTooltip = viewChild.required<KbqTooltipTrigger>('derivedTooltip');
+    readonly enabledTooltip = viewChild.required<KbqTooltipTrigger>('enabledTooltip');
 
     controlDisabled = false;
 }

--- a/packages/docs-examples/components/breadcrumbs/breadcrumbs-truncate-center-items/breadcrumbs-truncate-center-items-example.ts
+++ b/packages/docs-examples/components/breadcrumbs/breadcrumbs-truncate-center-items/breadcrumbs-truncate-center-items-example.ts
@@ -47,32 +47,6 @@ import { KbqToolTipModule } from '@koobiq/components/tooltip';
             .kbq-breadcrumb-item:last-of-type {
                 max-width: 124px;
             }
-
-            /* The directive renders these two spans but ships no styles for them, so every host declares
-               the same layout contract. Scoped to this example on purpose: the component is
-               ViewEncapsulation.None, and an unprefixed .kbq-ellipsis-center would also style the file
-               upload examples further down the same docs page. */
-            .kbq-ellipsis-center {
-                position: relative;
-                display: flex;
-
-                max-width: 100%;
-                min-width: 0;
-                overflow: hidden;
-
-                .kbq-ellipsis-center_data-text-start {
-                    flex: 0 1 auto;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: pre;
-                }
-
-                .kbq-ellipsis-center_data-text-end {
-                    flex: 1 0 auto;
-                    overflow: hidden;
-                    white-space: pre;
-                }
-            }
         }
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/packages/e2e/routes.ts
+++ b/packages/e2e/routes.ts
@@ -54,6 +54,7 @@ import {
     E2eDropdownStates,
     E2eDropdownTitleOverflow
 } from '../components/dropdown/e2e';
+import { E2eEllipsisCenterOverflow } from '../components/ellipsis-center/e2e';
 import { E2eEmptyStateStateAndStyle } from '../components/empty-state/e2e';
 import { E2eFileUploadDropzone, E2eFileUploadStateAndStyle } from '../components/file-upload/e2e';
 import {
@@ -336,6 +337,7 @@ const components = [
     E2eUsernameStateAndStyle,
     E2eToastStates,
     E2eTitleOverflow,
+    E2eEllipsisCenterOverflow,
     E2eToastInteraction,
     E2eNotificationCenterStates,
     E2eNotificationCenterEmpty,

--- a/tools/public_api_guard/components/ellipsis-center.api.md
+++ b/tools/public_api_guard/components/ellipsis-center.api.md
@@ -13,6 +13,7 @@ import { Subject } from 'rxjs';
 
 // @public
 export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnInit, AfterViewInit, OnDestroy {
+    constructor();
     readonly charWidth: i0.InputSignal<number>;
     readonly debounceInterval: i0.InputSignalWithTransform<number, unknown>;
     readonly ignoreTooltipPointerEvents: i0.InputSignal<boolean>;

--- a/tools/public_api_guard/components/ellipsis-center.api.md
+++ b/tools/public_api_guard/components/ellipsis-center.api.md
@@ -16,6 +16,7 @@ export class KbqEllipsisCenterDirective extends KbqTooltipTrigger implements OnI
     constructor();
     readonly charWidth: i0.InputSignal<number>;
     readonly debounceInterval: i0.InputSignalWithTransform<number, unknown>;
+    protected foldDisabled(): boolean;
     readonly ignoreTooltipPointerEvents: i0.InputSignal<boolean>;
     // (undocumented)
     set kbqEllipsisCenter(value: string);

--- a/tools/public_api_guard/components/title.api.md
+++ b/tools/public_api_guard/components/title.api.md
@@ -14,6 +14,7 @@ import { TemplateRef } from '@angular/core';
 export class KbqTitleDirective extends KbqTooltipTrigger implements AfterViewInit {
     constructor();
     protected get child(): HTMLElement | undefined;
+    protected foldDisabled(): boolean;
     protected handleElementEnter(): void;
     protected hideTooltip(): void;
     readonly ignoreTooltipPointerEvents: i0.InputSignal<boolean>;

--- a/tools/public_api_guard/components/tooltip.api.md
+++ b/tools/public_api_guard/components/tooltip.api.md
@@ -136,10 +136,13 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
     createOverlay(): OverlayRef;
     get customClass(): string;
     set customClass(value: string);
+    protected derivedDisabled: boolean | undefined;
     get disabled(): boolean;
     set disabled(value: boolean);
     enterDelay: number;
+    protected explicitlyDisabled: boolean | undefined;
     protected focusMonitor: FocusMonitor;
+    protected foldDisabled(): boolean;
     readonly forDisabledComponent: i0.InputSignal<Record<"disabledSignal", WritableSignal<boolean>> | undefined>;
     getOverlayHandleComponentType(): Type<KbqTooltipComponent>;
     header: string | TemplateRef<unknown>;
@@ -170,6 +173,7 @@ export class KbqTooltipTrigger extends KbqPopUpTrigger<KbqTooltipComponent> impl
     protected renderer: Renderer2;
     protected get scrollStrategy(): () => ScrollStrategy;
     readonly scrollStrategyOverride: i0.InputSignal<(() => ScrollStrategy) | undefined>;
+    protected setDerivedDisabled(value: boolean): void;
     setOverlayPanelClass(panelClass: string | string[]): void;
     show(delay?: number): void;
     showForElement(element: HTMLElement): void;


### PR DESCRIPTION
## Summary

addressed review fixes from #2007 that are related to initial fix but not actually connected to it, just an improvement
