### PR TITLE
chore(deps): resolve open dependabot advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
         "diff@^4.0.1": "4.0.4",
         "diff@~8.0.2": "8.0.4",
         "http-proxy-middleware@3.0.5": "3.0.7",
-        "js-yaml@^4.1.0": "^4.3.1",
+        "js-yaml@^4.1.0": "^4.3.2",
         "nanoid": "^3.3.17",
         "postcss": "^8.5.25",
         "serialize-javascript": "^7.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,57 +12,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/gateway@npm:2.0.139":
-  version: 2.0.139
-  resolution: "@ai-sdk/gateway@npm:2.0.139"
+"@ai-sdk/gateway@npm:3.0.190":
+  version: 3.0.190
+  resolution: "@ai-sdk/gateway@npm:3.0.190"
   dependencies:
-    "@ai-sdk/provider": "npm:2.0.3"
-    "@ai-sdk/provider-utils": "npm:3.0.32"
-    "@vercel/oidc": "npm:3.1.0"
+    "@ai-sdk/provider": "npm:3.0.15"
+    "@ai-sdk/provider-utils": "npm:4.0.50"
+    "@vercel/oidc": "npm:3.2.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/ed0b2a1bed22911ae26987f2c219c7506ecae3cc28e564c59d12581d1ddc0b3bfa5c7e6894e56526a899b78cf7370e6c7634336d76fb015a6f210582c8a1001f
+  checksum: 10c0/ddceb709feaa3aa3633243a09df951640d6186f6ee18c2801ab27f37ec41c85d468ab9619b3163fb62e940e43096680790d50fe1c25fec8e412fb5d81d8c6d0b
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:3.0.32":
-  version: 3.0.32
-  resolution: "@ai-sdk/provider-utils@npm:3.0.32"
+"@ai-sdk/provider-utils@npm:4.0.50":
+  version: 4.0.50
+  resolution: "@ai-sdk/provider-utils@npm:4.0.50"
   dependencies:
-    "@ai-sdk/provider": "npm:2.0.3"
-    "@standard-schema/spec": "npm:^1.0.0"
-    eventsource-parser: "npm:^3.0.6"
-    undici: "npm:^5.29.0"
+    "@ai-sdk/provider": "npm:3.0.15"
+    "@standard-schema/spec": "npm:^1.1.0"
+    eventsource-parser: "npm:^3.0.8"
+    undici: "npm:^6.28.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/1f3ba144ad469d197980554f159e3f32170833b157823f18c26ee42a541a542a43e9049fee9b86f01b67a052cdc815dd5bf6ebeb2a3171fd8549e0b9215043a2
+  checksum: 10c0/c80ea0a8489da063aa704a431354c4d9136880ab30c6e54324d9458cfb02ea30858bac24e8d559a21de3b984fec16b6aedee6e2ce85687f11d8a65a06311ed86
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@ai-sdk/provider@npm:2.0.3"
+"@ai-sdk/provider@npm:3.0.15":
+  version: 3.0.15
+  resolution: "@ai-sdk/provider@npm:3.0.15"
   dependencies:
     json-schema: "npm:^0.4.0"
-  checksum: 10c0/f0f663a2d2226d3cb447a3bcc13c70333c1957953237c5583681f26b0d4109f7136ce234499ba730c63bba97243e127b7763d8d962571377d1d9b5193506232c
+  checksum: 10c0/0a17eca818c6d821e9488188cf02789502e426eff125d9c9572c2308baead3ed2e93ad53856887b207f287e6907441da81860e31350b12a11c91a6dfd1c6f344
   languageName: node
   linkType: hard
 
-"@ai-sdk/react@npm:^2.0.30":
-  version: 2.0.247
-  resolution: "@ai-sdk/react@npm:2.0.247"
+"@ai-sdk/react@npm:^3.0.259":
+  version: 3.0.282
+  resolution: "@ai-sdk/react@npm:3.0.282"
   dependencies:
-    "@ai-sdk/provider-utils": "npm:3.0.32"
-    ai: "npm:5.0.244"
+    "@ai-sdk/provider-utils": "npm:4.0.50"
+    ai: "npm:6.0.279"
     swr: "npm:^2.2.5"
     throttleit: "npm:2.1.0"
   peerDependencies:
     react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
