### PR TITLE
docs: reference @koobiq/icons llms.txt / llms-full.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@koobiq/ag-grid-angular-theme": "^34.5.1",
         "@koobiq/date-adapter": "^3.5.1",
         "@koobiq/date-formatter": "^3.5.1",
-        "@koobiq/icons": "^12.2.0",
+        "@koobiq/icons": "^12.2.1",
         "@maskito/angular": "^5.1.0",
         "@maskito/core": "^5.1.0",
         "@maskito/kit": "^5.3.1",

--- a/tools/generate-llms-txt.ts
+++ b/tools/generate-llms-txt.ts
@@ -71,19 +71,14 @@ try {
         if (category.id === DocsStructureCategoryId.Icons) {
             try {
                 const iconsPackageDir = dirname(require.resolve('@koobiq/icons/package.json'));
-                const iconsLlmsFullTxtPath = join(iconsPackageDir, 'llms-full.txt');
 
-                if (existsSync(iconsLlmsFullTxtPath)) {
+                if (existsSync(iconsPackageDir)) {
                     const { version: iconsVersion } = JSON.parse(
                         readFileSync(join(iconsPackageDir, 'package.json'), 'utf-8')
                     );
 
-                    content += `- [icon reference](https://github.com/koobiq/icons/blob/main/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
-                    contentFull += `${readFileSync(iconsLlmsFullTxtPath, 'utf-8')}\n`;
-                } else {
-                    console.warn(
-                        `⚠️ Skipping icons reference: llms-full.txt not found in installed @koobiq/icons — update the dependency once it publishes it`
-                    );
+                    content += `- [icon reference](https://github.com/koobiq/icons/blob/main/llms.txt) — brief explanation of package (@koobiq/icons@${iconsVersion})\n\n`;
+                    contentFull += `- [icon reference](https://github.com/koobiq/icons/blob/main/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
                 }
             } catch (error) {
                 console.warn(`⚠️ Skipping icons reference: could not resolve @koobiq/icons package (${error})`);

--- a/tools/generate-llms-txt.ts
+++ b/tools/generate-llms-txt.ts
@@ -65,21 +65,18 @@ try {
             continue;
         }
 
-        content += `## ${category.id}\n\n`;
-        contentFull += `## ${category.id}\n\n`;
-
         if (category.id === DocsStructureCategoryId.Icons) {
             try {
                 const iconsPackageDir = dirname(require.resolve('@koobiq/icons/package.json'));
 
                 if (existsSync(iconsPackageDir)) {
+                    content += `## ${category.id}\n\n`;
+                    contentFull += `## ${category.id}\n\n`;
+
                     const { version: iconsVersion } = JSON.parse(
                         readFileSync(join(iconsPackageDir, 'package.json'), 'utf-8')
                     );
 
-                    // raw.githubusercontent.com, not github.com/blob: the blob URL wraps a 1 KB
-                    // file in ~236 KB of GitHub UI markup, and a missing file answers with a
-                    // 200 KB "404" page instead of a bare `404: Not Found`.
                     content += `- [icon reference](https://raw.githubusercontent.com/koobiq/icons/${iconsVersion}/llms.txt) — brief explanation of package (@koobiq/icons@${iconsVersion})\n\n`;
                     contentFull += `- [icon full reference](https://raw.githubusercontent.com/koobiq/icons/${iconsVersion}/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
                 }

--- a/tools/generate-llms-txt.ts
+++ b/tools/generate-llms-txt.ts
@@ -78,7 +78,7 @@ try {
                     );
 
                     content += `- [icon reference](https://github.com/koobiq/icons/blob/${iconsVersion}/llms.txt) — brief explanation of package (@koobiq/icons@${iconsVersion})\n\n`;
-                    contentFull += `- [icon reference](https://github.com/koobiq/icons/blob/${iconsVersion}/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
+                    contentFull += `- [icon full reference](https://github.com/koobiq/icons/blob/${iconsVersion}/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
                 }
             } catch (error) {
                 console.warn(`⚠️ Skipping icons reference: could not resolve @koobiq/icons package (${error})`);

--- a/tools/generate-llms-txt.ts
+++ b/tools/generate-llms-txt.ts
@@ -77,8 +77,11 @@ try {
                         readFileSync(join(iconsPackageDir, 'package.json'), 'utf-8')
                     );
 
-                    content += `- [icon reference](https://github.com/koobiq/icons/blob/${iconsVersion}/llms.txt) — brief explanation of package (@koobiq/icons@${iconsVersion})\n\n`;
-                    contentFull += `- [icon full reference](https://github.com/koobiq/icons/blob/${iconsVersion}/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
+                    // raw.githubusercontent.com, not github.com/blob: the blob URL wraps a 1 KB
+                    // file in ~236 KB of GitHub UI markup, and a missing file answers with a
+                    // 200 KB "404" page instead of a bare `404: Not Found`.
+                    content += `- [icon reference](https://raw.githubusercontent.com/koobiq/icons/${iconsVersion}/llms.txt) — brief explanation of package (@koobiq/icons@${iconsVersion})\n\n`;
+                    contentFull += `- [icon full reference](https://raw.githubusercontent.com/koobiq/icons/${iconsVersion}/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
                 }
             } catch (error) {
                 console.warn(`⚠️ Skipping icons reference: could not resolve @koobiq/icons package (${error})`);

--- a/tools/generate-llms-txt.ts
+++ b/tools/generate-llms-txt.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { docsGetCategories, DocsStructureCategoryId, DocsStructureItemId } from '../apps/docs/src/app/structure';
 
 const isFileExists = (relativePath: string): boolean => {
@@ -61,12 +61,34 @@ try {
     let contentFull = content;
 
     for (const category of docsGetCategories()) {
-        if (category.id === DocsStructureCategoryId.Other || category.id === DocsStructureCategoryId.Icons) {
+        if (category.id === DocsStructureCategoryId.Other) {
             continue;
         }
 
         content += `## ${category.id}\n\n`;
         contentFull += `## ${category.id}\n\n`;
+
+        if (category.id === DocsStructureCategoryId.Icons) {
+            try {
+                const iconsPackageDir = dirname(require.resolve('@koobiq/icons/package.json'));
+                const iconsLlmsFullTxtPath = join(iconsPackageDir, 'llms-full.txt');
+
+                if (existsSync(iconsLlmsFullTxtPath)) {
+                    const { version: iconsVersion } = JSON.parse(
+                        readFileSync(join(iconsPackageDir, 'package.json'), 'utf-8')
+                    );
+
+                    content += `- [icon reference](https://github.com/koobiq/icons/blob/main/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
+                    contentFull += `${readFileSync(iconsLlmsFullTxtPath, 'utf-8')}\n`;
+                } else {
+                    console.warn(
+                        `⚠️ Skipping icons reference: llms-full.txt not found in installed @koobiq/icons — update the dependency once it publishes it`
+                    );
+                }
+            } catch (error) {
+                console.warn(`⚠️ Skipping icons reference: could not resolve @koobiq/icons package (${error})`);
+            }
+        }
 
         if (category.id === DocsStructureCategoryId.Main) {
             for (const item of category.items) {

--- a/tools/generate-llms-txt.ts
+++ b/tools/generate-llms-txt.ts
@@ -77,8 +77,8 @@ try {
                         readFileSync(join(iconsPackageDir, 'package.json'), 'utf-8')
                     );
 
-                    content += `- [icon reference](https://github.com/koobiq/icons/blob/main/llms.txt) — brief explanation of package (@koobiq/icons@${iconsVersion})\n\n`;
-                    contentFull += `- [icon reference](https://github.com/koobiq/icons/blob/main/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
+                    content += `- [icon reference](https://github.com/koobiq/icons/blob/${iconsVersion}/llms.txt) — brief explanation of package (@koobiq/icons@${iconsVersion})\n\n`;
+                    contentFull += `- [icon reference](https://github.com/koobiq/icons/blob/${iconsVersion}/llms-full.txt) — every icon name, sizes, tags, and import examples (@koobiq/icons@${iconsVersion})\n\n`;
                 }
             } catch (error) {
                 console.warn(`⚠️ Skipping icons reference: could not resolve @koobiq/icons package (${error})`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5289,10 +5289,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@koobiq/icons@npm:^12.2.0":
-  version: 12.2.0
-  resolution: "@koobiq/icons@npm:12.2.0"
-  checksum: 10c0/1ad86135f9bcee80df6a00479235e76f4a141156235bf1e40987ff6489eb5ab8b72e7c3e56f7dbce310636f677e4acb5fed8cf6372d5b9ad62d7b09f75448e35
+"@koobiq/icons@npm:^12.2.1":
+  version: 12.2.1
+  resolution: "@koobiq/icons@npm:12.2.1"
+  checksum: 10c0/9dceea0f4e220d8ee63319b7dc6a036a63b10db5e34168a9a1f36edfbc9c29b8ff33d176495b01c24f5cac8d7648fbc6e568b0d678948236f23e1bc4539060c3
   languageName: node
   linkType: hard
 
@@ -14142,7 +14142,7 @@ __metadata:
     "@koobiq/date-adapter": "npm:^3.5.1"
     "@koobiq/date-formatter": "npm:^3.5.1"
     "@koobiq/design-tokens": "npm:^3.19.0"
-    "@koobiq/icons": "npm:^12.2.0"
+    "@koobiq/icons": "npm:^12.2.1"
     "@koobiq/luxon-date-adapter": "npm:^3.5.1"
     "@koobiq/moment-date-adapter": "npm:^3.5.1"
     "@koobiq/tokens-builder": "npm:^3.19.0"


### PR DESCRIPTION
## Summary
- The generated site `llms.txt`/`llms-full.txt` previously skipped the `Icons` category entirely (no icon reference at all)
- Now resolves the installed `@koobiq/icons` package and adds a link (not embedded content) to its `llms.txt` in `llms.txt`, and to its `llms-full.txt` in `llms-full.txt`, pinned to the installed package's version tag
- Fails gracefully (warns, skips) if `@koobiq/icons` can't be resolved

## Test plan
- [x] Дождаться выпуска версии с llms.txt