### PR TITLE
fix(schematics): treat a prefix unary read as a read in five signal migrations

### DIFF
--- a/packages/schematics/src/migrations/autocomplete-signals/index.spec.ts
+++ b/packages/schematics/src/migrations/autocomplete-signals/index.spec.ts
@@ -349,6 +349,22 @@ describe(SCHEMATIC_NAME, () => {
         expect(updated).toContain('delete (autocomplete as any).showPanel;');
     });
 
+    it('rewrites a read under a negation instead of taking it for a write', async () => {
+        const ts = firstTsPath();
+
+        appTree.overwrite(
+            ts,
+            "import { KbqAutocomplete } from '@koobiq/components/autocomplete';\n" +
+                'class Demo {\n' +
+                '    read(autocomplete: KbqAutocomplete) {\n' +
+                '        return !autocomplete.showPanel;\n' +
+                '    }\n' +
+                '}\n'
+        );
+
+        expect((await run()).readText(ts)).toContain('return !autocomplete.showPanel();');
+    });
+
     it('rewrites a displayWith invocation to a read followed by the call', async () => {
         const ts = firstTsPath();
 

--- a/packages/schematics/src/migrations/autocomplete-signals/index.ts
+++ b/packages/schematics/src/migrations/autocomplete-signals/index.ts
@@ -321,6 +321,9 @@ const ASSIGNMENT_OPERATORS = new Set<ts.SyntaxKind>([
     ts.SyntaxKind.QuestionQuestionEqualsToken
 ]);
 
+/** Unary operators that write their operand back. Every other prefix operator is a plain read. */
+const INCREMENT_OPERATORS = new Set<ts.SyntaxKind>([ts.SyntaxKind.PlusPlusToken, ts.SyntaxKind.MinusMinusToken]);
+
 /** Whether `node` sits on the left of a destructuring assignment, where it is written rather than read. */
 function isDestructuringTarget(node: ts.Node): boolean {
     let current: ts.Node = node;
@@ -376,8 +379,11 @@ function classifyAccess(node: ts.PropertyAccessExpression, sourceFile: ts.Source
         return;
     }
 
-    // `a.showPanel++` / `--a.showPanel` and `delete a.showPanel` are writes too, for the same reason.
-    if ((ts.isPostfixUnaryExpression(parent) || ts.isPrefixUnaryExpression(parent)) && parent.operand === node) return;
+    // `a.showPanel++` / `--a.showPanel` and `delete a.showPanel` are writes too. Only the increment operators
+    // count: a `PrefixUnaryExpression` is also how `!a.showPanel` is spelled, and that is a read.
+    if (ts.isPostfixUnaryExpression(parent) && parent.operand === node) return;
+    if (ts.isPrefixUnaryExpression(parent) && parent.operand === node && INCREMENT_OPERATORS.has(parent.operator))
+        return;
     if (ts.isDeleteExpression(parent)) return;
     if (isDestructuringTarget(node)) return;
 

--- a/packages/schematics/src/migrations/badge-signals/index.spec.ts
+++ b/packages/schematics/src/migrations/badge-signals/index.spec.ts
@@ -386,6 +386,22 @@ describe(SCHEMATIC_NAME, () => {
         expect((await run()).readText(ts)).toContain('badge.compact++;');
     });
 
+    it('rewrites a read under a negation instead of taking it for a write', async () => {
+        const ts = firstTsPath();
+
+        appTree.overwrite(
+            ts,
+            "import { KbqBadge } from '@koobiq/components/badge';\n" +
+                'class Demo {\n' +
+                '    read(badge: KbqBadge) {\n' +
+                '        return !badge.compact;\n' +
+                '    }\n' +
+                '}\n'
+        );
+
+        expect((await run()).readText(ts)).toContain('return !badge.compact();');
+    });
+
     it('leaves a local that shadows the receiver name alone', async () => {
         const ts = firstTsPath();
 

--- a/packages/schematics/src/migrations/badge-signals/index.ts
+++ b/packages/schematics/src/migrations/badge-signals/index.ts
@@ -367,6 +367,9 @@ const ASSIGNMENT_OPERATORS = new Set<ts.SyntaxKind>([
     ts.SyntaxKind.QuestionQuestionEqualsToken
 ]);
 
+/** Unary operators that write their operand back. Every other prefix operator is a plain read. */
+const INCREMENT_OPERATORS = new Set<ts.SyntaxKind>([ts.SyntaxKind.PlusPlusToken, ts.SyntaxKind.MinusMinusToken]);
+
 /** Whether `node` sits on the left of a destructuring assignment, where it is written rather than read. */
 function isDestructuringTarget(node: ts.Node): boolean {
     let current: ts.Node = node;
@@ -411,8 +414,11 @@ function classifyAccess(node: ts.PropertyAccessExpression, sourceFile: ts.Source
         return;
     }
 
-    // `x.compact++` / `--x.compact` and `delete x.compact` are writes too, for the same reason.
-    if ((ts.isPostfixUnaryExpression(parent) || ts.isPrefixUnaryExpression(parent)) && parent.operand === node) return;
+    // `x.compact++` / `--x.compact` and `delete x.compact` are writes too. Only the increment operators
+    // count: a `PrefixUnaryExpression` is also how `!x.compact` is spelled, and that is a read.
+    if (ts.isPostfixUnaryExpression(parent) && parent.operand === node) return;
+    if (ts.isPrefixUnaryExpression(parent) && parent.operand === node && INCREMENT_OPERATORS.has(parent.operator))
+        return;
     if (ts.isDeleteExpression(parent)) return;
 
     // A destructuring assignment target: `({ a: x.compact } = source)`, `[x.compact] = source`.

--- a/packages/schematics/src/migrations/loader-overlay-signals/index.spec.ts
+++ b/packages/schematics/src/migrations/loader-overlay-signals/index.spec.ts
@@ -348,6 +348,22 @@ describe(SCHEMATIC_NAME, () => {
         expect(updated).toContain('delete (overlay as any).text;');
     });
 
+    it('rewrites a read under a negation instead of taking it for a write', async () => {
+        const ts = firstTsPath();
+
+        appTree.overwrite(
+            ts,
+            "import { KbqLoaderOverlay } from '@koobiq/components/loader-overlay';\n" +
+                'class Demo {\n' +
+                '    read(overlay: KbqLoaderOverlay) {\n' +
+                '        return !overlay.text;\n' +
+                '    }\n' +
+                '}\n'
+        );
+
+        expect((await run()).readText(ts)).toContain('return !overlay.text();');
+    });
+
     it('leaves a callback parameter that shadows the receiver name alone', async () => {
         const ts = firstTsPath();
 

--- a/packages/schematics/src/migrations/loader-overlay-signals/index.ts
+++ b/packages/schematics/src/migrations/loader-overlay-signals/index.ts
@@ -352,6 +352,9 @@ const ASSIGNMENT_OPERATORS = new Set<ts.SyntaxKind>([
     ts.SyntaxKind.QuestionQuestionEqualsToken
 ]);
 
+/** Unary operators that write their operand back. Every other prefix operator is a plain read. */
+const INCREMENT_OPERATORS = new Set<ts.SyntaxKind>([ts.SyntaxKind.PlusPlusToken, ts.SyntaxKind.MinusMinusToken]);
+
 /** Whether `node` sits on the left of a destructuring assignment, where it is written rather than read. */
 function isDestructuringTarget(node: ts.Node): boolean {
     let current: ts.Node = node;
@@ -392,8 +395,10 @@ function classifyAccess(node: ts.PropertyAccessExpression, edits: Edit[]): Acces
     if (ts.isBinaryExpression(parent) && parent.left === node && ASSIGNMENT_OPERATORS.has(parent.operatorToken.kind))
         return 'write';
 
-    // `x.text++` / `--x.text` and `delete x.text` are writes too.
-    if ((ts.isPostfixUnaryExpression(parent) || ts.isPrefixUnaryExpression(parent)) && parent.operand === node)
+    // `x.text++` / `--x.text` and `delete x.text` are writes too. Only the increment operators
+    // count: a `PrefixUnaryExpression` is also how `!x.text` is spelled, and that is a read.
+    if (ts.isPostfixUnaryExpression(parent) && parent.operand === node) return 'write';
+    if (ts.isPrefixUnaryExpression(parent) && parent.operand === node && INCREMENT_OPERATORS.has(parent.operator))
         return 'write';
     if (ts.isDeleteExpression(parent)) return 'write';
     if (isDestructuringTarget(node)) return 'write';

--- a/packages/schematics/src/migrations/markdown-signals/index.spec.ts
+++ b/packages/schematics/src/migrations/markdown-signals/index.spec.ts
@@ -335,6 +335,22 @@ describe(SCHEMATIC_NAME, () => {
         expect(updated).toContain('delete (markdown as any).markdownText;');
     });
 
+    it('rewrites a read under a negation instead of taking it for a write', async () => {
+        const ts = firstTsPath();
+
+        appTree.overwrite(
+            ts,
+            "import { KbqMarkdown } from '@koobiq/components/markdown';\n" +
+                'class Demo {\n' +
+                '    read(markdown: KbqMarkdown) {\n' +
+                '        return !markdown.markdownText;\n' +
+                '    }\n' +
+                '}\n'
+        );
+
+        expect((await run()).readText(ts)).toContain('return !markdown.markdownText();');
+    });
+
     it('does not let a parameter in a type position widen the receiver scope to the file', async () => {
         const ts = firstTsPath();
 

--- a/packages/schematics/src/migrations/markdown-signals/index.ts
+++ b/packages/schematics/src/migrations/markdown-signals/index.ts
@@ -343,6 +343,9 @@ const ASSIGNMENT_OPERATORS = new Set<ts.SyntaxKind>([
     ts.SyntaxKind.QuestionQuestionEqualsToken
 ]);
 
+/** Unary operators that write their operand back. Every other prefix operator is a plain read. */
+const INCREMENT_OPERATORS = new Set<ts.SyntaxKind>([ts.SyntaxKind.PlusPlusToken, ts.SyntaxKind.MinusMinusToken]);
+
 /** Whether `node` sits on the left of a destructuring assignment, where it is written rather than read. */
 function isDestructuringTarget(node: ts.Node): boolean {
     let current: ts.Node = node;
@@ -380,8 +383,11 @@ function classifyAccess(node: ts.PropertyAccessExpression, edits: Edit[]): void 
     if (ts.isBinaryExpression(parent) && parent.left === node && ASSIGNMENT_OPERATORS.has(parent.operatorToken.kind))
         return;
 
-    // `x.markdownText++` / `--x.markdownText` and `delete x.markdownText` are writes too.
-    if ((ts.isPostfixUnaryExpression(parent) || ts.isPrefixUnaryExpression(parent)) && parent.operand === node) return;
+    // `x.markdownText++` / `--x.markdownText` and `delete x.markdownText` are writes too. Only the increment operators
+    // count: a `PrefixUnaryExpression` is also how `!x.markdownText` is spelled, and that is a read.
+    if (ts.isPostfixUnaryExpression(parent) && parent.operand === node) return;
+    if (ts.isPrefixUnaryExpression(parent) && parent.operand === node && INCREMENT_OPERATORS.has(parent.operator))
+        return;
     if (ts.isDeleteExpression(parent)) return;
     if (isDestructuringTarget(node)) return;
 

--- a/packages/schematics/src/migrations/progress-spinner-signals/index.spec.ts
+++ b/packages/schematics/src/migrations/progress-spinner-signals/index.spec.ts
@@ -308,6 +308,22 @@ describe(SCHEMATIC_NAME, () => {
         expect(updated).toContain('delete (spinner as any).mode;');
     });
 
+    it('rewrites a read under a negation or a unary minus instead of taking it for a write', async () => {
+        const ts = firstTsPath();
+
+        appTree.overwrite(
+            ts,
+            "import { KbqProgressSpinner } from '@koobiq/components/progress-spinner';\n" +
+                'class Demo {\n' +
+                '    read(spinner: KbqProgressSpinner) {\n' +
+                '        return !spinner.size || -spinner.value < 0;\n' +
+                '    }\n' +
+                '}\n'
+        );
+
+        expect((await run()).readText(ts)).toContain('return !spinner.size() || -spinner.value() < 0;');
+    });
+
     it('does not let a parameter in a type position widen the receiver scope to the file', async () => {
         const ts = firstTsPath();
 

--- a/packages/schematics/src/migrations/progress-spinner-signals/index.ts
+++ b/packages/schematics/src/migrations/progress-spinner-signals/index.ts
@@ -341,6 +341,9 @@ const ASSIGNMENT_OPERATORS = new Set<ts.SyntaxKind>([
     ts.SyntaxKind.QuestionQuestionEqualsToken
 ]);
 
+/** Unary operators that write their operand back. Every other prefix operator is a plain read. */
+const INCREMENT_OPERATORS = new Set<ts.SyntaxKind>([ts.SyntaxKind.PlusPlusToken, ts.SyntaxKind.MinusMinusToken]);
+
 /** Whether `node` sits on the left of a destructuring assignment, where it is written rather than read. */
 function isDestructuringTarget(node: ts.Node): boolean {
     let current: ts.Node = node;
@@ -386,8 +389,12 @@ function classifyAccess(node: ts.PropertyAccessExpression, sourceFile: ts.Source
         return;
     }
 
-    // `x.size++` / `--x.size` and `delete x.size` are writes too, for the same reason.
-    if ((ts.isPostfixUnaryExpression(parent) || ts.isPrefixUnaryExpression(parent)) && parent.operand === node) return;
+    // `x.size++` / `--x.size` and `delete x.size` are writes too. Only the increment operators
+    // count: a `PrefixUnaryExpression` is also how `!x.size` and `-x.value` are spelled, and those
+    // are reads.
+    if (ts.isPostfixUnaryExpression(parent) && parent.operand === node) return;
+    if (ts.isPrefixUnaryExpression(parent) && parent.operand === node && INCREMENT_OPERATORS.has(parent.operator))
+        return;
     if (ts.isDeleteExpression(parent)) return;
     if (isDestructuringTarget(node)) return;
 


### PR DESCRIPTION
## Summary

Пять ng-update миграций считали записью любое префиксное унарное выражение над сигнальным членом. `ts.isPrefixUnaryExpression` покрывает не только `++`/`--`, но и `!`, `-`, `+`, `~` — поэтому чтение вида `!overlay.text` классифицировалось как запись, `()` не дописывалось, и после миграции `text` — это `InputSignal`, то есть объект-функция, всегда истинный. Ошибки компиляции нет, предупреждения нет, условие молча переворачивается.

Теперь записью считаются только `PlusPlusToken` и `MinusMinusToken` — так же, как это уже сделано в `link-signals` (#1983).

## List of notable changes:

- **fixed** `classifyAccess` in `badge-signals`, `loader-overlay-signals`, `markdown-signals`, `progress-spinner-signals`, `autocomplete-signals`: a prefix unary expression is a write only for the increment operators
- **added** a `INCREMENT_OPERATORS` set to each of the five migrations, matching `link-signals`
- **added** a test per migration covering a read under a negation (`return !overlay.text;` → `return !overlay.text();`); `progress-spinner` additionally covers the unary minus

## What should reviewers focus on?

- Формулировка в `checkbox-signals/index.ts:390` содержит ровно тот же дефект и в этот PR не входит — стоит решить, чинить ли её отдельно или добавить сюда.
- Каждый новый тест проверен на падение до правки и прохождение после.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