-    zod: ^3.25.76 || ^4.1.8
-  peerDependenciesMeta:
-    zod:
-      optional: true
-  checksum: 10c0/d1c0f1cdf8018efe5cfa808dbb17f321b328b1cba7eaba59998a44fe22a94c53a932f33bad118cf21dbf21b16033a75382736bd9f32565e26c065c4e562d4cb9
+  checksum: 10c0/d454c1d4698d5de1705c64f89c890002bd5f61cb8068a4156e56d60f96c636374574c76f6975677a597ae471071c620c729580bdf91345f5a12a976ac667ccfb
   languageName: node
   linkType: hard
 
@@ -3582,9 +3578,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docsearch/core@npm:5.0.4":
-  version: 5.0.4
-  resolution: "@docsearch/core@npm:5.0.4"
+"@docsearch/core@npm:5.1.0":
+  version: 5.1.0
+  resolution: "@docsearch/core@npm:5.1.0"
   peerDependencies:
     "@types/react": ">= 16.8.0 < 20.0.0"
     react: ">= 16.8.0 < 20.0.0"
@@ -3596,34 +3592,34 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/f1d1ea48c086c739d9a758b5a8fef4d963bfd65cc1f8d95333309128ff7a5225ff3661fde33a11a2f131af920dc6b2b76a9f843646162e9c1ea47f75d7cf9931
+  checksum: 10c0/e3d83745ac69d7d4bd490e43b85ef7c47bee9dced1d0b931d93af21f04a303e4c3eb747e3c18ff61dfce2dd8e8d124e9ea15901c52580872fe5f5ef2c030d341
   languageName: node
   linkType: hard
 
-"@docsearch/css@npm:5.0.4, @docsearch/css@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "@docsearch/css@npm:5.0.4"
-  checksum: 10c0/5a3fb9dcd293a9636657fc1a442eb1ad8d8b84cb6347433826a01006335a0ad7550ee27e59492970ef8086559bea4feb46a34fd60af3f892cef9fdc1ad83ad0b
+"@docsearch/css@npm:5.1.0, @docsearch/css@npm:^5.0.4":
+  version: 5.1.0
+  resolution: "@docsearch/css@npm:5.1.0"
+  checksum: 10c0/479acbc5f0ac961feca7321808b325ea14cc5ca80043c6fb12ac7828b6289f4681803fa8819186619cd72441f71a2cc88bf462618f45b548b2e228c981a8125e
   languageName: node
   linkType: hard
 
 "@docsearch/js@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "@docsearch/js@npm:5.0.4"
-  checksum: 10c0/eea3e110e9bb822f99a4a55c640873a4a35b1859e85fdbf8a828b9db41bbe191facf0ff1193ba8e5a89fc206bd7a380510aeb01a45e63478a3e9b37511a343d7
+  version: 5.1.0
+  resolution: "@docsearch/js@npm:5.1.0"
+  checksum: 10c0/2f66c15a51345076637a19fd3a6d0661eb69fc5c38f8b5bcc9c9116bdb14cd4db11ff4bc47106486d0611587efae2e07725e408870aa61ef959304a71960dc77
   languageName: node
   linkType: hard
 
 "@docsearch/react@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "@docsearch/react@npm:5.0.4"
+  version: 5.1.0
+  resolution: "@docsearch/react@npm:5.1.0"
   dependencies:
-    "@ai-sdk/react": "npm:^2.0.30"
+    "@ai-sdk/react": "npm:^3.0.259"
     "@algolia/autocomplete-core": "npm:1.19.2"
     "@base-ui/react": "npm:^1.5.0"
-    "@docsearch/core": "npm:5.0.4"
-    "@docsearch/css": "npm:5.0.4"
-    ai: "npm:^5.0.30"
+    "@docsearch/core": "npm:5.1.0"
+    "@docsearch/css": "npm:5.1.0"
+    ai: "npm:^6.0.256"
     algoliasearch: "npm:^5.28.0"
     marked: "npm:^16.3.0"
     zod: "npm:^4.1.8"
@@ -3641,7 +3637,7 @@ __metadata:
       optional: true
     search-insights:
       optional: true
-  checksum: 10c0/db8caaad38cb48b323b2c8d5b8012ccba3c5abe25449c98c90d9502edd2bd14a4c10e8464620ca34fcfcb7ae11cf0760bcaefa3b8b26da6435d94776197dce56
+  checksum: 10c0/3c3734327da5faae14a714119a1f82e7261691df5a2bb4aafee9885aeb3de7d83d2e8a7af8c6a52d637457c94835aae959e384c943d12aaa45f4265874504c86
   languageName: node
   linkType: hard
 
