### PR TITLE
feat(components): use KbqScrollbarViewport in textarea (#DS-5453)

### DIFF
--- a/packages/components/autocomplete/autocomplete.component.ts
+++ b/packages/components/autocomplete/autocomplete.component.ts
@@ -255,18 +255,12 @@ export class KbqAutocomplete implements AfterContentInit {
 
     /** @docs-private */
     setScrollTop(scrollTop: number): void {
-        const panel = this.panel();
-
-        if (panel) {
-            panel.nativeElement.scrollTop = scrollTop;
-        }
+        this.scrollbarViewport()?.scrollTo({ top: scrollTop });
     }
 
     /** @docs-private */
     getScrollTop(): number {
-        const panel = this.panel();
-
-        return panel ? panel.nativeElement.scrollTop : 0;
+        return this.scrollbarViewport()?.getNativeElement().scrollTop ?? 0;
     }
 
     /** @docs-private */

--- a/packages/components/code-block/code-block.html
+++ b/packages/components/code-block/code-block.html
@@ -96,10 +96,8 @@
     #tabPanel="kbqTabNavPanel"
     #codeBlockContent="kbqOverflowShadowContainer"
     cdkMonitorElementFocus
-    cdkScrollable
-    kbqNativeScrollbar
-    kbqNativeScrollbarDescendants
     kbqOverflowShadowContainer
+    kbqScrollbarViewport
     kbqTabNavPanel
     class="kbq-code-block__main"
     [style.max-height.px]="calculatedMaxHeight"

--- a/packages/components/code-block/code-block.scss
+++ b/packages/components/code-block/code-block.scss
@@ -113,6 +113,21 @@
         }
     }
 