@@ -4134,13 +4130,6 @@ __metadata:
     "@eslint/core": "npm:^0.17.0"
     levn: "npm:^0.4.1"
   checksum: 10c0/51600f78b798f172a9915dffb295e2ffb44840d583427bc732baf12ecb963eb841b253300e657da91d890f4b323d10a1bd12934bf293e3018d8bb66fdce5217b
-  languageName: node
-  linkType: hard
-
-"@fastify/busboy@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@fastify/busboy@npm:2.1.1"
-  checksum: 10c0/6f8027a8cba7f8f7b736718b013f5a38c0476eea67034c94a0d3c375e2b114366ad4419e6a6fa7ffc2ef9c6d3e0435d76dd584a7a1cbac23962fda7650b579e3
   languageName: node
   linkType: hard
 
@@ -6189,10 +6178,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@opentelemetry/api@npm:1.9.0"
-  checksum: 10c0/9aae2fe6e8a3a3eeb6c1fdef78e1939cf05a0f37f8a4fae4d6bf2e09eb1e06f966ece85805626e01ba5fab48072b94f19b835449e58b6d26720ee19a58298add
+"@opentelemetry/api@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "@opentelemetry/api@npm:1.9.1"
+  checksum: 10c0/c608485fc8b5a91e1f7e05e843b45b509307456b31cd2ad365933d90813e40ebfedf179f1451c762037e82d7c76aa8500e95d2da3609f640a1206cde5322cd14
   languageName: node
   linkType: hard
 
@@ -7577,7 +7566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
+"@standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
@@ -8396,10 +8385,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/oidc@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@vercel/oidc@npm:3.1.0"
-  checksum: 10c0/f57278ed4b4c022c7ca85e8baa5f9bdb2623397abfa0e5dbfd75de283c8e5dc534d64dac1364b5ad8c96d00eb2d469886e6f7b640f6f195def5766950ad8ce71
+"@vercel/oidc@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@vercel/oidc@npm:3.2.0"
+  checksum: 10c0/98318d3236f58c296616c8c2e1655b268c7bf58525bcd985adac7af6d900e05fc610f6f03ce2ff4bdcd3df7885a40c0ca44fdc761f122dcfe15a78c2756b0243
   languageName: node
   linkType: hard
 
@@ -8749,17 +8738,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ai@npm:5.0.244, ai@npm:^5.0.30":
-  version: 5.0.244
-  resolution: "ai@npm:5.0.244"
+"ai@npm:6.0.279, ai@npm:^6.0.256":
+  version: 6.0.279
+  resolution: "ai@npm:6.0.279"
   dependencies:
-    "@ai-sdk/gateway": "npm:2.0.139"
-    "@ai-sdk/provider": "npm:2.0.3"
-    "@ai-sdk/provider-utils": "npm:3.0.32"
-    "@opentelemetry/api": "npm:1.9.0"
+    "@ai-sdk/gateway": "npm:3.0.190"
+    "@ai-sdk/provider": "npm:3.0.15"
+    "@ai-sdk/provider-utils": "npm:4.0.50"
+    "@opentelemetry/api": "npm:^1.9.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/48439a1eb6d364a95b70d2185bda1378474494b2cbea7269349e05b7cac06a473e5028a2889079c8779c1d36223d4a9c93b1036929d5ef50a4e53ca53856f9dd
+  checksum: 10c0/9f99fda8be4eac2e980f1f639a6accc1d256ae0fa373ffbafd8f866dc0f8ea1e4ddc52a8eee13f484254fb8e4d036f1f06b155d77d195a6b27f326d3aa531b50
   languageName: node
   linkType: hard
 
@@ -9298,12 +9287,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.10.42":
-  version: 2.10.42
-  resolution: "baseline-browser-mapping@npm:2.10.42"
+"baseline-browser-mapping@npm:^2.11.20":
+  version: 2.11.21
+  resolution: "baseline-browser-mapping@npm:2.11.21"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/4a9f54818d17d8dbee69096563b2cd5e2175f66752c479f1c10d31e072c1c2b7241a9bdaee78d5236178c581ca2735e75fbb0d0877d6492958eed9f6e46e03f3
+  checksum: 10c0/1110ca70b60de9fa673e6d71154cbb2752225c28e069266c2f455f5a26367efc0e5b47a52afba22c9ef1e06d56a6c81aa964dda1fbc66c487e65c18a7c1e11c4
   languageName: node
   linkType: hard
 
@@ -9457,17 +9446,17 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.21.5, browserslist@npm:^4.22.1, browserslist@npm:^4.23.0, browserslist@npm:^4.24.0, browserslist@npm:^4.24.4, browserslist@npm:^4.28.1, browserslist@npm:^4.28.4":
-  version: 4.28.5
-  resolution: "browserslist@npm:4.28.5"
+  version: 4.28.9
+  resolution: "browserslist@npm:4.28.9"
   dependencies:
-    baseline-browser-mapping: "npm:^2.10.42"
-    caniuse-lite: "npm:^1.0.30001800"
-    electron-to-chromium: "npm:^1.5.387"
-    node-releases: "npm:^2.0.50"
-    update-browserslist-db: "npm:^1.2.3"
+    baseline-browser-mapping: "npm:^2.11.20"
+    caniuse-lite: "npm:^1.0.30001810"
+    electron-to-chromium: "npm:^1.5.420"
+    node-releases: "npm:^2.0.54"
+    update-browserslist-db: "npm:^1.3.2"
   bin:
     browserslist: cli.js
-  checksum: 10c0/d6bb4ab286a7071db52cbeabd46ff816e09c9171d7e5da246f0b9489601ad3d4adb9fc3d14fa934a8646078f8a717507c0518a364128735a3b5a7875900b5a19
+  checksum: 10c0/c4c7457cccb188bb904bb84566ff2d09e6f45ccf48619333111e5d60dfad456522a64e3e4af7c7608bc171371fc006f32bcc296877b0586bf80fb9f60841a110
   languageName: node
   linkType: hard
 
@@ -9601,10 +9590,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001799, caniuse-lite@npm:^1.0.30001800":
+"caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001799":
   version: 1.0.30001803
   resolution: "caniuse-lite@npm:1.0.30001803"
   checksum: 10c0/71586e9c84633cf766b208448eb76f860ec6e3befffc626d1f004e1902da063a7ab96cc94d1f4b36c0324e12997b3325a726de3287edfec91d0df495627a1d43
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001810":
+  version: 1.0.30001810
+  resolution: "caniuse-lite@npm:1.0.30001810"
+  checksum: 10c0/d29bc73f33c888025d54c7ff2984372d3b350b15a6a9e174884fb40976175e9177f202e2a72c2d428dddfc032784bc8ba635a31d168fcab9fac65756d7b3d6b4
   languageName: node
   linkType: hard
 
@@ -10949,10 +10945,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.387":
-  version: 1.5.388
-  resolution: "electron-to-chromium@npm:1.5.388"
-  checksum: 10c0/7ae7c7d348858917f7b38295c121496af76906b9d4be556fa9661762f16481e992004c7859acf6a0fbb21be5d32a3293752d6605eaf843dc427c308bb57fdb34
+"electron-to-chromium@npm:^1.5.420":
+  version: 1.5.425
+  resolution: "electron-to-chromium@npm:1.5.425"
+  checksum: 10c0/c911780d2a0914a97a677e3d0782a608699aac6891d56035b1ee96fe214e1c0b9e947a87af21cb99d117c77b3343cc7bac77b9411310840838d4b62b04f56d7b
   languageName: node
   linkType: hard
 
@@ -11668,7 +11664,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource-parser@npm:^3.0.6":
+"eventsource-parser@npm:^3.0.8":
   version: 3.1.1
   resolution: "eventsource-parser@npm:3.1.1"
   checksum: 10c0/dd3236c61140587253dcaaf947de528ac0e7371caffdc53c77afaeee36a17661f00e251a6ea16af56c99be5ac138303e67b5d750630e7c41b02e3564e8ad8c44
@@ -11938,9 +11934,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+  version: 3.1.7
+  resolution: "fast-uri@npm:3.1.7"
+  checksum: 10c0/ca2baa4bde48fc7322bdc692c6636975943ebe4f6dd97e07d70b14e0ab85af2ff30de90f550f5ec2956684fe208e150d85d6cb5f3c74438c8ac1bf86bd435c13
   languageName: node
   linkType: hard
 
@@ -12653,9 +12649,9 @@ __metadata:
   linkType: hard
 
 "hono@npm:^4.11.4":
-  version: 4.13.0
-  resolution: "hono@npm:4.13.0"
-  checksum: 10c0/d7cfb4d1063be19bea1982ea2a6b3cfa1840e8403a03203e86d17278e76fed11e7483974738345257543e183a935ea73ffc6d4a1e6ad7f0008451f55cdf8be7b
+  version: 4.13.7
+  resolution: "hono@npm:4.13.7"
+  checksum: 10c0/29672a94a4f2be7f3f4d959ad69808dd3bbc220909ca4f9660997022ff45d48ae71e42a460e417d808809d68110196f19359aaab2b14ae6a750331d789601b5a
   languageName: node
   linkType: hard
 