+    // A block box is as wide as its containing block, never as wide as the content overflowing it, so
+    // under `white-space: pre` the code box stays one scrollport wide and the long lines simply spill
+    // past it. That goes unnoticed while the background sits on an ancestor — but the code's own right
+    // padding is painted at the edge of that unstretched box, so scrolling a long line to the end puts
+    // the last glyph flush against the border. Stretching the box to its content puts the padding back
+    // where the line ends; `min-width` keeps a short file filling the scrollport rather than shrinking
+    // to its widest line. Excluded under soft wrap, where `max-content` is the width the text would
+    // take unwrapped — which is exactly what that mode exists to avoid.
+    &:not(.kbq-code-block_soft-wrap) {
+        .kbq-code-block__pre {
+            width: max-content;
+            min-width: 100%;
+        }
+    }
+
     &.kbq-code-block_view-all {
         .kbq-code-block__main {
             max-height: unset;

--- a/packages/components/code-block/code-block.spec.ts
+++ b/packages/components/code-block/code-block.spec.ts
@@ -1,9 +1,10 @@
 import { SharedResizeObserver } from '@angular/cdk/observers/private';
 import { Platform } from '@angular/cdk/platform';
 import { ChangeDetectionStrategy, Component, DebugElement, Provider, Type } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { KbqScrollbarViewport } from '@koobiq/components/scrollbar';
 import { KbqTabNavBar } from '@koobiq/components/tabs';
 import { HLJSApi } from 'highlight.js';
 import { Observable, Subject } from 'rxjs';
@@ -43,6 +44,10 @@ const createComponent = <T>(component: Type<T>, providers: Provider[] = []): Com
 
     return fixture;
 };
+
+// By.directive would find the tab nav bar's viewport first; the code content is the one these want.
+const getScrollbarViewport = (fixture: ComponentFixture<unknown>): KbqScrollbarViewport =>
+    fixture.debugElement.query(By.css('.kbq-code-block__main')).injector.get(KbqScrollbarViewport);
 
 const geCodeBlockDebugElement = (debugElement: DebugElement): DebugElement => {
     return debugElement.query(By.directive(KbqCodeBlock));
@@ -211,14 +216,19 @@ describe(KbqCodeBlock.name, () => {
         expect(codeBlock.classes['kbq-code-block_hide-line-numbers']).toBeFalsy();
     });
 
-    it('should apply lineNumbers plugin', waitForAsync(async () => {
+    // The async tests in this file are plain `async` rather than `waitForAsync`: the code content is a
+    // `KbqScrollbarViewport`, whose track polls on a self-rescheduling `requestAnimationFrame`. That
+    // chain is a macrotask of the test zone — `runOutsideAngular` leaves NgZone, not the zone
+    // `waitForAsync` waits on — so it never drains and every such test times out. `fixture.whenStable()`
+    // still settles, because it tracks NgZone, and that is what these tests actually need.
+    it('should apply lineNumbers plugin', async () => {
         const fixture = createComponent(BaseCodeBlock);
         const codeBlock = geCodeBlockDebugElement(fixture.debugElement);
 
         await fixture.whenStable();
 
         expect(codeBlock.nativeElement.querySelector('.hljs-ln')).toBeInstanceOf(HTMLTableElement);
-    }));
+    });
 
     it('should fill the code block', () => {
         const fixture = createComponent(BaseCodeBlock);
@@ -342,7 +352,7 @@ describe(KbqCodeBlock.name, () => {
         expect(codeBlock.classes['kbq-code-block_soft-wrap']).toBeTruthy();
     });
 
-    it('should set fallback file content language if not provided', waitForAsync(async () => {
+    it('should set fallback file content language if not provided', async () => {
         const fixture = createComponent(BaseCodeBlock);
         const { debugElement, componentInstance } = fixture;
 
@@ -354,9 +364,9 @@ describe(KbqCodeBlock.name, () => {
         expect(geCodeBlockHighlightDebugElement(debugElement).attributes['data-language']).toBe(
             TestBed.inject(KBQ_CODE_BLOCK_FALLBACK_FILE_LANGUAGE)
         );
-    }));
+    });
 
-    it('should set fallback file content language if is invalid', waitForAsync(async () => {
+    it('should set fallback file content language if is invalid', async () => {
         const fixture = createComponent(BaseCodeBlock);
         const { debugElement, componentInstance } = fixture;
 
@@ -368,7 +378,7 @@ describe(KbqCodeBlock.name, () => {
         expect(geCodeBlockHighlightDebugElement(debugElement).attributes['data-language']).toBe(
             TestBed.inject(KBQ_CODE_BLOCK_FALLBACK_FILE_LANGUAGE)
         );
-    }));
+    });
 
     it('should provide custom locale configuration', () => {
         const { debugElement } = createComponent(BaseCodeBlock, [
@@ -387,7 +397,7 @@ describe(KbqCodeBlock.name, () => {
         expect(geCodeBlockDebugElement(debugElement).componentInstance.localeConfiguration).toMatchSnapshot();
     });
 
-    it('should highlight code', waitForAsync(async () => {
+    it('should highlight code', async () => {
         const fixture = createComponent(BaseCodeBlock);
         const { debugElement, componentInstance } = fixture;
         const code = geCodeBlockHighlightDebugElement(debugElement);
@@ -406,7 +416,7 @@ describe(KbqCodeBlock.name, () => {
         fixture.detectChanges();
         expect(code.classes['hljs']).toBe(true);
         expect(code.attributes['data-language']).toBe('css');
-    }));
+    });
 
     it('should display toggle soft wrap button', () => {
         const fixture = createComponent(BaseCodeBlock);
@@ -771,7 +781,7 @@ describe(KbqCodeBlock.name, () => {
                 registerLanguage: jest.fn()
             }) as unknown as HLJSApi;
 
-        it('should defer highlighting until hljs core is loaded', waitForAsync(async () => {
+        it('should defer highlighting until hljs core is loaded', async () => {
             const mockCore = buildMockCore();
             const fixture = createComponent(BaseCodeBlock, [
                 kbqCodeBlockHighlightJsConfigProvider({
@@ -786,9 +796,9 @@ describe(KbqCodeBlock.name, () => {
 
             expect(code.attributes['data-language']).toBe('html');
             expect(mockCore.highlight).toHaveBeenCalled();
-        }));
+        });
 
-        it('should call registerLanguage for each provided language', waitForAsync(async () => {
+        it('should call registerLanguage for each provided language', async () => {
             const mockCore = buildMockCore();
             const typescriptLoader = jest.fn().mockResolvedValue({ default: jest.fn() });
             const cssLoader = jest.fn().mockResolvedValue({ default: jest.fn() });
@@ -808,9 +818,9 @@ describe(KbqCodeBlock.name, () => {
             expect(typescriptLoader).toHaveBeenCalledTimes(1);
             expect(cssLoader).toHaveBeenCalledTimes(1);
             expect(mockCore.registerLanguage).toHaveBeenCalledTimes(2);
-        }));
+        });
 
-        it('should apply the pending file after hljs loads', waitForAsync(async () => {
+        it('should apply the pending file after hljs loads', async () => {
             const mockCore = buildMockCore();
             const fixture = createComponent(BaseCodeBlock, [
                 kbqCodeBlockHighlightJsConfigProvider({
@@ -825,9 +835,9 @@ describe(KbqCodeBlock.name, () => {
 
             expect(mockCore.highlight).toHaveBeenCalled();
             expect(code.attributes['data-language']).toBeDefined();
-        }));
+        });
 
-        it('should fall back to fallback language for unknown languages (async path)', waitForAsync(async () => {
+        it('should fall back to fallback language for unknown languages (async path)', async () => {
             const mockCore = buildMockCore();
 
             (mockCore.getLanguage as jest.Mock).mockReturnValue(undefined);
@@ -851,7 +861,7 @@ describe(KbqCodeBlock.name, () => {
             expect(geCodeBlockHighlightDebugElement(fixture.debugElement).attributes['data-language']).toBe(
                 TestBed.inject(KBQ_CODE_BLOCK_FALLBACK_FILE_LANGUAGE)
             );
-        }));
+        });
 
         it('should set pending to true while hljs is loading', () => {
             const fixture = createComponent(BaseCodeBlock, [
@@ -869,7 +879,7 @@ describe(KbqCodeBlock.name, () => {
             expect(highlight.pending()).toBe(true);
         });
 
-        it('should set pending to false after hljs has loaded', waitForAsync(async () => {
+        it('should set pending to false after hljs has loaded', async () => {
             const fixture = createComponent(BaseCodeBlock, [
                 kbqCodeBlockHighlightJsConfigProvider({
                     core: () => Promise.resolve({ default: buildMockCore() })
@@ -882,7 +892,7 @@ describe(KbqCodeBlock.name, () => {
             await fixture.whenStable();
 
             expect(highlight.pending()).toBe(false);
-        }));
+        });
     });
 
     describe('scrollTo', () => {
@@ -898,7 +908,7 @@ describe(KbqCodeBlock.name, () => {
                 registerLanguage: jest.fn()
             }) as unknown as HLJSApi;
 
-        it('should scroll immediately when highlighting is complete', waitForAsync(async () => {
+        it('should scroll immediately when highlighting is complete', async () => {
             const fixture = createComponent(BaseCodeBlock, [
                 kbqCodeBlockHighlightJsConfigProvider({
                     core: () => Promise.resolve({ default: createMockCore() })
@@ -908,14 +918,14 @@ describe(KbqCodeBlock.name, () => {
             await fixture.whenStable();
 
             const codeBlock = geCodeBlockDebugElement(fixture.debugElement).componentInstance as KbqCodeBlock;
-            const scrollSpy = jest.spyOn(codeBlock.scrollableCodeContent(), 'scrollTo').mockImplementation(() => {});
+            const scrollSpy = jest.spyOn(getScrollbarViewport(fixture), 'scrollTo').mockImplementation(() => {});
 
             codeBlock.scrollTo({ top: 50 });
 
             expect(scrollSpy).toHaveBeenCalledWith({ top: 50 });
-        }));
+        });
 
-        it('should defer scroll until highlighting completes when pending', waitForAsync(async () => {
+        it('should defer scroll until highlighting completes when pending', async () => {
             let resolveCore!: (value: { default: HLJSApi }) => void;
 
             const fixture = createComponent(BaseCodeBlock, [
@@ -928,7 +938,7 @@ describe(KbqCodeBlock.name, () => {
             ]);
 
             const codeBlock = geCodeBlockDebugElement(fixture.debugElement).componentInstance as KbqCodeBlock;
-            const scrollSpy = jest.spyOn(codeBlock.scrollableCodeContent(), 'scrollTo').mockImplementation(() => {});
+            const scrollSpy = jest.spyOn(getScrollbarViewport(fixture), 'scrollTo').mockImplementation(() => {});
 
             codeBlock.scrollTo({ top: 100 });
             expect(scrollSpy).not.toHaveBeenCalled();
@@ -937,6 +947,29 @@ describe(KbqCodeBlock.name, () => {
             await fixture.whenStable();
 
             expect(scrollSpy).toHaveBeenCalledWith({ top: 100 });
-        }));
+        });
+
+        it('reveals the scrollbar once highlighting settles, so an arriving block advertises its scroll', async () => {
+            let resolveCore!: (value: { default: HLJSApi }) => void;
+            // Installed on the prototype, before the component exists: a spy taken off the instance
+            // afterwards could not have recorded a premature flash, which is half of what this asserts.
+            const flashSpy = jest.spyOn(KbqScrollbarViewport.prototype, 'flashScrollIndicators');
+
+            const fixture = createComponent(BaseCodeBlock, [
+                kbqCodeBlockHighlightJsConfigProvider({
+                    core: () =>
+                        new Promise<{ default: HLJSApi }>((resolve) => {
+                            resolveCore = resolve;
+                        })
+                })
+            ]);
+
+            expect(flashSpy).not.toHaveBeenCalled();
+
+            resolveCore({ default: createMockCore() });
+            await fixture.whenStable();
+
+            expect(flashSpy).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/components/code-block/code-block.ts
+++ b/packages/components/code-block/code-block.ts
@@ -2,7 +2,7 @@ import { A11yModule, FocusMonitor } from '@angular/cdk/a11y';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { SharedResizeObserver } from '@angular/cdk/observers/private';
 import { Platform } from '@angular/cdk/platform';
-import { CdkScrollable, CdkScrollableModule, ExtendedScrollToOptions } from '@angular/cdk/scrolling';
+import { CdkScrollable } from '@angular/cdk/scrolling';
 import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
 import {
     AfterViewInit,
@@ -45,10 +45,10 @@ import {
     ruRULocaleData
 } from '@koobiq/components/core';
 import { KbqIconModule } from '@koobiq/components/icon';
-import { KbqNativeScrollbar } from '@koobiq/components/scrollbar';
+import { KbqScrollbarViewport, type KbqScrollbarScrollToOptions } from '@koobiq/components/scrollbar';
 import { KbqTabsModule } from '@koobiq/components/tabs';
 import { KbqToolTipModule, KbqTooltipTrigger } from '@koobiq/components/tooltip';
-import { debounceTime, filter, fromEvent, map, merge, take } from 'rxjs';
+import { debounceTime, filter, fromEvent, map, merge, take, type Observable } from 'rxjs';
 import { KbqCodeBlockHighlight } from './code-block-highlight';
 import { KbqCodeBlockFile, KbqTabLinkTemplateContext } from './types';
 
@@ -111,10 +111,9 @@ export class KbqCodeBlockTabLinkContent {}
         KbqButtonModule,
         KbqCodeBlockHighlight,
         A11yModule,
-        CdkScrollableModule,
         KbqToolTipModule,
         KbqIconModule,
-        KbqNativeScrollbar,
+        KbqScrollbarViewport,
         NgTemplateOutlet,
         KbqOverflowShadowContainer,
         KbqOverflowShadowTop
@@ -153,6 +152,12 @@ export class KbqCodeBlock implements AfterViewInit {
 
     /** @docs-private */
     private readonly highlight = viewChild.required(KbqCodeBlockHighlight);
+
+    /** @docs-private */
+    private readonly scrollbarViewport = viewChild.required(KbqScrollbarViewport);
+
+    /** Memoized so the three waiters below share one `toObservable` effect instead of one each. */
+    private highlightPending?: Observable<boolean>;
 
     /** @docs-private */
     private readonly preElementRef = viewChild.required<ElementRef<HTMLElement>>('codeBlockPre');
@@ -343,7 +348,7 @@ export class KbqCodeBlock implements AfterViewInit {
     private get canCodeContentBeFocused(): boolean {
         if (!this.platform.isBrowser) return false;
 
-        const element = this.scrollableCodeContent()?.getElementRef().nativeElement;
+        const element = this.scrollbarViewport().getNativeElement();
 
         return element && this.hasScroll(element) && !this.calculatedMaxHeight;
     }
@@ -389,6 +394,7 @@ export class KbqCodeBlock implements AfterViewInit {
 
     ngAfterViewInit(): void {
         this.setupContentOverflowDetection();
+        this.revealScrollbarOnHighlight();
 
         this.copyButtonTooltip()
             ?.visibleChange.pipe(takeUntilDestroyed(this.destroyRef))
@@ -423,18 +429,11 @@ export class KbqCodeBlock implements AfterViewInit {
     }
 
     /** Scrolls the code content to the specified position. */
-    scrollTo(options: ExtendedScrollToOptions): void {
-        const scroll = () => this.scrollableCodeContent().scrollTo(options);
+    scrollTo(options: KbqScrollbarScrollToOptions): void {
+        const scroll = () => this.scrollbarViewport().scrollTo(options);
 
-        const highlight = this.highlight();
-
-        if (highlight?.pending()) {
-            toObservable(highlight.pending, { injector: this.injector })
-                .pipe(
-                    filter((pending) => !pending),
-                    take(1)
-                )
-                .subscribe(scroll);
+        if (this.highlight().pending()) {
+            this.highlightSettled().pipe(take(1)).subscribe(scroll);
         } else {
             scroll();
         }
@@ -494,6 +493,33 @@ export class KbqCodeBlock implements AfterViewInit {
         );
     }
 
+    /**
+     * Briefly reveals the scrollbar once highlighting settles, so whether the code scrolls is answered
+     * on arrival rather than only after the pointer enters the block. Switching files needs nothing of
+     * its own: `onSelectedTabChange` scrolls the content back to the top, and that scroll reveals the
+     * track by itself.
+     *
+     * A viewport with nothing to scroll paints no track, so this stays silent for code that fits.
+     */
+    private revealScrollbarOnHighlight(): void {
+        if (!this.platform.isBrowser) return;
+
+        this.highlightSettled()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(() => this.scrollbarViewport().flashScrollIndicators());
+    }
+
+    /**
+     * Emits every time highlighting finishes. Built once and reused: `toObservable` installs an Angular
+     * effect that lives as long as the injector, so creating one per call — as `scrollTo` did on every
+     * tab click while a file was still highlighting — left an effect behind each time.
+     */
+    private highlightSettled(): Observable<boolean> {
+        this.highlightPending ??= toObservable(this.highlight().pending, { injector: this.injector });
+
+        return this.highlightPending.pipe(filter((pending) => !pending));
+    }
+
     private setupContentOverflowDetection(): void {
         if (!this.platform.isBrowser) return;
 
@@ -505,15 +531,8 @@ export class KbqCodeBlock implements AfterViewInit {
 
         checkOverflow();
 
-        const highlight = this.highlight();
-
-        if (highlight?.pending()) {
-            toObservable(highlight.pending, { injector: this.injector })
-                .pipe(
-                    filter((pending) => !pending),
-                    take(1)
-                )
-                .subscribe(checkOverflow);
+        if (this.highlight().pending()) {
+            this.highlightSettled().pipe(take(1)).subscribe(checkOverflow);
         }
 
         this.sharedResizeObserver
@@ -538,7 +557,7 @@ export class KbqCodeBlock implements AfterViewInit {
         this.toggleViewAll();
 
         if (this.canCodeContentBeFocused) {
-            this.focusMonitor.focusVia(this.scrollableCodeContent().getElementRef().nativeElement, 'keyboard');
+            this.focusMonitor.focusVia(this.scrollbarViewport().getNativeElement(), 'keyboard');
         }
     }
 

--- a/packages/components/code-block/e2e.playwright-spec.ts
+++ b/packages/components/code-block/e2e.playwright-spec.ts
@@ -1,5 +1,5 @@
 import { expect, Page, test } from '@playwright/test';
-import { e2eEnableDarkTheme } from 'packages/e2e/utils';
+import { e2eEnableDarkTheme, e2eExpectNoScrollbarAfterFlash, e2eWaitForSettledScrollbars } from 'packages/e2e/utils';
 
 test.describe('KbqCodeBlockModule', () => {
     test.describe('E2eCodeBlockStates', () => {
@@ -36,9 +36,45 @@ test.describe('KbqCodeBlockModule', () => {
                 )
                 .toBeLessThanOrEqual(1);
 
+            // The scroll above reveals every hover-mode track for `hideDelay`. One code block per
+            // fixture row, each with a single track.
+            await e2eWaitForSettledScrollbars(getComponent(page), 14);
+
             await expect(getComponent(page)).toHaveScreenshot('01-light.png');
             await e2eEnableDarkTheme(page);
             await expect(getComponent(page)).toHaveScreenshot('01-dark.png');
+        });
+    });
+
+    test.describe('E2eCodeBlockScrollbarFlash', () => {
+        // Scoped to the code content: the header's tab nav bar is a viewport too, but it runs in
+        // `hidden` mode and builds no track at all.
+        const getTrack = (page: Page, testId: string) =>
+            page.getByTestId(testId).locator('.kbq-code-block__main > kbq-scrollbar-track');
+
+        test.beforeEach(async ({ page }) => {
+            await page.goto('/E2eCodeBlockScrollbarFlash');
+        });
+
+        test('reveals the scrollbar once highlighting settles, without the pointer going near it', async ({ page }) => {
+            const track = getTrack(page, 'e2eCodeBlockFlashOverflowing');
+
+            await expect(track).toHaveClass(/kbq-scrollbar-track_revealed/);
+            await expect(track.locator('.kbq-scrollbar-track__bar')).not.toHaveCount(0);
+        });
+
+        test('reveals nothing for a code block that does not scroll', async ({ page }) => {
+            // Waited on first: the track reports no bars for its first frame plus one throttle window
+            // whatever the content is, so asserting the empty track before any tick has run would pass
+            // on the pre-computation window rather than on the behaviour. The overflowing block shares
+            // this page's frame loop, so its bars appearing prove a tick has been through.
+            await expect(
+                getTrack(page, 'e2eCodeBlockFlashOverflowing').locator('.kbq-scrollbar-track__bar')
+            ).not.toHaveCount(0);
+
+            await e2eExpectNoScrollbarAfterFlash(
+                page.getByTestId('e2eCodeBlockFlashFitting').locator('.kbq-code-block__main')
+            );
         });
     });
 });

--- a/packages/components/code-block/e2e.ts
+++ b/packages/components/code-block/e2e.ts
@@ -9,6 +9,7 @@ import {
     viewChildren
 } from '@angular/core';
 import { KbqCodeBlock, KbqCodeBlockFile } from '@koobiq/components/code-block';
+import { kbqScrollbarOptionsProvider } from '@koobiq/components/scrollbar';
 
 @Component({
     selector: 'e2e-code-block-states',
@@ -136,4 +137,53 @@ export class E2eCodeBlockStates {
             );
         });
     }
+}
+
+@Component({
+    selector: 'e2e-code-block-scrollbar-flash',
+    imports: [KbqCodeBlock],
+    template: `
+        <kbq-code-block
+            class="e2e-code-block"
+            data-testid="e2eCodeBlockFlashOverflowing"
+            [style.height.px]="120"
+            [files]="[longFile]"
+        />
+
+        <kbq-code-block class="e2e-code-block" data-testid="e2eCodeBlockFlashFitting" [files]="[shortFile]" />
+    `,
+    styles: `
+        :host {
+            display: flex;
+            gap: var(--kbq-size-l);
+            padding: var(--kbq-size-m);
+        }
+
+        .e2e-code-block {
+            width: 320px;
+        }
+    `,
+    providers: [
+        // The reveal lasts hideDelay and nothing brings it back, so the default second would make this
+        // a race against page load rather than a test of the behaviour.
+        kbqScrollbarOptionsProvider({ hideDelay: 5000 })
+    ],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'data-testid': 'e2eCodeBlockScrollbarFlash'
+    }
+})
+export class E2eCodeBlockScrollbarFlash {
+    protected readonly longFile: KbqCodeBlockFile = {
+        language: 'typescript',
+        filename: 'long.ts',
+        content: Array.from({ length: 40 }, (_, index) => `const value${index} = 'a fairly long line of code';`).join(
+            '\n'
+        )
+    };
+    protected readonly shortFile: KbqCodeBlockFile = {
+        language: 'bash',
+        filename: 'short.sh',
+        content: 'ng add @koobiq/components'
+    };
 }

--- a/packages/components/dropdown/dropdown.component.ts
+++ b/packages/components/dropdown/dropdown.component.ts
@@ -763,10 +763,9 @@ export class KbqDropdown implements AfterContentInit, KbqDropdownPanel, OnInit, 
         // because we move focus to the first item while it's still being animated, which can throw
         // the browser off when it determines the scroll position. Alternatively we can move focus
         // when the animation is done, however moving focus asynchronously will interrupt screen
-        // readers which are in the process of reading out the dropdown already. We take the `element`
-        // from the `event` since we can't use a `ViewChild` to access the pane.
+        // readers which are in the process of reading out the dropdown already.
         if (event.toState === 'enter' && this.keyManager.activeItemIndex <= 0) {
-            event.element.scrollTop = 0;
+            this.scrollbarViewport()?.scrollToTop();
         }
     }
 

--- a/packages/components/file-upload/e2e.playwright-spec.ts
+++ b/packages/components/file-upload/e2e.playwright-spec.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page, test } from '@playwright/test';
-import { e2eEnableDarkTheme } from '../../e2e/utils';
+import { e2eEnableDarkTheme, e2eExpectNoScrollbarAfterFlash, e2eWaitForSettledScrollbars } from '../../e2e/utils';
 
 test.describe('KbqFileUploadModule', () => {
     test.describe('E2eFileUploadStateAndStyle', () => {
@@ -44,9 +44,42 @@ test.describe('KbqFileUploadModule', () => {
 
             await expectFixtureDecorated(page);
 
+            // One track per file list; the single-file table has none.
+            await e2eWaitForSettledScrollbars(screenshotTarget, 14);
+
             await expect(screenshotTarget).toHaveScreenshot('02-light.png');
             await e2eEnableDarkTheme(page);
             await expect(screenshotTarget).toHaveScreenshot('02-dark.png');
+        });
+    });
+
+    test.describe('E2eFileUploadScrollbarFlash', () => {
+        const getTrack = (page: Page, testId: string) =>
+            page.getByTestId(testId).locator('.kbq-file-upload__list-viewport > kbq-scrollbar-track');
+
+        test.beforeEach(async ({ page }) => {
+            await page.goto('/E2eFileUploadScrollbarFlash');
+        });
+
+        test('reveals the scrollbar once the list is rendered, without the pointer going near it', async ({ page }) => {
+            const track = getTrack(page, 'e2eFileUploadFlashOverflowing');
+
+            await expect(track).toHaveClass(/kbq-scrollbar-track_revealed/);
+            await expect(track.locator('.kbq-scrollbar-track__bar')).not.toHaveCount(0);
+        });
+
+        test('reveals nothing for a list that fits', async ({ page }) => {
+            // Waited on first: the track reports no bars for its first frame plus one throttle window
+            // whatever the content is, so asserting the empty track before any tick has run would pass
+            // on the pre-computation window rather than on the behaviour. The overflowing list shares
+            // this page's frame loop, so its bars appearing prove a tick has been through.
+            await expect(
+                getTrack(page, 'e2eFileUploadFlashOverflowing').locator('.kbq-scrollbar-track__bar')
+            ).not.toHaveCount(0);
+
+            await e2eExpectNoScrollbarAfterFlash(
+                page.getByTestId('e2eFileUploadFlashFitting').locator('.kbq-file-upload__list-viewport')
+            );
         });
     });
 

--- a/packages/components/file-upload/e2e.ts
+++ b/packages/components/file-upload/e2e.ts
@@ -12,6 +12,7 @@ import {
     KbqLocalDropzone
 } from '@koobiq/components/file-upload';
 import { KbqIconModule } from '@koobiq/components/icon';
+import { kbqScrollbarOptionsProvider } from '@koobiq/components/scrollbar';
 
 type SingleUploadState = {
     file: KbqFileItem | null;
@@ -327,4 +328,55 @@ export class E2eFileUploadStateAndStyle {
 export class E2eFileUploadDropzone {
     protected readonly localDropzone = viewChild.required(KbqLocalDropzone);
     protected readonly fullScreenDropzoneService = inject(KbqFullScreenDropzoneService);
+}
+
+@Component({
+    selector: 'e2e-file-upload-scrollbar-flash',
+    imports: [KbqFileUploadModule],
+    template: `
+        <kbq-multiple-file-upload
+            class="e2e-file-upload"
+            data-testid="e2eFileUploadFlashOverflowing"
+            [files]="overflowingFiles"
+        />
+
+        <kbq-multiple-file-upload
+            class="e2e-file-upload"
+            data-testid="e2eFileUploadFlashFitting"
+            [files]="fittingFiles"
+        />
+    `,
+    styles: `
+        :host {
+            display: flex;
+            gap: var(--kbq-size-l);
+            padding: var(--kbq-size-m);
+        }
+
+        /* The list has no height cap by default (--kbq-file-upload-size-multiple-max-height is unset),
+           so it would simply grow to fit every row and never scroll. */
+        .e2e-file-upload {
+            --kbq-file-upload-size-multiple-max-height: 120px;
+
+            width: 320px;
+        }
+    `,
+    providers: [
+        // The reveal lasts hideDelay and nothing brings it back, so the default second would make this
+        // a race against page load rather than a test of the behaviour.
+        kbqScrollbarOptionsProvider({ hideDelay: 5000 })
+    ],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'data-testid': 'e2eFileUploadScrollbarFlash'
+    }
+})
+export class E2eFileUploadScrollbarFlash {
+    // Against the 120px cap the fixture sets: this many rows overflow it, a single one does not.
+    protected readonly overflowingFiles: KbqFileItem[] = Array.from({ length: 12 }, (_, index) => ({
+        file: new File(['test'] satisfies BlobPart[], `file-${index}.txt`)
+    })) satisfies KbqFileItem[];
+    protected readonly fittingFiles: KbqFileItem[] = [
+        { file: new File(['test'] satisfies BlobPart[], 'file.txt') }
+    ] satisfies KbqFileItem[];
 }

--- a/packages/components/file-upload/multiple-file-upload.component.html
+++ b/packages/components/file-upload/multiple-file-upload.component.html
@@ -23,52 +23,57 @@
         }
     } @else {
         <div class="kbq-file-upload__wrapper">
-            <kbq-list kbqNativeScrollbar kbqNativeScrollbarDescendants class="kbq-file-upload__list" role="list">
-                @for (file of files; track file) {
-                    <kbq-list-item
-                        role="listitem"
-                        class="kbq-file-upload__item"
-                        [class.kbq-disabled]="disabled"
-                        (keydown.backspace)="deleteFile($index)"
-                        (keydown.delete)="deleteFile($index)"
-                    >
-                        <div class="kbq-file-upload__row" [class.kbq-error]="file.hasError">
-                            <div class="kbq-file-upload__file kbq-file-upload__grid-cell">
-                                @if ({ loading: file.loading | async, progress: file.progress | async }; as asyncData) {
-                                    @if (!asyncData.loading) {
-                                        <ng-container
-                                            [ngTemplateOutlet]="$any(customFileIcon())"
-                                            [ngTemplateOutletContext]="{ $implicit: file }"
-                                        />
-                                    } @else {
-                                        <kbq-progress-spinner
-                                            class="kbq-file-upload-name-cell__icon"
-                                            [mode]="progressMode()"
-                                            [value]="asyncData.progress || 0"
-                                        />
+            <kbq-scrollbar class="kbq-file-upload__list-viewport">
+                <kbq-list class="kbq-file-upload__list" role="list">
+                    @for (file of files; track file) {
+                        <kbq-list-item
+                            role="listitem"
+                            class="kbq-file-upload__item"
+                            [class.kbq-disabled]="disabled"
+                            (keydown.backspace)="deleteFile($index)"
+                            (keydown.delete)="deleteFile($index)"
+                        >
+                            <div class="kbq-file-upload__row" [class.kbq-error]="file.hasError">
+                                <div class="kbq-file-upload__file kbq-file-upload__grid-cell">
+                                    @if (
+                                        { loading: file.loading | async, progress: file.progress | async };
+                                        as asyncData
+                                    ) {
+                                        @if (!asyncData.loading) {
+                                            <ng-container
+                                                [ngTemplateOutlet]="$any(customFileIcon())"
+                                                [ngTemplateOutletContext]="{ $implicit: file }"
+                                            />
+                                        } @else {
+                                            <kbq-progress-spinner
+                                                class="kbq-file-upload-name-cell__icon"
+                                                [mode]="progressMode()"
+                                                [value]="asyncData.progress || 0"
+                                            />
+                                        }
                                     }
-                                }
-                                <span
-                                    class="kbq-file-item__text"
-                                    [debounceInterval]="0"
-                                    [kbqTooltipDisabled]="disabled"
-                                    [kbqEllipsisCenter]="file.file.name"
-                                ></span>
+                                    <span
+                                        class="kbq-file-item__text"
+                                        [debounceInterval]="0"
+                                        [kbqTooltipDisabled]="disabled"
+                                        [kbqEllipsisCenter]="file.file.name"
+                                    ></span>
+                                </div>
+                                <div class="kbq-file-upload__size kbq-file-upload__grid-cell">
+                                    {{ file.file.size | kbqDataSize }}
+                                </div>
+                                <i
+                                    kbq-icon-button="kbq-circle-xmark_16"
+                                    class="kbq-file-upload__action kbq-file-upload__grid-cell"
+                                    [color]="file.hasError ? 'error' : 'contrast-fade'"
+                                    [disabled]="disabled"
+                                    (click)="deleteFile($index, $event, 'program')"
+                                ></i>
                             </div>
-                            <div class="kbq-file-upload__size kbq-file-upload__grid-cell">
-                                {{ file.file.size | kbqDataSize }}
-                            </div>
-                            <i
-                                kbq-icon-button="kbq-circle-xmark_16"
-                                class="kbq-file-upload__action kbq-file-upload__grid-cell"
-                                [color]="file.hasError ? 'error' : 'contrast-fade'"
-                                [disabled]="disabled"
-                                (click)="deleteFile($index, $event, 'program')"
-                            ></i>
-                        </div>
-                    </kbq-list-item>
-                }
-            </kbq-list>
+                        </kbq-list-item>
+                    }
+                </kbq-list>
+            </kbq-scrollbar>
             <div class="kbq-file-upload__list-footer kbq-file-dropzone">
                 <i kbq-icon="kbq-arrow-up-from-bracket_16" class="kbq-file-upload__dropzone-icon"></i>
                 <span class="kbq-file-upload__dropzone-caption">

--- a/packages/components/file-upload/multiple-file-upload.component.scss
+++ b/packages/components/file-upload/multiple-file-upload.component.scss
@@ -204,7 +204,9 @@
         --kbq-empty-state-size-normal-title-margin-bottom: var(--kbq-size-xs);
     }
 
-    .kbq-file-upload__list {
+    // The scroll viewport around the list, not the list itself: every declaration here sizes and pads
+    // the scrollport, and `<kbq-list>` sits inside it.
+    .kbq-file-upload__list-viewport {
         // Content-box so that the height cap counts rows and is not eaten by the 27px of padding
         // below — the same reasoning, and the same wording, as `%kbq-select-content` in
         // `core/styles/common/_select.scss`. A global `border-box` reset in a consuming application
@@ -213,8 +215,6 @@
 
         min-height: var(--kbq-file-upload-size-multiple-min-height);
         max-height: var(--kbq-file-upload-size-multiple-max-height);
-
-        overflow-y: auto;
 
         padding-top: calc(var(--kbq-size-xxs) - var(--kbq-size-border-width));
         padding-bottom: var(--kbq-size-xxl);

--- a/packages/components/file-upload/multiple-file-upload.component.ts
+++ b/packages/components/file-upload/multiple-file-upload.component.ts
@@ -35,7 +35,7 @@ import { KbqIcon, KbqIconButton } from '@koobiq/components/icon';
 import { KbqLink } from '@koobiq/components/link';
 import { KbqListModule } from '@koobiq/components/list';
 import { KbqProgressSpinnerModule, ProgressSpinnerMode } from '@koobiq/components/progress-spinner';
-import { KbqNativeScrollbar } from '@koobiq/components/scrollbar';
+import { KbqScrollbar } from '@koobiq/components/scrollbar';
 import { BehaviorSubject, of } from 'rxjs';
 import { KbqDropzoneData, KbqFileUploadEmptyState, KbqFullScreenDropzoneService } from './dropzone';
 import {
@@ -71,7 +71,7 @@ export const KBQ_MULTIPLE_FILE_UPLOAD_DEFAULT_CONFIGURATION: KbqMultipleFileUplo
         KbqListModule,
         KbqDataSizePipe,
         KbqProgressSpinnerModule,
-        KbqNativeScrollbar,
+        KbqScrollbar,
         KbqEllipsisCenterDirective,
         KbqFileLoader,
         KbqFileUploadEmptyState
@@ -167,6 +167,12 @@ export class KbqMultipleFileUploadComponent
     protected readonly customFileIcon = contentChild('kbqFileIcon', { read: TemplateRef });
 
     protected readonly fileLoader = viewChild(KbqFileLoader);
+
+    /** The list's scroll viewport. Absent until there is at least one file to list. */
+    private readonly listViewport = viewChild(KbqScrollbar);
+
+    /** File count the scrollbar was last revealed for — see the effect in the constructor. */
+    private announcedFileCount = 0;
 
     /** @docs-private */
     protected readonly hint = contentChildren(KbqHint);
@@ -279,6 +285,32 @@ export class KbqMultipleFileUploadComponent
         }
 
         this.dropzoneService.filesDropped.subscribe((files) => this.onFileDropped(files));
+
+        // Briefly reveals the scrollbar whenever the list arrives or grows, so whether the list scrolls
+        // is answered on sight rather than only once the pointer enters it. Both signals are read: the
+        // viewport appears a tick after the first file does, and a later file can push a list that fitted
+        // past its height cap.
+        //
+        // Gated on growth, not on any write: `list` is re-set wholesale by the `files` setter and by
+        // `writeValue`, so an unguarded effect would re-announce scrollability while the user is deleting
+        // rows, and would fire on every change-detection pass for a consumer binding `[files]` to an
+        // expression that returns a fresh array.
+        effect(() => {
+            const count = this.fileList.list().length;
+            const viewport = this.listViewport();
+
+            if (!viewport) {
+                // The list is not rendered; leave the count alone so its next appearance still counts as
+                // growth and gets announced.
+                return;
+            }
+
+            if (count > this.announcedFileCount) {
+                viewport.flashScrollIndicators();
+            }
+
+            this.announcedFileCount = count;
+        });
 
         effect(() => {
             const fullScreenDropZone = this.fullScreenDropZone();

--- a/packages/components/form-field/form-field.html
+++ b/packages/components/form-field/form-field.html
@@ -12,7 +12,12 @@
             </div>
         }
 
-        <div class="kbq-form-field__infix">
+        <div
+            kbqScrollbarViewport
+            class="kbq-form-field__infix"
+            [kbqScrollbarMode]="scrollportMode"
+            [style.max-height.px]="scrollportMaxHeight()"
+        >
             <ng-content />
         </div>
 

--- a/packages/components/form-field/form-field.scss
+++ b/packages/components/form-field/form-field.scss
@@ -108,6 +108,53 @@
         border-radius: var(--kbq-form-field-size-border-radius);
     }
 
+    // A `<textarea>` cannot host the custom scrollbar's track, so it hands its scrolling here:
+    // `KbqTextarea` keeps the element as tall as its text and the infix is what scrolls. Every other
+    // control leaves `KBQ_FORM_FIELD_SCROLLPORT` unprovided, which puts the viewport in `native` mode:
+    // no track, and the browser's own scrollbar untouched.
+    &.kbq-form-field-type-textarea .kbq-form-field__infix {
+        overflow-y: auto;
+
+        // Fill the scrollport while the text is shorter than the visible box, so that a click or a
+        // drag-selection anywhere in it lands on the textarea. The `min-height` `grow()` writes takes over
+        // as soon as the content is the taller of the two.
+        .kbq-textarea {
+            block-size: 100%;
+        }
+
+        // `canGrow="false"` means a fixed box the reader can drag taller — a height, not a cap, so the
+        // resize grip has something to override. A `maxRows` cap arrives instead as an inline
+        // `max-height` from the control, and leaves the box free to grow up to it.
+        &:has(.kbq-textarea-resizable:not(.kbq-textarea_max-row-limit-reached)) {
+            resize: vertical;
+            height: var(--kbq-textarea-size-min-height);
+
+            // The browser paints `::-webkit-resizer` only in the gutter its native scrollbar would
+            // occupy, and the custom scrollbar hides that scrollbar — so the grip goes invisible while
+            // still taking the drag. Draw it back as a sticky box pinned to the end of the scrollport,
+            // transparent to the pointer so the real resizer underneath keeps the gesture. Negative
+            // margins cancel its layout contribution, the same trick the scrollbar track uses.
+            &::after {
+                content: '';
+                position: sticky;
+                display: block;
+                inset-block-end: 0;
+                margin-block-start: calc(-1 * var(--kbq-scrollbar-track-size));
+                margin-inline-start: calc(100% - var(--kbq-scrollbar-track-size));
+                inline-size: var(--kbq-scrollbar-track-size);
+                block-size: var(--kbq-scrollbar-track-size);
+                background: var(--kbq-textarea-resizer-icon) center no-repeat;
+                pointer-events: none;
+            }
+
+            // Stop the track short of that grip: a bar painted over it would hide the only affordance
+            // saying the box can be dragged taller.
+            .kbq-scrollbar-track__bar_vertical {
+                inset-block-end: var(--kbq-scrollbar-track-size);
+            }
+        }
+    }
+
     &:hover {
         z-index: 1;
     }

--- a/packages/components/form-field/form-field.spec.ts
+++ b/packages/components/form-field/form-field.spec.ts
@@ -794,6 +794,28 @@ describe(KbqFormField.name, () => {
         expect(getContentNativeElement(debugElement).classList.contains('test-content')).toBeTruthy();
     });
 
+    describe('scrollport', () => {
+        it('should leave the native scrollbar of a control that scrolls on its own element', () => {
+            const fixture = createComponent(InputFormFieldWithHintCustomization);
+
+            fixture.detectChanges();
+
+            const infix: HTMLElement = fixture.nativeElement.querySelector('.kbq-form-field__infix');
+
+            expect(infix.classList.contains('kbq-scrollbar-viewport_native-scrollbar-hidden')).toBe(false);
+        });
+
+        it('should not put the control in a stacking context of its own when no track is built', () => {
+            const fixture = createComponent(InputFormFieldWithHintCustomization);
+
+            fixture.detectChanges();
+
+            const infix: HTMLElement = fixture.nativeElement.querySelector('.kbq-form-field__infix');
+
+            expect(infix.classList.contains('kbq-scrollbar-viewport_with-track')).toBe(false);
+        });
+    });
+
     describe('lifecycle', () => {
         const getStateChangesObserverCount = (debugElement: DebugElement): number => {
             const control = debugElement.query(By.directive(KbqInputPassword)).injector.get(KbqInputPassword);

--- a/packages/components/form-field/form-field.ts
+++ b/packages/components/form-field/form-field.ts
@@ -13,6 +13,7 @@ import {
     contentChildren,
     DestroyRef,
     Directive,
+    effect,
     ElementRef,
     HostAttributeToken,
     inject,
@@ -29,6 +30,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
 import { KBQ_CONNECTED_OVERLAY_ORIGIN, KBQ_FORM_FIELD_REF, KbqColorDirective } from '@koobiq/components/core';
 import { kbqIconErrorStateContextFactoryProvider } from '@koobiq/components/icon';
+import { KBQ_SCROLLBAR_OPTIONS, KbqScrollbarViewport, type KbqScrollbarMode } from '@koobiq/components/scrollbar';
 import { EMPTY, merge } from 'rxjs';
 import { delay, startWith } from 'rxjs/operators';
 import { KbqCleaner, kbqCleanerFactoryProvider } from './cleaner';
@@ -40,6 +42,7 @@ import { hasPasswordStrengthError, KbqPasswordHint } from './password-hint';
 import { KbqPasswordToggle } from './password-toggle';
 import { KbqPrefix } from './prefix';
 import { KbqReactivePasswordHint } from './reactive-password-hint';
+import { KBQ_FORM_FIELD_SCROLLPORT } from './scrollport';
 import { KbqStepper } from './stepper';
 import { KbqSuffix } from './suffix';
 
@@ -91,7 +94,7 @@ export const kbqFormFieldDefaultOptionsProvider = (options: KbqFormFieldDefaultO
 /** Container for form controls that applies styling and behavior. */
 @Component({
     selector: 'kbq-form-field',
-    imports: [],
+    imports: [KbqScrollbarViewport],
     templateUrl: 'form-field.html',
     styleUrls: [
         'form-field.scss',
@@ -179,6 +182,7 @@ export class KbqFormField
     private readonly focusMonitor = inject(FocusMonitor);
     private readonly defaultOptions = inject(KBQ_FORM_FIELD_DEFAULT_OPTIONS, { optional: true });
     private readonly customOverlayOrigin = inject(KBQ_CONNECTED_OVERLAY_ORIGIN, { optional: true });
+    private readonly scrollbarOptions = inject(KBQ_SCROLLBAR_OPTIONS);
     /**
      * @docs-private
      */
@@ -205,6 +209,31 @@ export class KbqFormField
      * @docs-private
      */
     readonly control = contentChild.required(KbqFormFieldControl);
+
+    /**
+     * The projected control when it asks the form field to scroll on its behalf — see
+     * {@link KBQ_FORM_FIELD_SCROLLPORT}. Queried, and not injected, because injection does not reach
+     * into projected content.
+     */
+    private readonly scrollport = contentChild(KBQ_FORM_FIELD_SCROLLPORT);
+
+    /** Height cap for the scrollport around the control, or `null` when it is uncapped. */
+    protected readonly scrollportMaxHeight = computed(() => this.scrollport()?.maxHeight() ?? null);
+
+    /**
+     * Scrollbar mode for that scrollport. `native` — no track, no observers, and the browser's own
+     * scrollbar left alone — for every control that scrolls on its own element or does not scroll at
+     * all, which is all of them but the textarea.
+     */
+    protected get scrollportMode(): KbqScrollbarMode {
+        return this.scrollport() ? this.scrollbarOptions.mode : 'native';
+    }
+
+    private readonly scrollportViewport = viewChild(KbqScrollbarViewport);
+
+    /** Content height whose growth has already been announced, so the same growth is not shown twice. */
+    private announcedContentHeight = 0;
+
     /**
      * @docs-private
      */
@@ -390,6 +419,28 @@ export class KbqFormField
 
     /** Ids last written to the control's `aria-describedby`, to skip redundant DOM writes. */
     private appliedDescribedByIds: string = '';
+
+    constructor() {
+        super();
+
+        // Reveals the scrollbar whenever the control's content grows, so content that arrives already past
+        // the visible box says so without waiting for the pointer. Growth only: shrinking exposes nothing
+        // new, and the first run has nothing to compare against.
+        effect(() => {
+            const contentHeight = this.scrollport()?.contentHeight() ?? 0;
+            const viewport = this.scrollportViewport();
+
+            // Before the viewport exists the flash would be pushed into a track that cannot receive it,
+            // so leave the growth unannounced and let the next run, which has one, announce it.
+            if (!viewport) return;
+
+            if (contentHeight > this.announcedContentHeight) {
+                viewport.flashScrollIndicators();
+            }
+
+            this.announcedContentHeight = contentHeight;
+        });
+    }
 
     ngAfterContentInit(): void {
         this.validateControlChild();

--- a/packages/components/form-field/public-api.ts
+++ b/packages/components/form-field/public-api.ts
@@ -10,5 +10,6 @@ export * from './password-hint';
 export * from './password-toggle';
 export * from './prefix';
 export * from './reactive-password-hint';
+export * from './scrollport';
 export * from './stepper';
 export * from './suffix';

--- a/packages/components/form-field/scrollport.ts
+++ b/packages/components/form-field/scrollport.ts
@@ -1,0 +1,37 @@
+import { InjectionToken, Signal } from '@angular/core';
+
+/**
+ * Contract for a control that cannot scroll on its own element and hands its scrolling to the form field,
+ * which turns the infix around the control into the scrollport.
+ *
+ * It exists for `KbqTextarea`: a `<textarea>` cannot have element children, so it cannot host the custom
+ * scrollbar's track. Controls that scroll themselves, or do not scroll at all, do not provide it, and the
+ * form field builds no track for them.
+ *
+ * @docs-private
+ */
+export interface KbqFormFieldScrollport {
+    /**
+     * Height the control's whole content needs, in px, or `0` before it has been measured. The form field
+     * watches it to reveal the scrollbar when the content grows past the visible box.
+     */
+    readonly contentHeight: Signal<number>;
+
+    /**
+     * Height cap for the scrollport, in px, or `null` while it is uncapped.
+     *
+     * A signal because the form field applies it from a template binding and runs `OnPush`.
+     */
+    readonly maxHeight: Signal<number | null>;
+}
+
+/**
+ * Token a control provides — `{ provide: KBQ_FORM_FIELD_SCROLLPORT, useExisting: MyControl }` — to ask the
+ * form field to scroll on its behalf.
+ *
+ * The form field reads it with a content query rather than `inject`, because injection does not reach from a
+ * component to its own projected content.
+ *
+ * @docs-private
+ */
+export const KBQ_FORM_FIELD_SCROLLPORT = new InjectionToken<KbqFormFieldScrollport>('KbqFormFieldScrollport');

--- a/packages/components/notification-center/notification-center.spec.ts
+++ b/packages/components/notification-center/notification-center.spec.ts
@@ -56,13 +56,6 @@ describe('KbqNotificationCenter', () => {
                 getPropertyValue: (_property: string) => ''
             })
         });
-
-        // jsdom does not implement Element.prototype.scrollTo; the container reveal calls it via
-        // KbqScrollbarViewport.scrollTo (CdkScrollable). Stub it only when it's missing so a real
-        // implementation is never shadowed.
-        if (!HTMLElement.prototype.scrollTo) {
-            Object.defineProperty(HTMLElement.prototype, 'scrollTo', { configurable: true, value: () => {} });
-        }
     });
 
     afterAll(() => {

--- a/packages/components/scrollbar/e2e.playwright-spec.ts
+++ b/packages/components/scrollbar/e2e.playwright-spec.ts
@@ -183,6 +183,60 @@ test.describe('KbqScrollbar', () => {
         });
     });
 
+    test.describe('E2eScrollbarNonScrollableOverflow', () => {
+        const getAuto = (page: Page) => page.getByTestId('e2eScrollbarOverflowAuto');
+        const getHidden = (page: Page) => page.getByTestId('e2eScrollbarOverflowHidden');
+        const getHiddenX = (page: Page) => page.getByTestId('e2eScrollbarOverflowHiddenX');
+        const getVerticalBar = (viewport: Locator) => viewport.locator('.kbq-scrollbar-track__bar_vertical');
+        const getHorizontalBar = (viewport: Locator) => viewport.locator('.kbq-scrollbar-track__bar_horizontal');
+
+        // Asserted before every expectation about a missing bar: a bar that is absent because there is
+        // nothing to scroll would prove nothing about the overflow the track is supposed to be reading.
+        const expectOverflowsBothAxes = async (viewport: Locator) =>
+            expect
+                .poll(() =>
+                    viewport.evaluate((element) => ({
+                        x: element.scrollWidth > element.clientWidth,
+                        y: element.scrollHeight > element.clientHeight
+                    }))
+                )
+                .toEqual({ x: true, y: true });
+
+        test.beforeEach(async ({ page }) => {
+            await page.goto('/E2eScrollbarNonScrollableOverflow');
+        });
+
+        test('paints both bars while the browser would scroll both axes', async ({ page }) => {
+            const viewport = getAuto(page);
+
+            await expectOverflowsBothAxes(viewport);
+
+            await expect(getVerticalBar(viewport)).toBeVisible();
+            await expect(getHorizontalBar(viewport)).toBeVisible();
+        });
+
+        test('paints no bar for a viewport the browser gives no scrollbar to', async ({ page }) => {
+            const viewport = getHidden(page);
+
+            await expectOverflowsBothAxes(viewport);
+
+            // The track stays — `overflow` can change without the viewport being rebuilt — but with
+            // nothing on it, which also leaves no thumb to drag a non-scrollable viewport by.
+            await expect(viewport.locator('kbq-scrollbar-track')).toBeAttached();
+            await expect(viewport.locator('.kbq-scrollbar-track__bar')).toHaveCount(0);
+            await expect(viewport.locator('.kbq-scrollbar-track__thumb')).toHaveCount(0);
+        });
+
+        test('keeps the bar on the axis that stays scrollable when only the other one is hidden', async ({ page }) => {
+            const viewport = getHiddenX(page);
+
+            await expectOverflowsBothAxes(viewport);
+
+            await expect(getVerticalBar(viewport)).toBeVisible();
+            await expect(getHorizontalBar(viewport)).toHaveCount(0);
+        });
+    });
+
     test.describe('E2eScrollbarMode', () => {
         const getScrollbar = (page: Page) => page.getByTestId('e2eScrollbarModeTarget');
         const getTrack = (page: Page) => getScrollbar(page).locator('kbq-scrollbar-track');

--- a/packages/components/scrollbar/e2e.ts
+++ b/packages/components/scrollbar/e2e.ts
@@ -534,3 +534,75 @@ export class E2eScrollbarViewportBoundId {
     }
 })
 export class E2eScrollbarStacking {}
+
+@Component({
+    selector: 'e2e-scrollbar-non-scrollable-overflow',
+    imports: [KbqScrollbarViewport],
+    template: `
+        <div
+            kbqScrollbarViewport
+            kbqScrollbarMode="always"
+            class="e2e-viewport e2e-viewport_auto"
+            data-testid="e2eScrollbarOverflowAuto"
+        >
+            <div class="e2e-viewport__content">auto</div>
+        </div>
+
+        <div
+            kbqScrollbarViewport
+            kbqScrollbarMode="always"
+            class="e2e-viewport e2e-viewport_hidden"
+            data-testid="e2eScrollbarOverflowHidden"
+        >
+            <div class="e2e-viewport__content">hidden</div>
+        </div>
+
+        <div
+            kbqScrollbarViewport
+            kbqScrollbarMode="always"
+            class="e2e-viewport e2e-viewport_hidden-x"
+            data-testid="e2eScrollbarOverflowHiddenX"
+        >
+            <div class="e2e-viewport__content">hidden-x</div>
+        </div>
+    `,
+    styles: `
+        :host {
+            display: inline-flex;
+            gap: var(--kbq-size-m);
+            padding: var(--kbq-size-xs);
+        }
+
+        .e2e-viewport {
+            width: 125px;
+            height: 125px;
+            background-color: var(--kbq-background-bg-secondary);
+        }
+
+        .e2e-viewport_auto {
+            overflow: auto;
+        }
+
+        /* overflow hidden keeps the element scrollable from script while the browser paints no
+           scrollbar — the state the custom track has to refuse to offer. */
+        .e2e-viewport_hidden {
+            overflow: hidden;
+        }
+
+        .e2e-viewport_hidden-x {
+            overflow-x: hidden;
+            overflow-y: auto;
+        }
+
+        /* Overflows both axes in every case above, so an absent bar is never absent for want of content. */
+        .e2e-viewport__content {
+            width: 250px;
+            height: 250px;
+        }
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'data-testid': 'e2eScrollbarNonScrollableOverflow'
+    }
+})
+export class E2eScrollbarNonScrollableOverflow {}

--- a/packages/components/scrollbar/scrollbar-viewport.scss
+++ b/packages/components/scrollbar/scrollbar-viewport.scss
@@ -1,7 +1,10 @@
 // Confines the track's z-index to this element, mirroring how an OS draws its scrollbar as a sibling of
 // the scrolled content rather than a peer competing with it. Without this the track would either lose to
 // positioned content inside the viewport, or — once raised above it — leak past page-level layers.
-.kbq-scrollbar-viewport {
+// Only where a track exists: a stacking context costs the content inside it subpixel antialiasing, and in
+// `native` and `hidden` modes there is nothing to confine — the browser paints its own scrollbar outside
+// this element's stacking context, and `hidden` paints none at all.
+.kbq-scrollbar-viewport_with-track {
     isolation: isolate;
 }
 

--- a/packages/components/scrollbar/scrollbar.spec.ts
+++ b/packages/components/scrollbar/scrollbar.spec.ts
@@ -232,6 +232,20 @@ describe(KbqScrollbar.name, () => {
             );
         });
 
+        it.each<[KbqScrollbarMode, boolean]>([
+            ['hover', true],
+            ['always', true],
+            ['native', false],
+            ['hidden', false]
+        ])('sets kbq-scrollbar-viewport_with-track for mode="%s": %s', (mode, expected) => {
+            const fixture = createComponent(TestScrollbarMode);
+
+            fixture.componentInstance.mode = mode;
+            fixture.detectChanges();
+
+            expect(getHost(fixture).classList.contains('kbq-scrollbar-viewport_with-track')).toBe(expected);
+        });
+
         it('reacts to mode changing at runtime, creating the track once it starts being needed', () => {
             const fixture = createComponent(TestScrollbarMode);
 

--- a/packages/components/scrollbar/scrollbar.spec.ts
+++ b/packages/components/scrollbar/scrollbar.spec.ts
@@ -372,6 +372,81 @@ describe(KbqScrollbar.name, () => {
             discardPeriodicTasks();
         }));
 
+        it('paints no bar for an axis the browser refuses to scroll, however much it overflows', fakeAsync(() => {
+            const fixture = createComponent(TestScrollbarTrackVisibility);
+            const viewportEl = getViewportEl(fixture);
+
+            // `overflow: hidden` keeps the element scrollable from script, so the size ratio on its own
+            // would paint a bar over a viewport the browser gives no scrollbar to — and hand the user a
+            // thumb to drag it with.
+            // Longhands, not the `overflow` shorthand: jsdom does not expand it into the computed
+            // per-axis values this reads.
+            viewportEl.style.overflowX = 'hidden';
+            viewportEl.style.overflowY = 'hidden';
+
+            setMetrics(viewportEl, {
+                clientHeight: 100,
+                scrollHeight: 200,
+                clientWidth: 100,
+                scrollWidth: 200
+            });
+
+            tick(300);
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.querySelector('.kbq-scrollbar-track__bar_vertical')).toBeNull();
+            expect(fixture.nativeElement.querySelector('.kbq-scrollbar-track__bar_horizontal')).toBeNull();
+
+            discardPeriodicTasks();
+        }));
+
+        it('paints no bar for a box left at the initial overflow, which is not a scroll container', fakeAsync(() => {
+            const fixture = createComponent(TestScrollbarTrackVisibility);
+            const viewportEl = getViewportEl(fixture);
+
+            // `visible` on both axes is the one combination that stays `visible` — the box overflows but
+            // cannot be scrolled by the user at all, so a bar over it would offer what does not exist.
+            viewportEl.style.overflowX = 'visible';
+            viewportEl.style.overflowY = 'visible';
+
+            setMetrics(viewportEl, {
+                clientHeight: 100,
+                scrollHeight: 200,
+                clientWidth: 100,
+                scrollWidth: 200
+            });
+
+            tick(300);
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.querySelector('.kbq-scrollbar-track__bar')).toBeNull();
+
+            discardPeriodicTasks();
+        }));
+
+        it('keeps the bar on the axis that is still scrollable when only the other one is hidden', fakeAsync(() => {
+            const fixture = createComponent(TestScrollbarTrackVisibility);
+            const viewportEl = getViewportEl(fixture);
+
+            viewportEl.style.overflowX = 'hidden';
+            viewportEl.style.overflowY = 'auto';
+
+            setMetrics(viewportEl, {
+                clientHeight: 100,
+                scrollHeight: 200,
+                clientWidth: 100,
+                scrollWidth: 200
+            });
+
+            tick(300);
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.querySelector('.kbq-scrollbar-track__bar_vertical')).not.toBeNull();
+            expect(fixture.nativeElement.querySelector('.kbq-scrollbar-track__bar_horizontal')).toBeNull();
+
+            discardPeriodicTasks();
+        }));
+
         it('flashScrollIndicators paints no bar when the content cannot overflow', fakeAsync(() => {
             @Component({
                 selector: 'test-flash-no-overflow',
@@ -419,6 +494,28 @@ describe(KbqScrollbar.name, () => {
 
             expect(trackEl.style.blockSize).toBe('49px');
             expect(trackEl.style.marginBlockEnd).toBe('-49px');
+
+            discardPeriodicTasks();
+        }));
+
+        it('keeps the track layout-neutral on a zero-sized viewport instead of leaving a positive end margin', fakeAsync(() => {
+            const { provider, triggerResize } = createResizeTrigger();
+            const fixture = createComponent(TestScrollbarTrackVisibility, [provider]);
+            const trackEl: HTMLElement = fixture.nativeElement.querySelector('kbq-scrollbar-track');
+
+            setMetrics(getViewportEl(fixture), { clientHeight: 0, clientWidth: 0 });
+
+            triggerResize();
+            fixture.detectChanges();
+
+            // A negative size is dropped by CSSOM while the margin paired with it is not, so an
+            // unclamped `size - 1` would leave the track a pixel tall inside a scrollport with no room
+            // for it — which changes clientHeight and re-enters this write through the resize observer.
+            expect(trackEl.style.blockSize).toBe('0px');
+            expect(trackEl.style.marginBlockEnd).toBe('0px');
+            expect(trackEl.style.minInlineSize).toBe('0px');
+            expect(trackEl.style.maxInlineSize).toBe('0px');
+            expect(trackEl.style.marginInlineEnd).toBe('0px');
 
             discardPeriodicTasks();
         }));

--- a/packages/components/scrollbar/scrollbar.ts
+++ b/packages/components/scrollbar/scrollbar.ts
@@ -165,6 +165,14 @@ type Orientation = 'horizontal' | 'vertical';
 
 const TRACK_THROTTLE_TIME = 300;
 
+/**
+ * Computed `overflow` values that rule out user scrolling. `visible` belongs here as much as the other
+ * two: it only computes to `auto` when the other axis scrolls, so a box left at the initial value on
+ * both axes is not a scroll container at all. Listed as the exclusions rather than as the scrollable
+ * values so an unreadable computed style leaves the scrollbar alone instead of erasing it.
+ */
+const NON_SCROLLABLE_OVERFLOW: readonly string[] = ['clip', 'hidden', 'visible'];
+
 /** Based on --kbq-scrollbar-thumb-min-size */
 const MIN_THUMB_SIZE = 32;
 
@@ -629,6 +637,7 @@ class KbqScrollbarTrack {
     private readonly destroyRef = inject(DestroyRef);
     private readonly resizeObserver = inject(SharedResizeObserver);
     private readonly nativeElement = kbqInjectNativeElement();
+    private readonly scheduler = zoneFreeScheduler();
 
     protected readonly visibility = toSignal<ScrollbarVisibility>(
         animationFrame().pipe(
@@ -643,8 +652,11 @@ class KbqScrollbarTrack {
 
     protected readonly revealed = toSignal(
         merge(this.viewport.scrollChanges, this.viewport.flashes).pipe(
-            // The stream is already outside Angular; injecting a scheduler inside switchMap would fail.
-            switchMap(() => concat(of(true), timer(this.hideDelay()).pipe(map(() => false)))),
+            // Hoisted rather than injected inside switchMap, which runs outside an injection context.
+            // The scheduler is what keeps the hide timer out of Angular: `scrollChanges` already emits
+            // outside the zone, but `flashes` carries whatever zone its caller was in, and a caller
+            // inside Angular would otherwise leave NgZone unstable for the whole hideDelay.
+            switchMap(() => concat(of(true), timer(this.hideDelay(), this.scheduler).pipe(map(() => false)))),
             startWith(false),
             distinctUntilChanged(),
             zoneOptimized()
@@ -697,10 +709,14 @@ class KbqScrollbarTrack {
 
     private get scrollbars(): ScrollbarVisibility {
         const { clientHeight, scrollHeight, clientWidth, scrollWidth } = this.viewportElement;
+        // An overflowing axis is not necessarily a scrollable one: `overflow: hidden` still scrolls
+        // programmatically, so the size ratio alone would paint a bar — and hand over a draggable
+        // thumb — for an axis the browser itself refuses to give a scrollbar to.
+        const { overflowX, overflowY } = this.window.getComputedStyle(this.viewportElement);
 
         return [
-            Math.ceil((clientHeight / scrollHeight) * 100) < 100,
-            Math.ceil((clientWidth / scrollWidth) * 100) < 100
+            !NON_SCROLLABLE_OVERFLOW.includes(overflowY) && Math.ceil((clientHeight / scrollHeight) * 100) < 100,
+            !NON_SCROLLABLE_OVERFLOW.includes(overflowX) && Math.ceil((clientWidth / scrollWidth) * 100) < 100
         ];
     }
 
@@ -722,14 +738,22 @@ class KbqScrollbarTrack {
         const setStyle = (property: string, value: number) =>
             this.renderer.setStyle(this.nativeElement, property, coerceCssPixelValue(value));
 
-        setStyle('blockSize', blockSize - 1);
+        // Clamped once and reused, so the size and the end margin cancel out by construction. Passing
+        // the unclamped value would break that on a zero-sized viewport: CSSOM silently drops the
+        // negative size while it accepts the positive margin paired with it, leaving the track a pixel
+        // tall inside a scrollport that has no room for it. That pixel changes `clientHeight`, which
+        // re-runs this method through the resize observer, which takes the pixel back — forever.
+        const trackBlockSize = Math.max(0, blockSize - 1);
+        const trackInlineSize = Math.max(0, inlineSize - 1);
+
+        setStyle('blockSize', trackBlockSize);
         setStyle('marginBlockStart', -paddingBlockStart);
-        setStyle('marginBlockEnd', paddingBlockStart - (blockSize - 1));
+        setStyle('marginBlockEnd', paddingBlockStart - trackBlockSize);
         setStyle('insetBlockStart', -paddingBlockStart);
-        setStyle('minInlineSize', inlineSize - 1);
-        setStyle('maxInlineSize', inlineSize - 1);
+        setStyle('minInlineSize', trackInlineSize);
+        setStyle('maxInlineSize', trackInlineSize);
         setStyle('marginInlineStart', -paddingInlineStart);
-        setStyle('marginInlineEnd', paddingInlineStart - (inlineSize - 1));
+        setStyle('marginInlineEnd', paddingInlineStart - trackInlineSize);
         setStyle('insetInlineStart', -paddingInlineStart);
     }
 }

--- a/packages/components/scrollbar/scrollbar.ts
+++ b/packages/components/scrollbar/scrollbar.ts
@@ -15,6 +15,7 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
+    computed,
     createComponent,
     DestroyRef,
     Directive,
@@ -248,6 +249,7 @@ type ScrollPosition = [number, number];
     host: {
         class: 'kbq-scrollbar-viewport',
         '[class.kbq-scrollbar-viewport_native-scrollbar-hidden]': 'mode() !== "native"',
+        '[class.kbq-scrollbar-viewport_with-track]': 'withTrack()',
         '[attr.id]': 'id'
     },
     hostDirectives: [CdkScrollable]
@@ -282,6 +284,13 @@ export class KbqScrollbarViewport {
         transform: numberAttribute
     });
 
+    /** Whether this viewport owns a track, as opposed to leaving the browser's scrollbar or no scrollbar at all. */
+    private readonly withTrack = computed(() => {
+        const mode = this.mode();
+
+        return mode !== 'native' && mode !== 'hidden';
+    });
+
     private trackRef: ComponentRef<KbqScrollbarTrack> | null = null;
 
     private readonly flashSubject = new Subject<void>();
@@ -298,9 +307,8 @@ export class KbqScrollbarViewport {
         effect(() => {
             const mode = this.mode();
             const hideDelay = this.hideDelay();
-            const showTrack = mode !== 'native' && mode !== 'hidden';
 
-            if (!showTrack) {
+            if (!this.withTrack()) {
                 this.destroyTrack();
 
                 return;

--- a/packages/components/select/select.component.ts
+++ b/packages/components/select/select.component.ts
@@ -1639,7 +1639,7 @@ export class KbqSelect
         this.overlayDir.positionChange.pipe(take(1)).subscribe(() => {
             this._changeDetectorRef.detectChanges();
             this.setOverlayPosition();
-            this.optionsContainer().nativeElement.scrollTop = this.scrollTop;
+            this.scrollbarViewport()?.scrollTo({ top: this.scrollTop });
 
             this.updateScrollSize();
             this.subscribeToScrolledToBottom();

--- a/packages/components/tabs/_tabs-common.scss
+++ b/packages/components/tabs/_tabs-common.scss
@@ -192,24 +192,17 @@
 
         overflow-x: auto;
         overflow-y: hidden;
-        scrollbar-width: none;
-        -ms-overflow-style: none;
-
-        &::-webkit-scrollbar {
-            display: none;
-        }
 
         // `kbq-tab-group_vertical` sits on an ancestor either way: the `<kbq-tab-group>` wrapping a
         // `kbq-tab-header`, or the `[kbqTabNavBar]` host itself — so one descendant selector covers
-        // both `KbqPaginatedTabHeader` subclasses instead of the two disagreeing on the scrollbar.
+        // both `KbqPaginatedTabHeader` subclasses instead of the two disagreeing on the scroll axis.
+        // Whether a scrollbar is shown on that axis is `KbqScrollbarViewport`'s call, driven by
+        // `scrollbarMode`. Nothing is hidden here: a local rule would apply unconditionally, including
+        // in `native` mode where the directive deliberately adds no hiding class, and would leave that
+        // header with no scrollbar at all.
         .kbq-tab-group_vertical & {
             overflow-x: hidden;
             overflow-y: auto;
-            scrollbar-width: auto;
-
-            &::-webkit-scrollbar {
-                display: block;
-            }
         }
 
         .kbq-tab-header__pagination-controls_enabled & {

--- a/packages/components/tabs/e2e.playwright-spec.ts
+++ b/packages/components/tabs/e2e.playwright-spec.ts
@@ -1,5 +1,5 @@
 import { expect, Page, test } from '@playwright/test';
-import { e2eEnableDarkTheme } from 'packages/e2e/utils';
+import { e2eEnableDarkTheme, e2eExpectNoScrollbarAfterFlash, e2eWaitForSettledScrollbars } from 'packages/e2e/utils';
 
 test.describe('KbqTabsModule', () => {
     test.describe('E2eTabsStates', () => {
@@ -14,9 +14,44 @@ test.describe('KbqTabsModule', () => {
             // Flaky test workaround: click to underlined tab to ensure proper bottom outline rendering
             await getTabsUnderlined(page).locator('.kbq-tab-label_underlined').nth(0).click();
 
+            // Only the vertical headers build a track; the horizontal ones run in `hidden` mode.
+            await e2eWaitForSettledScrollbars(component, 4);
+
             await expect(component).toHaveScreenshot('01-light.png');
             await e2eEnableDarkTheme(page);
             await expect(component).toHaveScreenshot('01-dark.png');
+        });
+    });
+
+    test.describe('E2eTabsScrollbarFlash', () => {
+        const getTrack = (page: Page, testId: string) =>
+            page.getByTestId(testId).locator('.kbq-tab-header__scroll-container > kbq-scrollbar-track');
+
+        test.beforeEach(async ({ page }) => {
+            await page.goto('/E2eTabsScrollbarFlash');
+        });
+
+        test('reveals the scrollbar once the strip is rendered, without the pointer going near it', async ({
+            page
+        }) => {
+            const track = getTrack(page, 'e2eTabsFlashOverflowing');
+
+            await expect(track).toHaveClass(/kbq-scrollbar-track_revealed/);
+            await expect(track.locator('.kbq-scrollbar-track__bar')).not.toHaveCount(0);
+        });
+
+        test('reveals nothing for a strip whose tabs fit', async ({ page }) => {
+            // Waited on first: the track reports no bars for its first frame plus one throttle window
+            // whatever the content is, so asserting the empty track before any tick has run would pass
+            // on the pre-computation window rather than on the behaviour. The overflowing strip shares
+            // this page's frame loop, so its bars appearing prove a tick has been through.
+            await expect(
+                getTrack(page, 'e2eTabsFlashOverflowing').locator('.kbq-scrollbar-track__bar')
+            ).not.toHaveCount(0);
+
+            await e2eExpectNoScrollbarAfterFlash(
+                page.getByTestId('e2eTabsFlashFitting').locator('.kbq-tab-header__scroll-container')
+            );
         });
     });
 

--- a/packages/components/tabs/e2e.ts
+++ b/packages/components/tabs/e2e.ts
@@ -1,5 +1,6 @@
 import { afterNextRender, ChangeDetectionStrategy, Component } from '@angular/core';
 import { KbqIconModule } from '@koobiq/components/icon';
+import { kbqScrollbarOptionsProvider } from '@koobiq/components/scrollbar';
 import { KbqTabsModule } from '@koobiq/components/tabs';
 
 @Component({
@@ -285,4 +286,49 @@ export class E2eTabNavBar {
         { testid: 'tabNavBar_default', disabled: false },
         { testid: 'tabNavBar_disabled', disabled: true }
     ];
+}
+
+@Component({
+    selector: 'e2e-tabs-scrollbar-flash',
+    imports: [KbqTabsModule],
+    template: `
+        <kbq-tab-group vertical class="e2e-tab-group" data-testid="e2eTabsFlashOverflowing">
+            @for (tab of manyTabs; track tab) {
+                <kbq-tab [tabId]="tab" [label]="tab">Active tab is {{ tab }}</kbq-tab>
+            }
+        </kbq-tab-group>
+
+        <kbq-tab-group vertical class="e2e-tab-group" data-testid="e2eTabsFlashFitting">
+            @for (tab of fewTabs; track tab) {
+                <kbq-tab [tabId]="tab" [label]="tab">Active tab is {{ tab }}</kbq-tab>
+            }
+        </kbq-tab-group>
+    `,
+    styles: `
+        :host {
+            display: flex;
+            gap: var(--kbq-size-l);
+            padding: var(--kbq-size-m);
+        }
+
+        /* The strip only scrolls against a height cap, and a vertical group's height is its own. */
+        .e2e-tab-group {
+            width: 240px;
+            height: 120px;
+        }
+    `,
+    providers: [
+        // The reveal lasts hideDelay and nothing brings it back, so the default second would make this
+        // a race against page load rather than a test of the behaviour.
+        kbqScrollbarOptionsProvider({ hideDelay: 5000 })
+    ],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'data-testid': 'e2eTabsScrollbarFlash'
+    }
+})
+export class E2eTabsScrollbarFlash {
+    // Against the 120px cap the fixture sets: this many labels overflow the strip, three do not.
+    protected readonly manyTabs: string[] = Array.from({ length: 12 }, (_, index) => `Tab ${index + 1}`);
+    protected readonly fewTabs: string[] = ['Tab 1', 'Tab 2', 'Tab 3'];
 }

--- a/packages/components/tabs/paginated-tab-header.ts
+++ b/packages/components/tabs/paginated-tab-header.ts
@@ -7,6 +7,7 @@ import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform
 import {
     AfterContentChecked,
     AfterContentInit,
+    afterNextRender,
     AfterViewInit,
     booleanAttribute,
     ChangeDetectorRef,
@@ -15,6 +16,7 @@ import {
     ElementRef,
     EventEmitter,
     inject,
+    Injector,
     Input,
     NgZone,
     numberAttribute,
@@ -23,6 +25,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DOWN_ARROW, END, HOME, KBQ_WINDOW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@koobiq/components/core';
+import { KBQ_SCROLLBAR_OPTIONS, type KbqScrollbarMode, type KbqScrollbarViewport } from '@koobiq/components/scrollbar';
 import { fromEvent, merge, of as observableOf, ReplaySubject, Subject, timer } from 'rxjs';
 import { auditTime, debounceTime, takeUntil } from 'rxjs/operators';
 
@@ -140,6 +143,8 @@ export abstract class KbqPaginatedTabHeader implements AfterContentChecked, Afte
 
     abstract readonly items: QueryList<KbqPaginatedTabHeaderItem>;
     abstract readonly tabListContainer: ElementRef<HTMLElement>;
+    /** The strip's scroll viewport — the same element as {@link tabListContainer}. */
+    protected abstract readonly scrollbarViewport: KbqScrollbarViewport | undefined;
     abstract readonly tabList: ElementRef<HTMLElement>;
     abstract readonly nextPaginator: ElementRef<HTMLElement>;
     abstract readonly previousPaginator: ElementRef<HTMLElement>;
@@ -243,6 +248,28 @@ export abstract class KbqPaginatedTabHeader implements AfterContentChecked, Afte
     private readonly dir = inject(Directionality, { optional: true });
     private readonly window = inject(KBQ_WINDOW);
     private readonly sharedResizeObserver = inject(SharedResizeObserver);
+    private readonly scrollbarOptions = inject(KBQ_SCROLLBAR_OPTIONS);
+    private readonly injector = inject(Injector);
+
+    /**
+     * Scrollbar mode for the tab strip. Only a vertical header scrolls in a direction the user is meant
+     * to see, so a horizontal one asks for `hidden`: the native scrollbar stays suppressed and no custom
+     * track is built for a strip that is paginated and dragged instead of scrolled by hand.
+     */
+    protected get scrollbarMode(): KbqScrollbarMode {
+        return this.verticallyScrolled ? this.scrollbarOptions.mode : 'hidden';
+    }
+
+    /**
+     * Whether the strip is laid out as a vertical scrollport — read off the class rather than the
+     * `vertical` input, because that class is what the stylesheet keys `overflow-y: auto` on and
+     * `KbqVerticalTabsCssStyler` matches on attribute *presence*: `[vertical]="false"` still gets it.
+     * Deriving the mode from the input alone would let the two disagree and leave such a strip
+     * scrollable with no scrollbar of any kind.
+     */
+    private get verticallyScrolled(): boolean {
+        return !!this.elementRef.nativeElement.closest('.kbq-tab-group_vertical');
+    }
 
     constructor() {
         // Bind the `mouseleave` event on the outside since it doesn't change anything in the view.
@@ -381,9 +408,27 @@ export abstract class KbqPaginatedTabHeader implements AfterContentChecked, Afte
     ngAfterContentChecked(): void {
         // If the number of tab labels have changed, check if scrolling should be enabled
         if (this.tabLabelCount !== this.items.length) {
+            // Read before `tabLabelCount` moves. Gated on growth rather than on any change: losing a tab
+            // cannot start the strip scrolling, so re-announcing it there would be noise.
+            const gainedTabs = this.items.length > (this.tabLabelCount ?? 0);
+
             this.updatePagination();
             this.tabLabelCount = this.items.length;
             this.changeDetectorRef.markForCheck();
+
+            // Briefly reveals the scrollbar when the strip arrives or gains tabs, so whether it scrolls
+            // is answered on sight rather than only once the pointer enters it. Vertical only: a
+            // horizontal strip is paginated and dragged, runs in `hidden` mode and has no scrollbar to
+            // announce.
+            //
+            // Deferred to after the render: the viewport builds its track from an effect, and effects
+            // flush after this hook, so flashing here directly would push into a subject nothing is
+            // listening to yet and the very first reveal — the one that matters — would be dropped.
+            if (gainedTabs && this.verticallyScrolled && this.platform.isBrowser) {
+                afterNextRender(() => this.scrollbarViewport?.flashScrollIndicators(), {
+                    injector: this.injector
+                });
+            }
         }
 
         // If the selected index has changed, scroll to the label.

--- a/packages/components/tabs/tab-header.component.ts
+++ b/packages/components/tabs/tab-header.component.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/core';
 import { isUndefined } from '@koobiq/components/core';
 import { KbqIconModule } from '@koobiq/components/icon';
-import { KbqNativeScrollbar } from '@koobiq/components/scrollbar';
+import { KbqScrollbarViewport } from '@koobiq/components/scrollbar';
 import { KbqPaginatedTabHeader } from './paginated-tab-header';
 import { KbqTabLabelWrapper } from './tab-label-wrapper.directive';
 
@@ -37,7 +37,7 @@ const TAB_PADDING = 12;
  */
 @Component({
     selector: 'kbq-tab-header',
-    imports: [KbqIconModule, CdkObserveContent, KbqNativeScrollbar],
+    imports: [KbqIconModule, CdkObserveContent, KbqScrollbarViewport],
     templateUrl: './tab-header.html',
     styleUrl: './tab-header.scss',
     changeDetection: ChangeDetectionStrategy.Default,
@@ -57,6 +57,8 @@ export class KbqTabHeader extends KbqPaginatedTabHeader {
 
     @ContentChildren(KbqTabLabelWrapper, { descendants: false }) readonly items: QueryList<KbqTabLabelWrapper>;
     @ViewChild('tabListContainer', { static: true }) readonly tabListContainer: ElementRef;
+    @ViewChild('tabListContainer', { static: true, read: KbqScrollbarViewport })
+    protected readonly scrollbarViewport: KbqScrollbarViewport | undefined;
     @ViewChild('tabList', { static: true }) readonly tabList: ElementRef;
     @ViewChild('nextPaginator') readonly nextPaginator: ElementRef<HTMLElement>;
     @ViewChild('previousPaginator') readonly previousPaginator: ElementRef<HTMLElement>;

--- a/packages/components/tabs/tab-header.html
+++ b/packages/components/tabs/tab-header.html
@@ -11,8 +11,9 @@
 
 <div
     #tabListContainer
-    kbqNativeScrollbar
+    kbqScrollbarViewport
     class="kbq-tab-header__container kbq-tab-header__scroll-container"
+    [kbqScrollbarMode]="scrollbarMode"
     [class.kbq-tab-header__scroll-container_overflow-before]="!disableScrollBefore"
     [class.kbq-tab-header__scroll-container_overflow-after]="!disableScrollAfter"
     (keydown)="handleKeydown($event)"

--- a/packages/components/tabs/tab-header.spec.ts
+++ b/packages/components/tabs/tab-header.spec.ts
@@ -10,18 +10,6 @@ import { KbqPaginatedTabHeader } from './paginated-tab-header';
 import { KbqTabHeader } from './tab-header.component';
 import { KbqTabLabelWrapper } from './tab-label-wrapper.directive';
 
-// jsdom doesn't implement `Element.prototype.scrollTo` at all
-// (https://github.com/jsdom/jsdom/issues/1695). `KbqPaginatedTabHeader`'s scroll-correction path
-// calls `container.scrollTo({ left, behavior })` directly, so the arrow-click/focus-scroll tests
-// below need it to actually move `scrollLeft`, not just be callable. Scoped to this file — jsdom
-// gives every spec file its own global environment, so this can't affect other suites the way a
-// `tools/jest/setup.ts` addition would.
-if (!Element.prototype.scrollTo) {
-    Element.prototype.scrollTo = function (this: Element, options?: ScrollToOptions | number): void {
-        if (typeof options === 'object' && options?.left !== undefined) this.scrollLeft = options.left;
-    };
-}
-
 /** Audit interval (ms) the header waits before re-checking pagination after a scroll-box resize. See `RESIZE_AUDIT_TIME`. */
 const RESIZE_AUDIT_TIME = 100;
 
@@ -283,9 +271,10 @@ describe('KbqTabHeader', () => {
                 Object.defineProperty(container, 'scrollWidth', { configurable: true, value: 400 });
                 Object.defineProperty(container, 'clientWidth', { configurable: true, value: 100 });
 
-                // Real browsers clamp `scrollLeft` to [0, scrollWidth - clientWidth]; the file-local
-                // `scrollTo` polyfill above doesn't, so an out-of-range target (e.g. the overscroll
-                // below the first tab) would otherwise assert a value no browser actually produces.
+                // Real browsers clamp `scrollLeft` to [0, scrollWidth - clientWidth]; the shared
+                // `scrollTo` polyfill in `tools/jest/setup.ts` doesn't, so an out-of-range target (e.g.
+                // the overscroll below the first tab) would otherwise assert a value no browser
+                // actually produces.
                 let scrollLeft = 0;
 
                 Object.defineProperty(container, 'scrollLeft', {

--- a/packages/components/tabs/tab-nav-bar.html
+++ b/packages/components/tabs/tab-nav-bar.html
@@ -11,8 +11,9 @@
 
 <div
     #tabListContainer
-    kbqNativeScrollbar
+    kbqScrollbarViewport
     class="kbq-tab-link__container kbq-tab-header__scroll-container"
+    [kbqScrollbarMode]="scrollbarMode"
     [class.kbq-tab-header__scroll-container_overflow-before]="!disableScrollBefore"
     [class.kbq-tab-header__scroll-container_overflow-after]="!disableScrollAfter"
     (keydown)="handleKeydown($event)"

--- a/packages/components/tabs/tab-nav-bar.ts
+++ b/packages/components/tabs/tab-nav-bar.ts
@@ -25,7 +25,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { isUndefined } from '@koobiq/components/core';
 import { KbqIconModule } from '@koobiq/components/icon';
-import { KbqNativeScrollbar } from '@koobiq/components/scrollbar';
+import { KbqScrollbarViewport } from '@koobiq/components/scrollbar';
 import { startWith } from 'rxjs/operators';
 import { KbqPaginatedTabHeader } from './paginated-tab-header';
 
@@ -43,7 +43,7 @@ const TAB_PADDING = 12;
     imports: [
         KbqIconModule,
         CdkObserveContent,
-        KbqNativeScrollbar
+        KbqScrollbarViewport
     ],
     templateUrl: './tab-nav-bar.html',
     styleUrls: [
@@ -69,6 +69,8 @@ const TAB_PADDING = 12;
 })
 export class KbqTabNavBar extends KbqPaginatedTabHeader implements AfterContentInit {
     @ViewChild('tabListContainer', { static: true }) readonly tabListContainer: ElementRef;
+    @ViewChild('tabListContainer', { static: true, read: KbqScrollbarViewport })
+    protected readonly scrollbarViewport: KbqScrollbarViewport | undefined;
     @ViewChild('tabList', { static: true }) readonly tabList: ElementRef;
     @ViewChild('nextPaginator') readonly nextPaginator: ElementRef<HTMLElement>;
     @ViewChild('previousPaginator') readonly previousPaginator: ElementRef<HTMLElement>;

--- a/packages/components/textarea/e2e.playwright-spec.ts
+++ b/packages/components/textarea/e2e.playwright-spec.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page, test } from '@playwright/test';
-import { e2eEnableDarkTheme } from '../../e2e/utils';
+import { e2eEnableDarkTheme, e2eExpectNoScrollbarAfterFlash, e2eWaitForSettledScrollbars } from '../../e2e/utils';
 
 const getHeight = async (locator: Locator): Promise<number> => {
     await expect(locator).toBeVisible();
@@ -89,19 +89,28 @@ test.describe('KbqTextareaModule', () => {
             expect(await getHeight(textarea)).toBeGreaterThan(shortHeight);
         });
 
-        test('should not grow beyond maxRows height', async ({ page }) => {
+        test('should not grow the visible box beyond maxRows height', async ({ page }) => {
             await page.goto('/E2eTextareaGrowMaxRows');
             const textarea = getTextarea(page);
+            // The cap lives on the form field's scrollport, not on the element: a `<textarea>` cannot
+            // host the custom scrollbar's track, so `KbqTextarea` keeps it as tall as its text and the
+            // scrollport is what stops growing and starts scrolling.
+            const scrollport = page.locator('.kbq-form-field__infix:has([data-testid="grow-max-rows_textarea"])');
 
             await pasteFromClipboard(page, textarea, 'line1\nline2\nline3\nline4\nline5');
-            const atMaxRowsHeight = await getHeight(textarea);
+            const atMaxRowsHeight = await getHeight(scrollport);
 
             await pasteFromClipboard(
                 page,
                 textarea,
                 'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10'
             );
-            expect(await getHeight(textarea)).toBe(atMaxRowsHeight);
+
+            expect(await getHeight(scrollport)).toBe(atMaxRowsHeight);
+            // The element itself keeps growing — otherwise the extra lines would be clipped rather than
+            // scrolled to.
+            expect(await getHeight(textarea)).toBeGreaterThan(atMaxRowsHeight);
+            expect(await scrollport.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true);
         });
     });
 
@@ -127,6 +136,65 @@ test.describe('KbqTextareaModule', () => {
             const textareaScrollTop = await textarea.evaluate((el: HTMLTextAreaElement) => el.scrollTop);
 
             expect(textareaScrollTop).toBe(0);
+        });
+    });
+    test.describe('E2eTextareaScrollbar', () => {
+        const getViewport = (page: Page, testId: string) => page.getByTestId(testId).locator('.kbq-form-field__infix');
+        const getTrack = (page: Page, testId: string) => getViewport(page, testId).locator('kbq-scrollbar-track');
+
+        test.beforeEach(async ({ page }) => page.goto('/E2eTextareaScrollbar'));
+
+        test('shows the scrollbar while the pointer is over an overflowing textarea', async ({ page }) => {
+            const viewport = getViewport(page, 'e2eTextareaScrollbarOverflowing');
+            const track = getTrack(page, 'e2eTextareaScrollbarOverflowing');
+
+            // Both fields build a track; the reveal from the initial flash has to pass before hover can
+            // be told apart from it.
+            await e2eWaitForSettledScrollbars(page, 2);
+            await expect(track).toHaveCSS('opacity', '0');
+
+            await viewport.hover();
+
+            await expect(track).toHaveCSS('opacity', '1');
+            await expect(track.locator('.kbq-scrollbar-track__thumb')).toBeVisible();
+        });
+
+        test('shows nothing while the pointer is over a textarea whose text fits', async ({ page }) => {
+            const viewport = getViewport(page, 'e2eTextareaScrollbarFitting');
+            const track = getTrack(page, 'e2eTextareaScrollbarFitting');
+
+            // The overflowing field shares this page's frame loop, so its bars appearing prove the
+            // track has computed its visibility at least once — without that, an empty track would pass
+            // here on the pre-computation window rather than on the behaviour.
+            await expect(
+                getTrack(page, 'e2eTextareaScrollbarOverflowing').locator('.kbq-scrollbar-track__bar')
+            ).not.toHaveCount(0);
+
+            await viewport.hover();
+
+            await expect(track).toHaveCSS('opacity', '1');
+            await expect(track.locator('.kbq-scrollbar-track__bar')).toHaveCount(0);
+        });
+    });
+
+    test.describe('E2eTextareaScrollbarFlash', () => {
+        const getViewport = (page: Page, testId: string) => page.getByTestId(testId).locator('.kbq-form-field__infix');
+
+        test.beforeEach(async ({ page }) => page.goto('/E2eTextareaScrollbarFlash'));
+
+        test('reveals the scrollbar once the text is laid out, without the pointer going near it', async ({ page }) => {
+            const track = getViewport(page, 'e2eTextareaFlashOverflowing').locator('kbq-scrollbar-track');
+
+            await expect(track).toHaveClass(/kbq-scrollbar-track_revealed/);
+            await expect(track.locator('.kbq-scrollbar-track__bar')).not.toHaveCount(0);
+        });
+
+        test('reveals nothing for a textarea whose text fits', async ({ page }) => {
+            await expect(
+                getViewport(page, 'e2eTextareaFlashOverflowing').locator('.kbq-scrollbar-track__bar')
+            ).not.toHaveCount(0);
+
+            await e2eExpectNoScrollbarAfterFlash(getViewport(page, 'e2eTextareaFlashFitting'));
         });
     });
 });

--- a/packages/components/textarea/e2e.ts
+++ b/packages/components/textarea/e2e.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, model } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { kbqScrollbarOptionsProvider } from '@koobiq/components/scrollbar';
 import { KbqTextareaModule } from '@koobiq/components/textarea';
 
 @Component({
@@ -180,4 +181,75 @@ const longTextareaContent =
 })
 export class E2eTextareaScrollOnFocus {
     protected readonly value = model<string>(longTextareaContent);
+}
+
+const overflowingTextareaValue = Array.from({ length: 8 }, (_, index) => `line ${index + 1}`).join('\n');
+
+@Component({
+    selector: 'e2e-textarea-scrollbar',
+    imports: [KbqTextareaModule, FormsModule],
+    template: `
+        <kbq-form-field data-testid="e2eTextareaScrollbarOverflowing">
+            <textarea kbqTextarea canGrow="false" [(ngModel)]="overflowingValue"></textarea>
+        </kbq-form-field>
+
+        <kbq-form-field data-testid="e2eTextareaScrollbarFitting">
+            <textarea kbqTextarea canGrow="false" [(ngModel)]="fittingValue"></textarea>
+        </kbq-form-field>
+    `,
+    styles: `
+        :host {
+            display: flex;
+            flex-direction: column;
+            gap: var(--kbq-size-l);
+            padding: var(--kbq-size-s);
+            width: 320px;
+        }
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'data-testid': 'e2eTextareaScrollbar'
+    }
+})
+export class E2eTextareaScrollbar {
+    // `canGrow="false"` fixes the visible box at one --kbq-textarea-size-min-height, which eight lines
+    // overflow and one does not.
+    protected readonly overflowingValue = model(overflowingTextareaValue);
+    protected readonly fittingValue = model('line 1');
+}
+
+@Component({
+    selector: 'e2e-textarea-scrollbar-flash',
+    imports: [KbqTextareaModule, FormsModule],
+    template: `
+        <kbq-form-field data-testid="e2eTextareaFlashOverflowing">
+            <textarea kbqTextarea canGrow="false" [(ngModel)]="overflowingValue"></textarea>
+        </kbq-form-field>
+
+        <kbq-form-field data-testid="e2eTextareaFlashFitting">
+            <textarea kbqTextarea canGrow="false" [(ngModel)]="fittingValue"></textarea>
+        </kbq-form-field>
+    `,
+    styles: `
+        :host {
+            display: flex;
+            flex-direction: column;
+            gap: var(--kbq-size-l);
+            padding: var(--kbq-size-s);
+            width: 320px;
+        }
+    `,
+    providers: [
+        // The reveal lasts hideDelay and nothing brings it back, so the default second would make this
+        // a race against page load rather than a test of the behaviour.
+        kbqScrollbarOptionsProvider({ hideDelay: 5000 })
+    ],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'data-testid': 'e2eTextareaScrollbarFlash'
+    }
+})
+export class E2eTextareaScrollbarFlash {
+    protected readonly overflowingValue = model(overflowingTextareaValue);
+    protected readonly fittingValue = model('line 1');
 }

--- a/packages/components/textarea/textarea.component.spec.ts
+++ b/packages/components/textarea/textarea.component.spec.ts
@@ -153,7 +153,14 @@ class TextareaControlWithAsyncValidators {
     imports: [KbqTextareaModule, FormsModule],
     template: `
         <kbq-form-field>
-            <textarea kbqTextarea [canGrow]="true" [maxRows]="3" [(ngModel)]="value"></textarea>
+            <!-- jsdom reports no line height of its own, and the maxRows cap is a multiple of it. -->
+            <textarea
+                kbqTextarea
+                style="line-height: 20px"
+                [canGrow]="true"
+                [maxRows]="3"
+                [(ngModel)]="value"
+            ></textarea>
         </kbq-form-field>
     `
 })
@@ -308,6 +315,18 @@ describe('KbqTextarea', () => {
 
             expect(getTextareaElement(fixture).classList.contains('kbq-textarea_max-row-limit-reached')).toBe(false);
         });
+
+        it('should cap the form field scrollport at maxRows height', fakeAsync(() => {
+            const fixture = createComponent(KbqTextareaGrowWithMaxRows);
+
+            fixture.detectChanges();
+            tick();
+            fixture.detectChanges();
+
+            const infix: HTMLElement = fixture.nativeElement.querySelector('.kbq-form-field__infix');
+
+            expect(infix.style.maxHeight).toBe('60px');
+        }));
     });
 
     describe('grow behavior', () => {

--- a/packages/components/textarea/textarea.component.ts
+++ b/packages/components/textarea/textarea.component.ts
@@ -2,6 +2,7 @@ import { coerceBooleanProperty, coerceCssPixelValue } from '@angular/cdk/coercio
 import { Platform } from '@angular/cdk/platform';
 import {
     booleanAttribute,
+    computed,
     Directive,
     DoCheck,
     ElementRef,
@@ -14,7 +15,9 @@ import {
     OnChanges,
     OnDestroy,
     OnInit,
-    Renderer2
+    Renderer2,
+    signal,
+    type Signal
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroupDirective, NgControl, NgForm, UntypedFormControl } from '@angular/forms';
@@ -25,8 +28,11 @@ import {
     KBQ_WINDOW,
     kbqInjectAutofilled
 } from '@koobiq/components/core';
-import { KbqFormFieldControl } from '@koobiq/components/form-field';
-import { KbqNativeScrollbar } from '@koobiq/components/scrollbar';
+import {
+    KBQ_FORM_FIELD_SCROLLPORT,
+    KbqFormFieldControl,
+    type KbqFormFieldScrollport
+} from '@koobiq/components/form-field';
 import { asapScheduler, observeOn, Subject } from 'rxjs';
 
 export const KBQ_TEXTAREA_VALUE_ACCESSOR = new InjectionToken<{ value: any }>('KBQ_TEXTAREA_VALUE_ACCESSOR');
@@ -35,7 +41,10 @@ let nextUniqueId = 0;
 
 @Directive({
     selector: 'textarea[kbqTextarea]',
-    providers: [{ provide: KbqFormFieldControl, useExisting: KbqTextarea }],
+    providers: [
+        { provide: KbqFormFieldControl, useExisting: KbqTextarea },
+        { provide: KBQ_FORM_FIELD_SCROLLPORT, useExisting: KbqTextarea }
+    ],
     host: {
         class: 'kbq-textarea',
         '[class.kbq-textarea-resizable]': '!canGrow',
@@ -49,11 +58,17 @@ let nextUniqueId = 0;
         '(focus)': 'focusChanged(true)',
         '(input)': 'dirtyCheckNativeValue()'
     },
-    hostDirectives: [KbqNativeScrollbar],
     exportAs: 'kbqTextarea'
 })
 export class KbqTextarea
-    implements KbqFormFieldControl<any>, OnInit, OnChanges, OnDestroy, DoCheck, CanUpdateErrorState
+    implements
+        KbqFormFieldControl<any>,
+        KbqFormFieldScrollport,
+        OnInit,
+        OnChanges,
+        OnDestroy,
+        DoCheck,
+        CanUpdateErrorState
 {
     protected elementRef = inject<ElementRef<HTMLTextAreaElement>>(ElementRef);
     ngControl = inject(NgControl, { optional: true, self: true });
@@ -210,6 +225,28 @@ export class KbqTextarea
         return this.rowsCount > this.maxRows();
     }
 
+    private readonly _contentHeight = signal(0);
+
+    /**
+     * Height the whole text needs, in px, as {@link grow} last measured it — `0` until the first
+     * measurement. See {@link KbqFormFieldScrollport}.
+     */
+    readonly contentHeight: Signal<number> = this._contentHeight.asReadonly();
+
+    /**
+     * The `maxRows` cap resolved to pixels, which the form field applies to the scrollport it puts around
+     * this element — see {@link KbqFormFieldScrollport}. `null` while `maxRows` is unset or the line height
+     * has not been measured yet.
+     */
+    readonly maxHeight: Signal<number | null> = computed(() => {
+        const maxRows = this.maxRows();
+
+        // Read so the cap is recomputed once the line height is known, not only when `maxRows` changes.
+        this.contentHeight();
+
+        return maxRows && this.lineHeight ? maxRows * this.lineHeight : null;
+    });
+
     protected uid = `kbq-textarea-${nextUniqueId++}`;
     protected previousNativeValue: any;
     private _disabled = false;
@@ -298,9 +335,16 @@ export class KbqTextarea
         this.focusChanged(false);
     }
 
-    /** Grow textarea height to avoid vertical scroll  */
+    /**
+     * Sizes the element to its whole content, so it never scrolls on its own.
+     *
+     * Runs whatever `canGrow` says: the element is always as tall as its text, and what differs between
+     * the modes is only who caps the visible box — `maxRows` through {@link maxHeight}, or the
+     * resize grip the form field puts on its scrollport. A `<textarea>` cannot host the custom
+     * scrollbar's track, so it must not be the thing that scrolls.
+     */
     grow = () => {
-        if (!this.isBrowser || !this._canGrow) return;
+        if (!this.isBrowser) return;
 
         this.ngZone.runOutsideAngular(() => {
             const textarea = this.elementRef.nativeElement;
@@ -312,17 +356,24 @@ export class KbqTextarea
             const outerHeight = parseInt(this.window.getComputedStyle(textarea).height!, 10);
             const diff = outerHeight - +textarea.clientHeight;
 
-            clone.style.minHeight = '0'; // this line is important to height recalculation
+            // Measure the text alone: `min-height` is what the previous run wrote, and the form field
+            // stretches the control to fill its scrollport, so both have to be off for `scrollHeight` to
+            // report the content rather than the box it currently sits in.
+            clone.style.minHeight = '0';
+            clone.style.blockSize = 'auto';
 
-            const height = Math.max(this.minHeight, +clone.scrollHeight + diff + this.freeRowsHeight);
+            // The free rows are a growth affordance — empty space the box grows into as the text reaches it.
+            // A box that cannot grow has no use for them, and they would only push the content past the
+            // visible box and raise a scrollbar for text that fits.
+            const freeRows = this._canGrow ? this.freeRowsHeight : 0;
+            const height = Math.max(this.minHeight, +clone.scrollHeight + diff + freeRows);
 
             clone.remove();
 
             this.rowsCount = Math.floor(height / this.lineHeight);
 
-            textarea.style.minHeight = coerceCssPixelValue(
-                this.maxRowLimitReached ? this.maxRows() * this.lineHeight : height
-            );
+            textarea.style.minHeight = coerceCssPixelValue(height);
+            this._contentHeight.set(height);
         });
     };
 

--- a/packages/components/textarea/textarea.scss
+++ b/packages/components/textarea/textarea.scss
@@ -9,8 +9,11 @@
     border: none;
     outline: none;
 
+    // Neither scrolls nor resizes on its own: a `<textarea>` cannot host the custom scrollbar's track,
+    // so the form field wraps it in a scrollport that does both, and `grow()` keeps this element exactly
+    // as tall as its text. See `.kbq-form-field-type-textarea` in `form-field.scss`.
     resize: none;
-    overflow: auto;
+    overflow: hidden;
 
     width: 100%;
 
@@ -20,24 +23,6 @@
 
     -webkit-appearance: none; // Chrome textarea height sizing fix
     vertical-align: bottom; // Chrome textarea height sizing fix
-
-    &:not(.kbq-textarea-resizable) {
-        box-sizing: border-box;
-        overflow-y: hidden;
-    }
-
-    &.kbq-textarea-resizable {
-        resize: vertical;
-        min-height: var(--kbq-textarea-size-min-height);
-
-        &::-webkit-resizer {
-            background: var(--kbq-textarea-resizer-icon) center no-repeat;
-        }
-    }
-
-    &.kbq-textarea_max-row-limit-reached {
-        resize: unset;
-    }
 }
 
 /* remove default red border for HTML5 validation invalid fields in Firefox */

--- a/packages/components/tree-select/tree-select.component.ts
+++ b/packages/components/tree-select/tree-select.component.ts
@@ -1343,7 +1343,7 @@ export class KbqTreeSelect
             this.changeDetectorRef.detectChanges();
             this.setOverlayPosition();
             // The panel itself is an `overflow: hidden` box; the option list is what scrolls.
-            this.optionsContainer()!.nativeElement.scrollTop = this.scrollTop;
+            this.scrollbarViewport()?.scrollTo({ top: this.scrollTop });
 
             this.tree()!.updateScrollSize();
             // Deliberately out of this frame — see `reanchorPanel`. A microtask still lands before paint.

--- a/packages/e2e/routes.ts
+++ b/packages/e2e/routes.ts
@@ -184,6 +184,8 @@ import {
 import {
     E2eTextareaGrowBehavior,
     E2eTextareaGrowMaxRows,
+    E2eTextareaScrollbar,
+    E2eTextareaScrollbarFlash,
     E2eTextareaScrollOnFocus,
     E2eTextareaStates
 } from '../components/textarea/e2e';
@@ -264,6 +266,8 @@ const components = [
     E2eTextareaStates,
     E2eTextareaGrowBehavior,
     E2eTextareaGrowMaxRows,
+    E2eTextareaScrollbar,
+    E2eTextareaScrollbarFlash,
     E2eTextareaScrollOnFocus,
     E2eDatepickerStates,
     E2eDatepickerPositioning,

--- a/packages/e2e/routes.ts
+++ b/packages/e2e/routes.ts
@@ -6,6 +6,7 @@ import {
     E2eScrollbarHover,
     E2eScrollbarMode,
     E2eScrollbarNested,
+    E2eScrollbarNonScrollableOverflow,
     E2eScrollbarPadding,
     E2eScrollbarScrollTo,
     E2eScrollbarStacking,
@@ -39,7 +40,7 @@ import {
 import { E2eButtonGroup, E2eButtonStateAndStyle, E2eButtonStress, E2eButtonTruncation } from '../components/button/e2e';
 import { E2eCheckboxStateAndStyle, E2eCheckboxWithTextAndCaption } from '../components/checkbox/e2e';
 import { E2eClampedTextStateAndStyle, E2eClampedTextStates } from '../components/clamped-text/e2e';
-import { E2eCodeBlockStates } from '../components/code-block/e2e';
+import { E2eCodeBlockScrollbarFlash, E2eCodeBlockStates } from '../components/code-block/e2e';
 import { E2eContentPanelScrollOverflow, E2eContentPanelState } from '../components/content-panel/e2e';
 import { E2eDatepickerPositioning, E2eDatepickerStates } from '../components/datepicker/e2e';
 import { E2eDividerStateAndStyle } from '../components/divider/e2e';
@@ -55,7 +56,11 @@ import {
     E2eDropdownTitleOverflow
 } from '../components/dropdown/e2e';
 import { E2eEmptyStateStateAndStyle } from '../components/empty-state/e2e';
-import { E2eFileUploadDropzone, E2eFileUploadStateAndStyle } from '../components/file-upload/e2e';
+import {
+    E2eFileUploadDropzone,
+    E2eFileUploadScrollbarFlash,
+    E2eFileUploadStateAndStyle
+} from '../components/file-upload/e2e';
 import {
     E2eFilterBarFilters,
     E2eFilterBarPanelMaxHeight,
@@ -167,7 +172,7 @@ import {
 } from '../components/split-button/e2e';
 import { E2eSplitterGhost } from '../components/splitter/e2e';
 import { E2eTableStates } from '../components/table/e2e';
-import { E2eTabNavBar, E2eTabsStates } from '../components/tabs/e2e';
+import { E2eTabNavBar, E2eTabsScrollbarFlash, E2eTabsStates } from '../components/tabs/e2e';
 import {
     E2eTagAutocompleteStates,
     E2eTagEditable,
@@ -227,6 +232,7 @@ const components = [
     E2eSplitterGhost,
     E2eFileUploadStateAndStyle,
     E2eFileUploadDropzone,
+    E2eFileUploadScrollbarFlash,
     E2eFormFieldAddons,
     E2eFormFieldAutofill,
     E2eFormFieldGroup,
@@ -241,6 +247,7 @@ const components = [
     E2eBreadcrumbsOverflowMax,
     E2eEmptyStateStateAndStyle,
     E2eCodeBlockStates,
+    E2eCodeBlockScrollbarFlash,
     E2eDlStates,
     E2eDlResizable,
     E2eAlertStateAndStyle,
@@ -249,6 +256,7 @@ const components = [
     E2eButtonToggleStatesStretched,
     E2eButtonToggleTruncation,
     E2eTabsStates,
+    E2eTabsScrollbarFlash,
     E2eTabNavBar,
     E2eClampedTextStateAndStyle,
     E2eClampedTextStates,
@@ -318,6 +326,7 @@ const components = [
     E2eScrollbarScrollTo,
     E2eScrollbarVirtualScroll,
     E2eScrollbarNested,
+    E2eScrollbarNonScrollableOverflow,
     E2eScrollbarPadding,
     E2eScrollbarViewportBoundId,
     E2eScrollbarStacking,

--- a/tools/jest/setup.ts
+++ b/tools/jest/setup.ts
@@ -69,3 +69,39 @@ if (!globalThis.structuredClone) {
 if (!Element.prototype.scrollIntoView) {
     Element.prototype.scrollIntoView = jest.fn();
 }
+
+// jsdom implements no scrolling at all (https://github.com/jsdom/jsdom/issues/1695), and components
+// scroll through `KbqScrollbarViewport`, which reaches `Element.prototype.scrollTo` via
+// `CdkScrollable`. A bare `jest.fn()` would make every such call silently do nothing, so this applies
+// the offsets the way a browser would — which is what a spec asserting a scroll position needs. No
+// clamping: jsdom has no layout to clamp against, so a spec that cares defines its own `scrollLeft`.
+if (!Element.prototype.scrollTo) {
+    // A spec that pins scroll metrics redefines them as value-only properties; leave those where the
+    // spec put them instead of throwing on assignment.
+    const applyOffset = (element: Element, property: 'scrollLeft' | 'scrollTop', value: number): void => {
+        const descriptor = Object.getOwnPropertyDescriptor(element, property);
+
+        if (descriptor && !descriptor.set && !descriptor.writable) return;
+
+        element[property] = value;
+    };
+
+    // Defined rather than assigned: a plain assignment would make it enumerable, so every `for…in` over
+    // an element and every serializer that walks own+inherited keys would start seeing it.
+    Object.defineProperty(Element.prototype, 'scrollTo', {
+        configurable: true,
+        writable: true,
+        value: function (this: Element, options?: ScrollToOptions | number, y?: number): void {
+            if (typeof options === 'number') {
+                applyOffset(this, 'scrollLeft', options);
+
+                if (y !== undefined) applyOffset(this, 'scrollTop', y);
+
+                return;
+            }
+
+            if (options?.left !== undefined) applyOffset(this, 'scrollLeft', options.left);
+            if (options?.top !== undefined) applyOffset(this, 'scrollTop', options.top);
+        }
+    });
+}

--- a/tools/public_api_guard/components/code-block.api.md
+++ b/tools/public_api_guard/components/code-block.api.md
@@ -7,13 +7,13 @@
 import { AfterViewInit } from '@angular/core';
 import * as _angular_core from '@angular/core';
 import { CdkScrollable } from '@angular/cdk/scrolling';
-import { ExtendedScrollToOptions } from '@angular/cdk/scrolling';
 import { HLJSApi } from 'highlight.js';
 import { InjectionToken } from '@angular/core';
 import { KbqButtonStyles } from '@koobiq/components/button';
 import { KbqCodeBlockLocaleConfiguration } from '@koobiq/components/core';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqDeepPartial } from '@koobiq/components/core';
+import { KbqScrollbarScrollToOptions } from '@koobiq/components/scrollbar';
 import { LanguageFn } from 'highlight.js';
 import { Provider } from '@angular/core';
 import { TemplateRef } from '@angular/core';
@@ -93,7 +93,7 @@ export class KbqCodeBlock implements AfterViewInit {
     protected openLink(): void;
     // @deprecated
     readonly scrollableCodeContent: _angular_core.Signal<CdkScrollable>;
-    scrollTo(options: ExtendedScrollToOptions): void;
+    scrollTo(options: KbqScrollbarScrollToOptions): void;
     softWrap: boolean;
     readonly softWrapChange: _angular_core.OutputEmitterRef<boolean>;
     protected readonly tabLinkTemplate: TemplateRef<KbqTabLinkTemplateContext>;

--- a/tools/public_api_guard/components/form-field.api.md
+++ b/tools/public_api_guard/components/form-field.api.md
@@ -16,6 +16,7 @@ import { InjectionToken } from '@angular/core';
 import { KbqColorDirective } from '@koobiq/components/core';
 import { KbqComponentColors } from '@koobiq/components/core';
 import { KbqIconButton } from '@koobiq/components/icon';
+import { KbqScrollbarMode } from '@koobiq/components/scrollbar';
 import { KbqTooltipTrigger } from '@koobiq/components/tooltip';
 import { NgControl } from '@angular/forms';
 import { Observable } from 'rxjs';
@@ -50,6 +51,9 @@ export const KBQ_FORM_FIELD_DEFAULT_OPTIONS: InjectionToken<Partial<{
     labelClass: string | string[] | Set<string>;
     contentClass: string | string[] | Set<string>;
 }>>;
+
+// @public
+export const KBQ_FORM_FIELD_SCROLLPORT: InjectionToken<KbqFormFieldScrollport>;
 
 // @public
 export const KBQ_STEPPER_INITIAL_TIMEOUT = 300;
@@ -114,6 +118,7 @@ export class KbqFieldsetItem {
 
 // @public
 export class KbqFormField extends KbqColorDirective implements AfterContentInit, AfterViewInit, OnDestroy, AfterContentChecked {
+    constructor();
     get autofilled(): boolean;
     // @deprecated
     canCleanerClearByEsc: boolean;
@@ -163,13 +168,15 @@ export class KbqFormField extends KbqColorDirective implements AfterContentInit,
     readonly passwordToggle: Signal<KbqPasswordToggle | undefined>;
     readonly prefix: Signal<readonly KbqPrefix[]>;
     runFocusMonitor: () => void;
+    protected readonly scrollportMaxHeight: Signal<number | null>;
+    protected get scrollportMode(): KbqScrollbarMode;
     shouldForward(prop: keyof NgControl): boolean;
     readonly stepper: Signal<KbqStepper | undefined>;
     stopFocusMonitor(): void;
     readonly suffix: Signal<readonly KbqSuffix[]>;
     protected validateControlChild(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<KbqFormField, "kbq-form-field", ["kbqFormField"], { "noBorders": { "alias": "noBorders"; "required": false; "isSignal": true; }; "inOverlay": { "alias": "inOverlay"; "required": false; "isSignal": true; }; "horizontal": { "alias": "horizontal"; "required": false; "isSignal": true; }; "labelClass": { "alias": "labelClass"; "required": false; "isSignal": true; }; "contentClass": { "alias": "contentClass"; "required": false; "isSignal": true; }; }, { "inOverlay": "inOverlayChange"; }, ["control", "stepper", "cleaner", "passwordToggle", "hint", "passwordHints", "suffix", "prefix", "controlElementRef", "reactivePasswordHint", "error", "label"], ["kbq-label", "[kbqPrefix]", "*", "kbq-cleaner", "kbq-password-toggle, kbq-stepper, [kbqSuffix]", "kbq-error", "kbq-hint, kbq-password-hint, kbq-reactive-password-hint"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<KbqFormField, "kbq-form-field", ["kbqFormField"], { "noBorders": { "alias": "noBorders"; "required": false; "isSignal": true; }; "inOverlay": { "alias": "inOverlay"; "required": false; "isSignal": true; }; "horizontal": { "alias": "horizontal"; "required": false; "isSignal": true; }; "labelClass": { "alias": "labelClass"; "required": false; "isSignal": true; }; "contentClass": { "alias": "contentClass"; "required": false; "isSignal": true; }; }, { "inOverlay": "inOverlayChange"; }, ["control", "scrollport", "stepper", "cleaner", "passwordToggle", "hint", "passwordHints", "suffix", "prefix", "controlElementRef", "reactivePasswordHint", "error", "label"], ["kbq-label", "[kbqPrefix]", "*", "kbq-cleaner", "kbq-password-toggle, kbq-stepper, [kbqSuffix]", "kbq-error", "kbq-hint, kbq-password-hint, kbq-reactive-password-hint"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqFormField, never>;
 }
@@ -214,6 +221,12 @@ export class KbqFormFieldModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<KbqFormFieldModule>;
     // (undocumented)
     static ɵmod: i0.ɵɵNgModuleDeclaration<KbqFormFieldModule, never, [typeof KbqCleaner, typeof KbqFormField, typeof KbqPrefix, typeof KbqSuffix, typeof KbqPasswordToggle, typeof KbqStepper, typeof KbqLabel, typeof KbqHint, typeof KbqError, typeof KbqReactivePasswordHint, typeof KbqLegend, typeof KbqFieldset, typeof KbqFieldsetItem, typeof KbqPasswordHint, typeof KbqTrim], [typeof KbqCleaner, typeof KbqFormField, typeof KbqPrefix, typeof KbqSuffix, typeof KbqPasswordToggle, typeof KbqStepper, typeof KbqLabel, typeof KbqHint, typeof KbqError, typeof KbqReactivePasswordHint, typeof KbqLegend, typeof KbqFieldset, typeof KbqFieldsetItem, typeof KbqPasswordHint, typeof KbqTrim]>;
+}
+
+// @public
+export interface KbqFormFieldScrollport {
+    readonly contentHeight: Signal<number>;
+    readonly maxHeight: Signal<number | null>;
 }
 
 // @public

--- a/tools/public_api_guard/components/tabs.api.md
+++ b/tools/public_api_guard/components/tabs.api.md
@@ -25,6 +25,8 @@ import * as i4 from '@koobiq/components/icon';
 import * as i5 from '@koobiq/components/tooltip';
 import * as i6 from '@angular/cdk/observers';
 import { InjectionToken } from '@angular/core';
+import { KbqScrollbarMode } from '@koobiq/components/scrollbar';
+import { KbqScrollbarViewport } from '@koobiq/components/scrollbar';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
@@ -252,6 +254,8 @@ export class KbqTabHeader extends KbqPaginatedTabHeader {
     // (undocumented)
     readonly previousPaginator: ElementRef<HTMLElement>;
     // (undocumented)
+    protected readonly scrollbarViewport: KbqScrollbarViewport | undefined;
+    // (undocumented)
     readonly tabList: ElementRef;
     // (undocumented)
     readonly tabListContainer: ElementRef;
@@ -365,6 +369,8 @@ export class KbqTabNavBar extends KbqPaginatedTabHeader implements AfterContentI
     readonly previousPaginator: ElementRef<HTMLElement>;
     // (undocumented)
     get role(): string | null;
+    // (undocumented)
+    protected readonly scrollbarViewport: KbqScrollbarViewport | undefined;
     // (undocumented)
     readonly tabList: ElementRef;
     // (undocumented)

--- a/tools/public_api_guard/components/textarea.api.md
+++ b/tools/public_api_guard/components/textarea.api.md
@@ -10,18 +10,19 @@ import { ElementRef } from '@angular/core';
 import { ErrorStateMatcher } from '@koobiq/components/core';
 import { FormGroupDirective } from '@angular/forms';
 import * as i0 from '@angular/core';
-import * as i1$1 from '@angular/cdk/a11y';
-import * as i1 from '@koobiq/components/scrollbar';
+import * as i1 from '@angular/cdk/a11y';
 import * as i2 from '@angular/forms';
 import * as i4 from '@koobiq/components/form-field';
 import { InjectionToken } from '@angular/core';
 import { KbqFormFieldControl } from '@koobiq/components/form-field';
+import { KbqFormFieldScrollport } from '@koobiq/components/form-field';
 import { NgControl } from '@angular/forms';
 import { NgForm } from '@angular/forms';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Renderer2 } from '@angular/core';
+import { Signal } from '@angular/core';
 import { Subject } from 'rxjs';
 
 // @public (undocumented)
@@ -30,11 +31,12 @@ export const KBQ_TEXTAREA_VALUE_ACCESSOR: InjectionToken<{
 }>;
 
 // @public (undocumented)
-export class KbqTextarea implements KbqFormFieldControl<any>, OnInit, OnChanges, OnDestroy, DoCheck, CanUpdateErrorState {
+export class KbqTextarea implements KbqFormFieldControl<any>, KbqFormFieldScrollport, OnInit, OnChanges, OnDestroy, DoCheck, CanUpdateErrorState {
     constructor();
-    readonly autofilled: i0.Signal<boolean>;
+    readonly autofilled: Signal<boolean>;
     get canGrow(): boolean;
     set canGrow(value: boolean);
+    readonly contentHeight: Signal<number>;
     controlType: string;
     // (undocumented)
     defaultErrorStateMatcher: ErrorStateMatcher;
@@ -56,6 +58,7 @@ export class KbqTextarea implements KbqFormFieldControl<any>, OnInit, OnChanges,
     protected isBadInput(): boolean;
     // (undocumented)
     protected readonly isBrowser: boolean;
+    readonly maxHeight: Signal<number | null>;
     get maxRowLimitReached(): boolean;
     readonly maxRows: i0.InputSignal<number>;
     // (undocumented)
@@ -94,7 +97,7 @@ export class KbqTextarea implements KbqFormFieldControl<any>, OnInit, OnChanges,
     get value(): string;
     set value(value: string);
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<KbqTextarea, "textarea[kbqTextarea]", ["kbqTextarea"], { "canGrow": { "alias": "canGrow"; "required": false; }; "maxRows": { "alias": "maxRows"; "required": false; "isSignal": true; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "id": { "alias": "id"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "freeRowsHeight": { "alias": "freeRowsHeight"; "required": false; }; "required": { "alias": "required"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, {}, never, never, true, [{ directive: typeof i1.KbqNativeScrollbar; inputs: {}; outputs: {}; }]>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<KbqTextarea, "textarea[kbqTextarea]", ["kbqTextarea"], { "canGrow": { "alias": "canGrow"; "required": false; }; "maxRows": { "alias": "maxRows"; "required": false; "isSignal": true; }; "errorStateMatcher": { "alias": "errorStateMatcher"; "required": false; }; "disabled": { "alias": "disabled"; "required": false; }; "id": { "alias": "id"; "required": false; }; "placeholder": { "alias": "placeholder"; "required": false; }; "freeRowsHeight": { "alias": "freeRowsHeight"; "required": false; }; "required": { "alias": "required"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<KbqTextarea, never>;
 }
@@ -106,7 +109,7 @@ export class KbqTextareaModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<KbqTextareaModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<KbqTextareaModule, never, [typeof i1$1.A11yModule, typeof i2.FormsModule, typeof KbqTextarea], [typeof KbqTextarea, typeof i4.KbqFormFieldModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<KbqTextareaModule, never, [typeof i1.A11yModule, typeof i2.FormsModule, typeof KbqTextarea], [typeof KbqTextarea, typeof i4.KbqFormFieldModule]>;
 }
 
 // (No @packageDocumentation comment for this package)


### PR DESCRIPTION
## Summary

Stacked on [#2034](https://github.com/koobiq/angular-components/pull/2034) (`feat/DS-5453`) — base it on `main` once that one lands.

`<textarea kbqTextarea>` was the last component still on `kbqNativeScrollbar`. A `<textarea>` cannot have element children, so it cannot host `KbqScrollbarViewport`'s track; the form field turns `.kbq-form-field__infix` — the box it already draws around the control — into the scrollport instead. `KbqTextarea` keeps its element exactly as tall as its text and never scrolls on its own.

The control asks for that through a narrow token rather than through the shared `KbqFormFieldControl` contract, so the other eleven controls learn nothing new: their infix runs in `native` mode — no track, no observers, the browser's own scrollbar untouched.

## List of notable changes:

- **added** `KBQ_FORM_FIELD_SCROLLPORT` and `KbqFormFieldScrollport` (both `@docs-private`) — a control provides the token to ask the form field to scroll on its behalf, carrying the height its content needs and the `maxRows` cap. Read with a content query, because injection does not reach from a component into its own projected content.
- **updated** `KbqFormField` to put `kbqScrollbarViewport` on the infix, to cap it at the control's `maxRows` height, and to reveal the scrollbar whenever the control's content grows — so text that arrives already past the visible box says so without waiting for the pointer.
- **updated** `KbqTextarea`: `grow()` now runs whatever `canGrow` says and sizes the element to its whole content (`overflow: hidden`, no `resize`); the free rows it adds are a growth affordance and are skipped for a box that cannot grow, which otherwise raised a scrollbar for text that fits. `hostDirectives: [KbqNativeScrollbar]` is gone — there is no native scrollbar left to customize.
- **updated** the scrollbar's `isolation: isolate` to apply only to a viewport that owns a track (`hover`/`always`). A stacking context costs the content inside it subpixel antialiasing, and in `native` and `hidden` modes there is nothing to confine.
- **added** unit coverage for the wiring (the scrollport cap, the untouched native scrollbar, the stacking context, the class per mode) and four Playwright specs: the scrollbar on hover with and without overflow, and the flash on initialization with and without overflow.

## What should reviewers focus on?

- **`resize: vertical` moved from the element to the scrollport.** The browser paints `::-webkit-resizer` only in the gutter its native scrollbar would occupy, and the custom scrollbar hides that gutter, so the grip is redrawn as a sticky `::after` that is transparent to the pointer. Worth a drag in both themes.
- **`max-height` is now an inline style on the infix.** Consumer CSS that capped `.kbq-textarea` directly no longer caps what scrolls.
- **Screenshot baselines are not in this PR.** `textarea/01-*` and `form-field/05-*` change (the resize grip moves by a pixel, the textarea element no longer fills the box), and the tabs baselines may shift too: a horizontal tab header runs in `hidden` mode and so loses the stacking context it had, which changes text antialiasing without changing paint order. Run `/approve-snapshots` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