@@ -14199,25 +14195,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.15.1
-  resolution: "js-yaml@npm:3.15.1"
+  version: 3.15.2
+  resolution: "js-yaml@npm:3.15.2"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
+  checksum: 10c0/e341df211dece9d4b784849647ad7568b5b6a58a9ee58ead750482316d83276387343649fe4b71522705dc6c76acf97718588f23dc19443833ef3e75033af967
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.3.0, js-yaml@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+"js-yaml@npm:^4.3.0, js-yaml@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
   languageName: node
   linkType: hard
 
@@ -15770,10 +15766,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.50":
-  version: 2.0.50
-  resolution: "node-releases@npm:2.0.50"
-  checksum: 10c0/ac75ed433864114cfd9862034960bb4f49838343dc9fc31dc7d5be8189ce5f39510ad0bb3a697efe3193d50ab6921e7a3a6ce3aae2a6f8abe62719ffd40a4cac
+"node-releases@npm:^2.0.54":
+  version: 2.0.55
+  resolution: "node-releases@npm:2.0.55"
+  checksum: 10c0/35a779a188b3c1801820b77ea3c429d0aacac346368016a92c357dfd781f2908540fc3782b25d41647c3334dec83c976890f40d254bfd788eb5e72c3730146d1
   languageName: node
   linkType: hard
 
@@ -16666,32 +16662,22 @@ __metadata:
   linkType: hard
 
 "postcss-selector-parser@npm:^6.0.2, postcss-selector-parser@npm:^6.0.4":
-  version: 6.0.16
-  resolution: "postcss-selector-parser@npm:6.0.16"
+  version: 6.1.4
+  resolution: "postcss-selector-parser@npm:6.1.4"
   dependencies:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/0e11657cb3181aaf9ff67c2e59427c4df496b4a1b6a17063fae579813f80af79d444bf38f82eeb8b15b4679653fd3089e66ef0283f9aab01874d885e6cf1d2cf
+  checksum: 10c0/996f3290dee08ecb073d5f396d1134e619494cfd83140aec07a29618ee1e76d370769a8959d4c0cfefb24aa96dcffa4e7c4937dd881e03b735d50cba959ceb19
   languageName: node
   linkType: hard
 
-"postcss-selector-parser@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "postcss-selector-parser@npm:7.1.1"
+"postcss-selector-parser@npm:^7.1.1, postcss-selector-parser@npm:^7.1.4":
+  version: 7.1.6
+  resolution: "postcss-selector-parser@npm:7.1.6"
   dependencies:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/02d3b1589ddcddceed4b583b098b95a7266dacd5135f041e5d913ebb48e874fd333a36e564cc9a2ec426a464cb18db11cb192ac76247aced5eba8c951bf59507
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^7.1.4":
-  version: 7.1.4
-  resolution: "postcss-selector-parser@npm:7.1.4"
-  dependencies:
-    cssesc: "npm:^3.0.0"
-    util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/3d533d25bab83592e7134be0435e6cb1e2865f5e7d9fde65f1e7e1c75ccc5905168c9f55b05d2a3e10d01914a178433d3a54eab003f5ef6aa9a9d6816926caa2
+  checksum: 10c0/fc8279859896b96ef25b24d0289b2bfff7bce6647b247aa983939ff872e226663788d1ea57bddf9d1695119c071e5cdcb8b2a364ed4313502efe4b0319879154
   languageName: node
   linkType: hard
 
@@ -19439,19 +19425,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.29.0":
-  version: 5.29.0
-  resolution: "undici@npm:5.29.0"
-  dependencies:
-    "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10c0/e4e4d631ca54ee0ad82d2e90e7798fa00a106e27e6c880687e445cc2f13b4bc87c5eba2a88c266c3eecffb18f26e227b778412da74a23acc374fca7caccec49b
-  languageName: node
-  linkType: hard
-
 "undici@npm:^6.25.0":
   version: 6.28.0
   resolution: "undici@npm:6.28.0"
   checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
+  languageName: node
+  linkType: hard
+
+"undici@npm:^6.28.0":
+  version: 6.28.1
+  resolution: "undici@npm:6.28.1"
+  checksum: 10c0/9c7c277da83972f4f506d564b1d627e3e78aadf866915eab768d96fc70daeae8ff7d87d0cdb32403ae1afdf3aef0f11715e0847d66910fda62822c33c5a7e674
   languageName: node
   linkType: hard
 
@@ -19611,9 +19595,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "update-browserslist-db@npm:1.2.3"
+"update-browserslist-db@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "update-browserslist-db@npm:1.3.2"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -19621,7 +19605,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10c0/13a00355ea822388f68af57410ce3255941d5fb9b7c49342c4709a07c9f230bbef7f7499ae0ca7e0de532e79a82cc0c4edbd125f1a323a1845bf914efddf8bec
+  checksum: 10c0/837b4ea8c4934228c5c2a922ea747a54b0ec9d1c408d2fbc9220a9b98327c04109776e6ea1206fa056ea61ed8534863af472d9f2cfce569d35f04e98c95db739
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes every open Dependabot alert on the repository (19 at the time of writing). All of them are development-scope transitives in `yarn.lock`, and in every case the patched release already sits inside the range its dependents declare — so this is a lockfile refresh, with no range changes, no new `resolutions` entries and no new `.yarnrc.yml` audit exceptions.

`undici` was the only case without an in-range fix: `5.29.0` is the last release on the 5.x line and all eight of its advisories are patched only in 6.x. Its single path into the tree was `@docsearch/react` -> `@ai-sdk/react@2` -> `ai@5` -> `@ai-sdk/provider-utils@3`, which pins `undici ^5.29.0`. Bumping `@docsearch/*` to 5.1.0 — within the already declared `^5.0.4` — moves that chain to `@ai-sdk/provider-utils@4`, which requires `undici ^6.28.0`, at or above the threshold of all eight advisories. `undici` 5.x now leaves the tree entirely, together with `@fastify/busboy`.

## List of notable changes:

- **updated** `yarn.lock` so the following resolve to patched releases:

  | Package | Before | After | Patch threshold |
  | --- | --- | --- | --- |
  | `js-yaml` (3.x) | 3.15.1 | 3.15.2 | 3.15.2 |
  | `js-yaml` (4.x) | 4.3.1 | 4.3.2 | 4.3.2 |
  | `hono` | 4.13.0 | 4.13.7 | 4.13.5 |
  | `baseline-browser-mapping` | 2.10.42 | 2.11.21 | 2.11.0 |
  | `fast-uri` | 3.1.5 | 3.1.7 | 3.1.6 |
  | `browserslist` | 4.28.5 | 4.28.9 | 4.28.7 |
  | `postcss-selector-parser` | 7.1.1 | 7.1.6 | 7.1.3 |
  | `undici` | 5.29.0 | removed | no 5.x fix exists |

- **updated** `@docsearch/js`, `@docsearch/css` and `@docsearch/react` 5.0.4 -> 5.1.0, which swaps the `@ai-sdk` chain (`react` 2 -> 3, `ai` 5 -> 6, `provider-utils` 3 -> 4). No new top-level packages: `@base-ui/react`, `marked`, `zod` and `algoliasearch` were already present as `@docsearch/react` dependencies and only change version.
- **updated** the `js-yaml` resolution floor in `package.json` from `^4.3.1` to `^4.3.2`, so a later install cannot resolve back below the patched release.

## What should reviewers focus on?

- **The `@docsearch/*` bump.** It is the only change with a runtime surface. `apps/docs/src/app/components/docsearch/docsearch.directive.ts` wraps the DocSearch translations in a `DeepRequired` type specifically so a newly added upstream key fails compilation instead of rendering an empty string. It still compiles: `TRANSLATION_RU` satisfies the 5.1.0 type unchanged, so no new strings were needed. Worth a manual look at search and Ask AI on the docs preview, since `@docsearch/css` also moved to 5.1.0 and the docs smoke suite does not cover DocSearch or take screenshots.
- **`browserslist` 4.28.5 -> 4.28.9**, which shifts build targets and therefore what gets downlevelled. `caniuse-lite`, `electron-to-chromium` and `node-releases` moved with it.
- Out of scope, for the record: the full audit still reports `colord` (via `stylelint`) and `qs` (via `express`). Both are auto-dismissed on GitHub, so neither is an open alert, and neither is touched here.

## Verification

Run locally, all green: both audit invocations from `audit.yml` and `audit-report.yml`, `check-peer-deps`, `check-npm-resolution`, `validate:license` (1737 packages), all four library builds, and a production `docs:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
